### PR TITLE
Adjust deps so that `pip install .`  can work

### DIFF
--- a/pufferlib/utils.py
+++ b/pufferlib/utils.py
@@ -9,7 +9,6 @@ import os
 import sys
 import pickle
 import subprocess
-from filelock import FileLock
 from contextlib import redirect_stdout, redirect_stderr, contextmanager
 from io import StringIO
 import psutil

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,9 @@ docs = [
 cleanrl = [
     'stable_baselines3==2.1.0',
     'tensorboard==2.11.2',
+    'torch',
     'tyro==0.8.6',
+    'wandb==0.13.7',
 ]
 
 ray = [
@@ -224,8 +226,6 @@ setup(
         'shimmy[gym-v21]',
         'psutil==5.9.5',
         'pynvml',
-        'torch',
-        'wandb==0.13.7',
     ],
     extras_require={
         'docs': docs,

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,7 @@ docs = [
 cleanrl = [
     'stable_baselines3==2.1.0',
     'tensorboard==2.11.2',
-    'torch',
-    'wandb==0.13.7',
-    'psutil==5.9.5',
-    'tyro==0.5.10',
-    'pynvml'
+    'tyro==0.8.6',
 ]
 
 ray = [
@@ -226,6 +222,10 @@ setup(
         f'gymnasium<={GYMNASIUM_VERSION}',
         f'pettingzoo<={PETTINGZOO_VERSION}',
         'shimmy[gym-v21]',
+        'psutil==5.9.5',
+        'pynvml',
+        'torch',
+        'wandb==0.13.7',
     ],
     extras_require={
         'docs': docs,


### PR DESCRIPTION
* made psutil and pynvml core dependencies (from cleanrl) -- still `pip install .[cleanrl]` is necessary to run demos.
* bumped up tyro, so that cleanrl scripts can work with python 3.11
* removed filelock, which caused an error right out of the box
