### PR TITLE
Update vector.py to remove double envs bug

### DIFF
--- a/pufferlib/vector.py
+++ b/pufferlib/vector.py
@@ -230,8 +230,6 @@ class Multiprocessing:
     def __init__(self, env_creators, env_args, env_kwargs,
             num_envs, num_workers=None, batch_size=None,
             zero_copy=True, **kwargs):
-        self.envs = [creator(*args, **kwargs) for (creator, args, kwargs)
-            in zip(env_creators, env_args, env_kwargs)]
         if batch_size is None:
             batch_size = num_envs
         if num_workers is None:


### PR DESCRIPTION
I'm impatient. Removed the line creating duplicate environments from Multiprocessing so I can stop fixing it locally.