### PR TITLE
Add mujoco binding

### DIFF
--- a/config/mujoco.ini
+++ b/config/mujoco.ini
@@ -1,0 +1,38 @@
+[base]
+package = mujoco
+env_name = HalfCheetah-v4 Hopper-v4 Swimmer-v4 Walker2d-v4 Ant-v4 Humanoid-v4 Reacher-v4 InvertedPendulum-v4 InvertedDoublePendulum-v4 Pusher-v4 HumanoidStandup-v4
+policy_name = CleanRLPolicy
+# rnn_name = Recurrent
+
+# The following is from https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_continuous_action.py
+[train]
+seed =  1
+torch_deterministic = True
+cpu_offload = False
+device = cuda
+total_timesteps = 1_000_000
+learning_rate = 3e-4
+anneal_lr = True
+gamma = 0.99
+gae_lambda = 0.95
+update_epochs = 10
+norm_adv = True
+clip_coef = 0.2
+clip_vloss = True
+vf_coef = 0.5
+vf_clip_coef = 0.2
+max_grad_norm = 0.5
+ent_coef = 0.0
+target_kl = None
+
+num_envs = 1
+num_workers = 1
+env_batch_size = None
+zero_copy = False
+data_dir = experiments
+checkpoint_interval = 200
+batch_size = 2048
+minibatch_size = 32
+bptt_horizon = 1
+compile = False
+compile_mode = reduce-overhead

--- a/demo.py
+++ b/demo.py
@@ -36,7 +36,6 @@ def init_wandb(args, name, id=None, resume=True):
     wandb.init(
         id=id or wandb.util.generate_id(),
         project=args['wandb_project'],
-        entity=args['wandb_entity'],
         group=args['wandb_group'],
         allow_val_change=True,
         save_code=True,
@@ -346,7 +345,6 @@ if __name__ == '__main__':
         default='serial', choices=['serial', 'multiprocessing', 'ray', 'native'])
     parser.add_argument('--exp-id', '--exp-name', type=str,
         default=None, help="Resume from experiment")
-    parser.add_argument('--wandb-entity', type=str, default='jsuarez')
     parser.add_argument('--wandb-project', type=str, default='pufferlib')
     parser.add_argument('--wandb-group', type=str, default='debug')
     parser.add_argument('--track', action='store_true', help='Track on WandB')

--- a/pufferlib/environments/mujoco/__init__.py
+++ b/pufferlib/environments/mujoco/__init__.py
@@ -1,0 +1,13 @@
+from .environment import env_creator
+
+try:
+    # NOTE: demo.py looks the policy class from the torch module
+    import pufferlib.environments.mujoco.policy as torch
+except ImportError:
+    pass
+else:
+    from .policy import Policy
+    try:
+        from .policy import Recurrent
+    except:
+        Recurrent = None

--- a/pufferlib/environments/mujoco/cleanrl.py
+++ b/pufferlib/environments/mujoco/cleanrl.py
@@ -19,8 +19,6 @@ from pufferlib.environments.mujoco.policy import CleanRLPolicy, Policy
 
 
 if __name__ == "__main__":
-    from demo import init_wandb
-
     # Simpler args parse just for this script. Configs are read from file ONLY.
     parser = argparse.ArgumentParser(description="Training arguments for cleanrl mujoco", add_help=False)
     parser.add_argument("-e", "--env-id", type=str, default="Hopper-v4")
@@ -30,7 +28,7 @@ if __name__ == "__main__":
     parser.add_argument("--wandb-project", type=str, default="cleanrl_mujoco")
     parser.add_argument("--wandb-group", type=str, default=None)
     parser.add_argument("--track", action="store_true", help="Track on WandB")
-    parser.add_argument("--capture-video", default=True)  # action="store_true", help="Capture videos")
+    parser.add_argument("--capture-video", action="store_true", help="Capture videos")
     args = parser.parse_known_args()[0]
 
     if not os.path.exists(args.config):
@@ -85,7 +83,15 @@ if __name__ == "__main__":
 
     wandb = None
     if args.track:
