### PR TITLE
Fix connect4 test_performance method

### DIFF
--- a/pufferlib/environments/ocean/connect4/connect4.py
+++ b/pufferlib/environments/ocean/connect4/connect4.py
@@ -1,4 +1,4 @@
-'''High-perf Pong
+'''High-perf Connect 4
 
 Inspired from https://gist.github.com/Yttrmin/18ecc3d2d68b407b4be1
 & https://jair.org/index.php/jair/article/view/10819/25823
@@ -7,8 +7,6 @@ Inspired from https://gist.github.com/Yttrmin/18ecc3d2d68b407b4be1
 
 import numpy as np
 import gymnasium
-
-from raylib import rl
 
 import pufferlib
 from pufferlib.environments.ocean.connect4.cy_connect4 import CyConnect4
@@ -51,11 +49,15 @@ class MyConnect4(pufferlib.PufferEnv):
         self.c_envs.render()
 
 def test_performance(timeout=10, atn_cache=1024):
-    env = MyConnect4(num_envs=1000)
+    num_envs = 1000
+    env = MyConnect4(num_envs=num_envs)
     env.reset()
     tick = 0
 
-    actions = np.random.randint(0, 2, (atn_cache, env.num_envs))
+    actions = np.random.randint(
+        0, env.single_action_space.n + 1,
+        (atn_cache, num_envs)
+    )
 
     import time
     start = time.time()
@@ -64,7 +66,8 @@ def test_performance(timeout=10, atn_cache=1024):
         env.step(atn)
         tick += 1
 
-    print(f'SPS: %f', env.num_envs * tick / (time.time() - start))
+    sps = num_envs * tick / (time.time() - start)
+    print(f'SPS: {sps:,}')
 
 if __name__ == '__main__':
     test_performance()


### PR DESCRIPTION
Fix the following error:

```bash
(venv) jakeforsey PufferLib (dev) >> python -m pufferlib.environments.ocean.connect4.connect4
```

```bash
/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/runpy.py:127: RuntimeWarning: 'pufferlib.environments.ocean.connect4.connect4' found in sys.modules after import of package 'pufferlib.environments.ocean.connect4', but prior to execution of 'pufferlib.environments.ocean.connect4.connect4'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
Traceback (most recent call last):
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/jakeforsey/dev/PufferLib/pufferlib/environments/ocean/connect4/connect4.py", line 68, in <module>
    test_performance()
  File "/Users/jakeforsey/dev/PufferLib/pufferlib/environments/ocean/connect4/connect4.py", line 56, in test_performance
    actions = np.random.randint(0, 2, (atn_cache, env.num_envs))
AttributeError: 'MyConnect4' object has no attribute 'num_envs'

```