### PR TITLE
Multiple obs dtypes handled by default (fixed Spaces) + setup update

### DIFF
--- a/clean_pufferl.py
+++ b/clean_pufferl.py
@@ -579,6 +579,9 @@ def count_params(policy):
 def rollout(env_creator, env_kwargs, policy_cls, rnn_cls, agent_creator, agent_kwargs,
         backend, render_mode='auto', model_path=None, device='cuda'):
 
+    if render_mode != 'auto':
+        env_kwargs['render_mode'] = render_mode
+
     # We are just using Serial vecenv to give a consistent
     # single-agent/multi-agent API for evaluation
     env = pufferlib.vector.make(env_creator, env_kwargs=env_kwargs, backend=backend)
@@ -592,15 +595,6 @@ def rollout(env_creator, env_kwargs, policy_cls, rnn_cls, agent_creator, agent_k
     driver = env.driver_env
     os.system('clear')
     state = None
-    
-    # Silently handle conflicts between runtime and agent render modes
-    if render_mode != 'auto':
-        if driver.render_mode is not None:
-            render_mode = driver.render_mode
-        else:
-            render_mode = agent_kwargs['render_mode']
-    else:
-        render_mode = driver.render_mode
 
     frames = []
     tick = 0

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,10 @@ cleanrl = [
     'stable_baselines3==2.1.0',
     'tensorboard==2.11.2',
     'torch',
-    'tyro==0.8.6',
     'wandb==0.13.7',
+    'psutil==5.9.5',
+    'tyro==0.5.10',
+    'pynvml'
 ]
 
 ray = [
@@ -224,9 +226,10 @@ setup(
         f'gymnasium<={GYMNASIUM_VERSION}',
         f'pettingzoo<={PETTINGZOO_VERSION}',
         'shimmy[gym-v21]',
-        'psutil==5.9.5',
-        'pynvml',
         'imageio',
+        'cffi',
+        'raylib',
+        
     ],
     extras_require={
         'docs': docs,


### PR DESCRIPTION
Default policy now handles multiple obs spaces of different dtypes (Spaces now converges); setup now installs necessary deps to render moba; reverted previous render 'fix' in clean_pufferl to correctly respect runtime args when specified.