-        wandb = init_wandb(args_dict, run_name)
+        import wandb
+        wandb.init(
+            project=args.wandb_project,
+            group=args.wandb_group,
+            save_code=True,
+            name=run_name,
+            config=args,
+        )
+
     episode_stats = {
         "episode_return": [],
         "episode_length": [],

--- a/pufferlib/environments/mujoco/cleanrl.py
+++ b/pufferlib/environments/mujoco/cleanrl.py
@@ -1,0 +1,325 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/ppo/#ppo_continuous_actionpy
+import configparser
+import argparse
+import random
+import time
+import ast
+import os
+from types import SimpleNamespace
+
+import gymnasium
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+import pufferlib.frameworks.cleanrl
+from pufferlib.environments.mujoco.environment import cleanrl_env_creator
+from pufferlib.environments.mujoco.policy import CleanRLPolicy, Policy
+
+
+if __name__ == "__main__":
+    from demo import init_wandb
+
+    # Simpler args parse just for this script. Configs are read from file ONLY.
+    parser = argparse.ArgumentParser(description="Training arguments for cleanrl mujoco", add_help=False)
+    parser.add_argument("-e", "--env-id", type=str, default="Hopper-v4")
+    parser.add_argument("-c", "--config", type=str, default="config/mujoco.ini")
+    # The current cleanrl script does NOT support recurrent policies
+    parser.add_argument("-p", "--policy", type=str, default="cleanrl", choices=["cleanrl", "puffer"])
+    parser.add_argument("--wandb-project", type=str, default="cleanrl_mujoco")
+    parser.add_argument("--wandb-group", type=str, default=None)
+    parser.add_argument("--track", action="store_true", help="Track on WandB")
+    parser.add_argument("--capture-video", default=True)  # action="store_true", help="Capture videos")
+    args = parser.parse_known_args()[0]
+
+    if not os.path.exists(args.config):
+        raise Exception(f'Config {args.config} not found')
+
+    p = configparser.ConfigParser()
+    p.read(args.config)
+    assert args.env_id in p['base']['env_name'].split(), f"Env {args.env_id} not found in {args.config}"
+
+    for section in p.sections():
+        for key in p[section]:
+            argparse_key = f'--{section}.{key}'.replace('_', '-')
+            parser.add_argument(argparse_key, default=p[section][key])
+
+    parsed = parser.parse_args().__dict__
+    args_dict = {'env': {}, 'policy': {}, 'rnn': {}}
+    env_name = parsed.pop('env_id')
+    for key, value in parsed.items():
+        next = args_dict
+        for subkey in key.split('.'):
+            if subkey not in next:
+                next[subkey] = {}
+            prev = next
+            next = next[subkey]
+        try:
+            prev[subkey] = ast.literal_eval(value)
+        except:
+            prev[subkey] = value
+
+    run_name = f"cleanrl_{env_name}_{args_dict['train']['seed']}_{int(time.time())}"
+
+    # Translate puffer args to cleanrl args
+    args = SimpleNamespace(**args_dict["train"])
+    args.env_id = env_name
+    args.policy = args_dict["policy"]
+    args.wandb_project = args_dict["wandb_project"]
+    args.wandb_group = args_dict["wandb_group"]
+    args.track = args_dict["track"]
+    args.capture_video = args_dict["capture_video"]
+    args.cuda = args_dict["train"]["device"] == "cuda"
+    if not hasattr(args, "target_kl"):
+        args.target_kl = None
+
+    # NOTE: These are CRITICAL (but confusing) for cleanrl to work
+    args.num_steps = args.batch_size
+    num_minibatches = args.minibatch_size
+
+    # These are placeholder values for cleanrl
+    args.batch_size = int(args.num_envs * args.num_steps)
+    args.minibatch_size = int(args.batch_size // num_minibatches)
+    args.num_iterations = args.total_timesteps // args.batch_size
+
+    wandb = None
+    if args.track:
+        wandb = init_wandb(args_dict, run_name)
+    episode_stats = {
+        "episode_return": [],
+        "episode_length": [],
+    }
+
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = args.torch_deterministic
+
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
+
+    # env setup
+    envs = gymnasium.vector.SyncVectorEnv(
+        [
+            cleanrl_env_creator(args.env_id, run_name, args.capture_video, args.gamma, i)
+            for i in range(args.num_envs)
+        ]
+    )
+    assert isinstance(
+        envs.single_action_space, gymnasium.spaces.Box
+    ), "only continuous action space is supported"
+
+    if args.policy == "cleanrl":
+        policy = CleanRLPolicy(envs)
+    elif args.policy == "puffer":
+        policy = Policy(envs)
+    
+    agent = pufferlib.frameworks.cleanrl.Policy(policy).to(device)
+    optimizer = optim.Adam(agent.parameters(), lr=args.learning_rate, eps=1e-5)
+
+    # ALGO Logic: Storage setup
+    obs = torch.zeros((args.num_steps, args.num_envs) + envs.single_observation_space.shape).to(
+        device
+    )
+    actions = torch.zeros((args.num_steps, args.num_envs) + envs.single_action_space.shape).to(
+        device
+    )
+    logprobs = torch.zeros((args.num_steps, args.num_envs)).to(device)
+    rewards = torch.zeros((args.num_steps, args.num_envs)).to(device)
+    dones = torch.zeros((args.num_steps, args.num_envs)).to(device)
+    values = torch.zeros((args.num_steps, args.num_envs)).to(device)
+
+    # TRY NOT TO MODIFY: start the game
+    global_step = 0
+    start_time = time.time()
+    next_obs, _ = envs.reset(seed=args.seed)
+    next_obs = torch.Tensor(next_obs).to(device)
+    next_done = torch.zeros(args.num_envs).to(device)
+
+    for iteration in range(1, args.num_iterations + 1):
+        # Annealing the rate if instructed to do so.
+        if args.anneal_lr:
+            frac = 1.0 - (iteration - 1.0) / args.num_iterations
+            lrnow = frac * args.learning_rate
+            optimizer.param_groups[0]["lr"] = lrnow
+
+        for step in range(0, args.num_steps):
+            global_step += args.num_envs
+            obs[step] = next_obs
+            dones[step] = next_done
+
+            # ALGO LOGIC: action logic
+            with torch.no_grad():
+                action, logprob, _, value = agent.get_action_and_value(next_obs)
+                values[step] = value.flatten()
+            actions[step] = action
+            logprobs[step] = logprob
+
+            # TRY NOT TO MODIFY: execute the game and log data.
+            next_obs, reward, terminations, truncations, infos = envs.step(action.cpu().numpy())
+            next_done = np.logical_or(terminations, truncations)
+            rewards[step] = torch.tensor(reward).to(device).view(-1)
+            next_obs, next_done = (
+                torch.Tensor(next_obs).to(device),
+                torch.Tensor(next_done).to(device),
+            )
+
+            if "final_info" in infos:
+                for info in infos["final_info"]:
+                    if info and "episode_return" in info:
+                        print(
+                            f"global_step: {global_step}, episode_return: {int(info['episode_return'])}"
+                        )
+                        episode_stats["episode_return"].append(info["episode_return"])
+                        episode_stats["episode_length"].append(info["episode_length"])
+
+        # bootstrap value if not done
+        with torch.no_grad():
+            next_value = agent.get_value(next_obs).reshape(1, -1)
+            advantages = torch.zeros_like(rewards).to(device)
+            lastgaelam = 0
+            for t in reversed(range(args.num_steps)):
+                if t == args.num_steps - 1:
+                    nextnonterminal = 1.0 - next_done
+                    nextvalues = next_value
+                else:
+                    nextnonterminal = 1.0 - dones[t + 1]
+                    nextvalues = values[t + 1]
+                delta = rewards[t] + args.gamma * nextvalues * nextnonterminal - values[t]
+                advantages[t] = lastgaelam = (
+                    delta + args.gamma * args.gae_lambda * nextnonterminal * lastgaelam
+                )
+            returns = advantages + values
+
+        # flatten the batch
+        b_obs = obs.reshape((-1,) + envs.single_observation_space.shape)
+        b_logprobs = logprobs.reshape(-1)
+        b_actions = actions.reshape((-1,) + envs.single_action_space.shape)
+        b_advantages = advantages.reshape(-1)
+        b_returns = returns.reshape(-1)
+        b_values = values.reshape(-1)
+
+        # Optimizing the policy and value network
+        b_inds = np.arange(args.batch_size)
+        clipfracs = []
+        for epoch in range(args.update_epochs):
+            np.random.shuffle(b_inds)
+            for start in range(0, args.batch_size, args.minibatch_size):
+                end = start + args.minibatch_size
+                mb_inds = b_inds[start:end]
+
+                _, newlogprob, entropy, newvalue = agent.get_action_and_value(
+                    b_obs[mb_inds], b_actions[mb_inds]
+                )
+                logratio = newlogprob - b_logprobs[mb_inds]
+                ratio = logratio.exp()
+
+                with torch.no_grad():
+                    # calculate approx_kl http://joschu.net/blog/kl-approx.html
+                    old_approx_kl = (-logratio).mean()
+                    approx_kl = ((ratio - 1) - logratio).mean()
+                    clipfracs += [((ratio - 1.0).abs() > args.clip_coef).float().mean().item()]
+
+                mb_advantages = b_advantages[mb_inds]
+                if args.norm_adv:
+                    mb_advantages = (mb_advantages - mb_advantages.mean()) / (
+                        mb_advantages.std() + 1e-8
+                    )
+
+                # Policy loss
+                pg_loss1 = -mb_advantages * ratio
+                pg_loss2 = -mb_advantages * torch.clamp(
+                    ratio, 1 - args.clip_coef, 1 + args.clip_coef
+                )
+                pg_loss = torch.max(pg_loss1, pg_loss2).mean()
+
+                # Value loss
+                newvalue = newvalue.view(-1)
+                if args.clip_vloss:
+                    v_loss_unclipped = (newvalue - b_returns[mb_inds]) ** 2
+                    v_clipped = b_values[mb_inds] + torch.clamp(
+                        newvalue - b_values[mb_inds],
+                        -args.vf_clip_coef,
+                        args.vf_clip_coef,
+                    )
+                    v_loss_clipped = (v_clipped - b_returns[mb_inds]) ** 2
+                    v_loss_max = torch.max(v_loss_unclipped, v_loss_clipped)
+                    v_loss = 0.5 * v_loss_max.mean()
+                else:
+                    v_loss = 0.5 * ((newvalue - b_returns[mb_inds]) ** 2).mean()
+
+                entropy_loss = entropy.mean()
+                loss = pg_loss - args.ent_coef * entropy_loss + v_loss * args.vf_coef
+
+                optimizer.zero_grad()
+                loss.backward()
+                nn.utils.clip_grad_norm_(agent.parameters(), args.max_grad_norm)
+                optimizer.step()
+
+            if args.target_kl is not None and approx_kl > args.target_kl:
+                break
+
+        y_pred, y_true = b_values.cpu().numpy(), b_returns.cpu().numpy()
+        var_y = np.var(y_true)
+        explained_var = np.nan if var_y == 0 else 1 - np.var(y_true - y_pred) / var_y
+
+        # TRY NOT TO MODIFY: record rewards for plotting purposes
+        print(f"Steps: {global_step}, SPS: {int(global_step / (time.time() - start_time))}")
+        if args.track and wandb is not None:
+            wandb.log(
+                {
+                    "0verview/agent_steps": global_step,
+                    "0verview/SPS": int(global_step / (time.time() - start_time)),
+                    "0verview/epoch": iteration,
+                    "0verview/learning_rate": optimizer.param_groups[0]["lr"],
+                    "losses/value_loss": v_loss.item(),
+                    "losses/policy_loss": pg_loss.item(),
+                    "losses/entropy": entropy_loss.item(),
+                    "losses/old_approx_kl": old_approx_kl.item(),
+                    "losses/approx_kl": approx_kl.item(),
+                    "losses/clipfrac": np.mean(clipfracs),
+                    "losses/explained_variance": explained_var,
+                    "environment/episode_return": np.mean(episode_stats["episode_return"]),
+                    "environment/episode_length": np.mean(episode_stats["episode_length"]),
+                }
+            )
+        episode_stats["episode_return"].clear()
+        episode_stats["episode_length"].clear()
+
+    # if args.save_model:
+    #     model_path = f"runs/{run_name}/{args.exp_name}.cleanrl_model"
+    #     torch.save(agent.state_dict(), model_path)
+    #     print(f"model saved to {model_path}")
+    #     from cleanrl_utils.evals.ppo_eval import evaluate
+
+    #     episodic_returns = evaluate(
+    #         model_path,
+    #         make_env,
+    #         args.env_id,
+    #         eval_episodes=10,
+    #         run_name=f"{run_name}-eval",
+    #         Model=Agent,
+    #         device=device,
+    #         gamma=args.gamma,
+    #     )
+    #     for idx, episodic_return in enumerate(episodic_returns):
+    #         writer.add_scalar("eval/episodic_return", episodic_return, idx)
+
+    #     if args.upload_model:
+    #         from cleanrl_utils.huggingface import push_to_hub
+
+    #         repo_name = f"{args.env_id}-{args.exp_name}-seed{args.seed}"
+    #         repo_id = f"{args.hf_entity}/{repo_name}" if args.hf_entity else repo_name
+    #         push_to_hub(
+    #             args,
+    #             episodic_returns,
+    #             repo_id,
+    #             "PPO",
+    #             f"runs/{run_name}",
+    #             f"videos/{run_name}-eval",
+    #         )
+
+    envs.close()
+    if args.track and wandb is not None:
+        wandb.finish()

--- a/pufferlib/environments/mujoco/environment.py
+++ b/pufferlib/environments/mujoco/environment.py
@@ -1,0 +1,59 @@
+
+from pdb import set_trace as T
+
+import functools
+
+import numpy as np
+import gymnasium
+
+import pufferlib
+import pufferlib.emulation
+import pufferlib.environments
+import pufferlib.postprocess
+
+
+def single_env_creator(env_name, capture_video, gamma, run_name=None, idx=None, obs_norm=True, pufferl=False):
+    if capture_video and idx == 0:
+        assert run_name is not None, "run_name must be specified when capturing videos"
+        env = gymnasium.make(env_name, render_mode="rgb_array")
+        env = gymnasium.wrappers.RecordVideo(env, f"videos/{run_name}")
+    else:
+        env = gymnasium.make(env_name)
+
+    env = pufferlib.postprocess.ClipAction(env)  # NOTE: this changed actions space
+    env = pufferlib.postprocess.EpisodeStats(env)
+
+    if obs_norm:
+        env = gymnasium.wrappers.NormalizeObservation(env)
+        env = gymnasium.wrappers.TransformObservation(env, lambda obs: np.clip(obs, -10, 10))
+
+    env = gymnasium.wrappers.NormalizeReward(env, gamma=gamma)
+    env = gymnasium.wrappers.TransformReward(env, lambda reward: np.clip(reward, -10, 10))
+
+    if pufferl is True:
+        env = pufferlib.emulation.GymnasiumPufferEnv(env=env)
+
+    return env
+
+
+def cleanrl_env_creator(env_name, run_name, capture_video, gamma, idx):
+    kwargs = {
+        "env_name": env_name,
+        "run_name": run_name,
+        "capture_video": capture_video,
+        "gamma": gamma,
+        "idx": idx,
+        "pufferl": False,
+    }
+    return functools.partial(single_env_creator, **kwargs)
+
+
+# Keep it simple for pufferl demo, for now
+def env_creator(env_name="HalfCheetah-v4", gamma=0.99):
+    default_kwargs = {
+        "env_name": env_name,
+        "capture_video": False,
+        "gamma": gamma,
+        "pufferl": True,
+    }
+    return functools.partial(single_env_creator, **default_kwargs)

--- a/pufferlib/environments/mujoco/policy.py
+++ b/pufferlib/environments/mujoco/policy.py
@@ -1,0 +1,73 @@
+import numpy as np
+import torch
+import torch.nn as nn
+
+import pufferlib
+from pufferlib.pytorch import layer_init
+
+from pufferlib.models import Default as Policy
+
+
+# Puffer LSTMWrapper does NOT support separate critic networks for now
+# Would be good to test he performance between these architectures
+class Recurrent(pufferlib.models.LSTMWrapper):
+    def __init__(self, env, policy, input_size=128, hidden_size=128, num_layers=1):
+        super().__init__(env, policy, input_size, hidden_size, num_layers)
+
+
+# Difference between CleanRL and PufferRL policies is that
+# CleanRL has seperate actor and critic networks, while
+# PufferRL has a single encoding network that is shared between
+# the actor and critic networks
+class CleanRLPolicy(torch.nn.Module):
+    def __init__(self, env, hidden_size=64):
+        super().__init__()
+        self.is_continuous = isinstance(env.single_action_space, pufferlib.spaces.Box)
+
+        self.actor_encoder = nn.Sequential(
+            layer_init(nn.Linear(np.array(env.single_observation_space.shape).prod(), hidden_size)),
+            nn.Tanh(),
+            layer_init(nn.Linear(hidden_size, hidden_size)),
+            nn.Tanh(),
+        )
+
+        self.actor_decoder_mean = layer_init(
+            nn.Linear(hidden_size, env.single_action_space.shape[0]), std=0.01
+        )
+        self.actor_decoder_logstd = nn.Parameter(torch.zeros(1, env.single_action_space.shape[0]))
+
+        self.critic = nn.Sequential(
+            layer_init(nn.Linear(np.array(env.single_observation_space.shape).prod(), hidden_size)),
+            nn.Tanh(),
+            layer_init(nn.Linear(hidden_size, hidden_size)),
+            nn.Tanh(),
+            layer_init(nn.Linear(hidden_size, 1), std=1.0),
+        )
+
+    def forward(self, observations):
+        observations = observations.float()
+        hidden, lookup = self.encode_observations(observations)
+        actions, _ = self.decode_actions(hidden, lookup)
+        value = self.critic(observations)
+        return actions, value
+
+    # NOTE: these are for the LSTM wrapper, which may NOT work as intended
+    def encode_observations(self, observations):
+        """Encodes a batch of observations into hidden states. Assumes
+        no time dimension (handled by LSTM wrappers)."""
+        batch_size = observations.shape[0]
+        observations = observations.view(batch_size, -1)
+        return self.actor_encoder(observations), None
+
+    def decode_actions(self, hidden, lookup, concat=True):
+        """Decodes a batch of hidden states into (multi)discrete actions.
+        Assumes no time dimension (handled by LSTM wrappers)."""
+        #value = self.value_head(hidden)
+
+        mean = self.actor_decoder_mean(hidden)
+        logstd = self.actor_decoder_logstd.expand_as(mean)
+        std = torch.exp(logstd)
+        probs = torch.distributions.Normal(mean, std)
+        # batch = hidden.shape[0]
+
+        return probs, 0  # NOTE: value comes form the separate critic network

--- a/pufferlib/postprocess.py
+++ b/pufferlib/postprocess.py
@@ -52,10 +52,9 @@ class EpisodeStats(gymnasium.Wrapper):
         self.action_space = env.action_space
         self.reset()
 
-    # TODO: Fix options. Maybe reimplement gymnasium.Wrapper with better compatibility
-    def reset(self, seed=None):
+    def reset(self, seed=None, options=None):
         self.info = dict(episode_return=[], episode_length=0)
-        return self.env.reset(seed=seed)
+        return self.env.reset(seed=seed, options=options)
 
     def step(self, action):
         observation, reward, terminated, truncated, info = super().step(action)

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,11 @@ environments = {
         f'gymnasium=={GYMNASIUM_VERSION}',
         'minihack==0.1.5',
     ],
+    'mujoco': [
+        f'gymnasium[mujoco]=={GYMNASIUM_VERSION}',
+        'mujoco==2.3.7',  # mujuco > 3 is supported by gymnasium > 1.0
+        'moviepy',
+    ],
     'nethack': [
         f'gym=={GYM_VERSION}',
         f'gymnasium=={GYMNASIUM_VERSION}',


### PR DESCRIPTION
* Added mujoco (2.3.7, the last version before 3.x, which are supported by gymnasium >= 1.0)  env binding
* Added the cleanrl hyper parameters, policy (the separate actor & critic networks), and the cleanrl script to test both the cleanrl and puffer default policies
  * The current num_worker=1, so it will be slow. We will update hyperparams based on CARBS sweep
* minor fixes in demo.py (took out wandb entity), postprocess.py (added options to reset)