### PR TITLE
Cache the number of elements in the action space

### DIFF
--- a/clean_pufferl.py
+++ b/clean_pufferl.py
@@ -438,7 +438,7 @@ def train(data):
     # Optimizing the policy and value network
     train_time = time.time()
     pg_losses, entropy_losses, v_losses, clipfracs, old_kls, kls = [], [], [], [], [], []
-    mb_obs_buffer = torch.zeros_like(b_obs[0], pin_memory=True)
+    mb_obs_buffer = torch.zeros_like(b_obs[0], pin_memory=data.device == "cuda")
 
     for epoch in range(config.update_epochs):
         lstm_state = None

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -13,7 +13,8 @@ def test_pack_unpack():
         flat_space = flatten_space(space)
         flat_sample = flatten(sample)
         pack_sample = concatenate(flat_sample)
-        unpack_sample = split(pack_sample, flat_space, batched=False)
+        sz = [int(np.prod(subspace.shape)) for subspace in flat_space.values()]
+        unpack_sample = split(pack_sample, flat_space, sz, batched=False)
         unflat_sample = unflatten(unpack_sample, space)
         assert pufferlib.utils.compare_space_samples(sample, unflat_sample), "Unflatten failed."
  
@@ -68,7 +69,8 @@ def test_flatten_unflatten(iterations=10_000):
         structure = flatten_structure(data)
         flat_space = flatten_space(space)
         merged = concatenate(flat)
-        unmerged = split(merged, flat_space, batched=False)
+        sz = [int(np.prod(subspace.shape)) for subspace in flat_space.values()]
+        unmerged = split(merged, flat_space, sz, batched=False)
         unflat = unflatten(unmerged, structure)
         assert pufferlib.utils.compare_space_samples(data, unflat), "Unflatten failed."
 
@@ -77,7 +79,7 @@ def test_flatten_unflatten(iterations=10_000):
         concatenate_times.append(timeit.timeit(
             lambda: concatenate(flat), number=iterations))
         split_times.append(timeit.timeit(
-            lambda: split(merged, flat_space, batched=False), number=iterations))
+            lambda: split(merged, flat_space, sz, batched=False), number=iterations))
         unflatten_times.append(timeit.timeit(
             lambda: unflatten(unmerged, structure), number=iterations))
 


### PR DESCRIPTION
You probably dont need to dispatch to numpy everytime you call `split` to calculate the number of elements in the space. This PR caches the sizes (in a less than nice way imo) as an example. Before and after pictures below 

<img width="772" alt="Screenshot 2024-01-28 at 9 12 20 PM" src="https://github.com/PufferAI/PufferLib/assets/148832074/0e7e1a40-0db7-4a16-a8b7-f5a305943b69">
<img width="628" alt="Screenshot 2024-01-28 at 9 12 52 PM" src="https://github.com/PufferAI/PufferLib/assets/148832074/3d81ccbc-0fb0-4009-ac3d-604fdc34512e">
