### PR TITLE
Revert render handling to original; make most envs in Ocean compatible with render

### DIFF
--- a/clean_pufferl.py
+++ b/clean_pufferl.py
@@ -579,6 +579,9 @@ def count_params(policy):
 def rollout(env_creator, env_kwargs, policy_cls, rnn_cls, agent_creator, agent_kwargs,
         backend, render_mode='auto', model_path=None, device='cuda'):
 
+    if render_mode != 'auto':
+        env_kwargs['render_mode'] = render_mode
+        
     # We are just using Serial vecenv to give a consistent
     # single-agent/multi-agent API for evaluation
     env = pufferlib.vector.make(env_creator, env_kwargs=env_kwargs, backend=backend)
@@ -592,15 +595,6 @@ def rollout(env_creator, env_kwargs, policy_cls, rnn_cls, agent_creator, agent_k
     driver = env.driver_env
     os.system('clear')
     state = None
-    
-    # Silently handle conflicts between runtime and agent render modes
-    if render_mode != 'auto':
-        if driver.render_mode is not None:
-            render_mode = driver.render_mode
-        else:
-            render_mode = agent_kwargs['render_mode']
-    else:
-        render_mode = driver.render_mode
 
     frames = []
     tick = 0

--- a/pufferlib/environments/ocean/environment.py
+++ b/pufferlib/environments/ocean/environment.py
@@ -96,7 +96,7 @@ def make_snake(widths=None, heights=None, num_snakes=None, num_food=None, vision
         vision=vision,
     )
 
-def make_continuous(discretize=False):
+def make_continuous(discretize=False, **kwargs):
     from . import sanity
     env = sanity.Continuous(discretize=discretize)
     if not discretize:
@@ -106,7 +106,7 @@ def make_continuous(discretize=False):
 
 def make_squared(distance_to_target=3, num_targets=1, **kwargs):
     from . import sanity
-    env = sanity.Squared(distance_to_target=distance_to_target, num_targets=num_targets)
+    env = sanity.Squared(distance_to_target=distance_to_target, num_targets=num_targets, **kwargs)
     env = pufferlib.postprocess.EpisodeStats(env)
     return pufferlib.emulation.GymnasiumPufferEnv(env=env, **kwargs)
 
@@ -123,25 +123,25 @@ def make_memory(mem_length=2, mem_delay=2, **kwargs):
     env = pufferlib.postprocess.EpisodeStats(env)
     return pufferlib.emulation.GymnasiumPufferEnv(env=env)
 
-def make_password(password_length=5):
+def make_password(password_length=5, **kwargs):
     from . import sanity
     env = sanity.Password(password_length=password_length)
     env = pufferlib.postprocess.EpisodeStats(env)
     return pufferlib.emulation.GymnasiumPufferEnv(env=env)
 
-def make_performance(delay_mean=0, delay_std=0, bandwidth=1):
+def make_performance(delay_mean=0, delay_std=0, bandwidth=1, **kwargs):
     from . import sanity
     env = sanity.Performance(delay_mean=delay_mean, delay_std=delay_std, bandwidth=bandwidth)
     env = pufferlib.postprocess.EpisodeStats(env)
     return pufferlib.emulation.GymnasiumPufferEnv(env=env)
 
-def make_performance_empiric(count_n=0, count_std=0, bandwidth=1):
+def make_performance_empiric(count_n=0, count_std=0, bandwidth=1, **kwargs):
     from . import sanity
     env = sanity.PerformanceEmpiric(count_n=count_n, count_std=count_std, bandwidth=bandwidth)
     env = pufferlib.postprocess.EpisodeStats(env)
     return pufferlib.emulation.GymnasiumPufferEnv(env=env)
 
-def make_stochastic(p=0.7, horizon=100):
+def make_stochastic(p=0.7, horizon=100, **kwargs):
     from . import sanity
     env = sanity.Stochastic(p=p, horizon=100)
     env = pufferlib.postprocess.EpisodeStats(env)
@@ -153,7 +153,7 @@ def make_spaces(**kwargs):
     env = pufferlib.postprocess.EpisodeStats(env)
     return pufferlib.emulation.GymnasiumPufferEnv(env=env, **kwargs)
 
-def make_multiagent():
+def make_multiagent(**kwargs):
     from . import sanity
     env = sanity.Multiagent()
     env = pufferlib.postprocess.MultiagentEpisodeStats(env)


### PR DESCRIPTION
Revert render handling to original (tested - works); 
Make most envs in Ocean compatible with most render runtime arguments (tested - works).

Exceptions:
--mode eval --env squared --render-mode <anything> still does not work, but --mode eval --env squared does.