### PR TITLE
Fix bugs in Stochastic and improve rendered Ocean runtime woes

### DIFF
--- a/pufferlib/environments/ocean/environment.py
+++ b/pufferlib/environments/ocean/environment.py
@@ -117,7 +117,7 @@ def make_bandit(num_actions=10, reward_scale=1, reward_noise=1):
     env = pufferlib.postprocess.EpisodeStats(env)
     return pufferlib.emulation.GymnasiumPufferEnv(env=env)
 
-def make_memory(mem_length=2, mem_delay=2):
+def make_memory(mem_length=2, mem_delay=2, **kwargs):
     from . import sanity
     env = sanity.Memory(mem_length=mem_length, mem_delay=mem_delay)
     env = pufferlib.postprocess.EpisodeStats(env)

--- a/pufferlib/environments/ocean/sanity.py
+++ b/pufferlib/environments/ocean/sanity.py
@@ -590,9 +590,11 @@ class Stochastic(gymnasium.Env):
             else:
                 c = 90
             return f'\033[{c}m██\033[0m'
-
         chars = []
-        solution = 0 if self.count / self.tick < self.p else 1
+        if self.tick == 0:
+            solution = 0
+        else:
+            solution = 0 if self.count / self.tick < self.p else 1
         chars.append(_render(solution))
         chars.append(' Solution\n')
 

--- a/setup.py
+++ b/setup.py
@@ -226,6 +226,7 @@ setup(
         'shimmy[gym-v21]',
         'psutil==5.9.5',
         'pynvml',
+        'imageio',
     ],
     extras_require={
         'docs': docs,


### PR DESCRIPTION
Fix Stochastic rendering and division-by-zero error, add imageio to setup.py, silently handle conflicts b/w runtime and agent render modes, and exit rendered ocean envs gracefully.

Steps to reproduce
make new pyenv python version 3.11.7
git clone https://github.com/PufferAI/PufferLib.git -b dev
cd Pufferlib
pip install -e .[cleanrl]
python demo.py --config ocean --mode evaluate --render raylib --env stochastic
