### PR TITLE
Perf changes

### DIFF
--- a/clean_pufferl.py
+++ b/clean_pufferl.py
@@ -410,10 +410,13 @@ def train(data):
     # Optimizing the policy and value network
     train_time = time.time()
     pg_losses, entropy_losses, v_losses, clipfracs, old_kls, kls = [], [], [], [], [], []
+    mb_obs_buffer = torch.zeros_like(b_obs[0], pin_memory=True)
+
     for epoch in range(config.update_epochs):
         lstm_state = None
         for mb in range(num_minibatches):
-            mb_obs = b_obs[mb].to(data.device)
+            mb_obs_buffer.copy_(b_obs[mb], non_blocking=True)
+            mb_obs = mb_obs_buffer.to(data.device, non_blocking=True)
             mb_actions = b_actions[mb].contiguous()
             mb_values = b_values[mb].reshape(-1)
             mb_advantages = b_advantages[mb].reshape(-1)


### PR DESCRIPTION
2 Changes:

1. Use a preallocated pinned memory buffer for handling the data movement of m_obs to device.
2. (UNTESTED) Categorical in torch can take a tensor of logits. This is an attempt at vectorizing that logic. For the small number of elements batchxlogits contains, I think this will do fine on the GPU.