### PR TITLE
Fix connect4 on linux

### DIFF
--- a/pufferlib/environments/ocean/connect4/connect4.c
+++ b/pufferlib/environments/ocean/connect4/connect4.c
@@ -1,7 +1,9 @@
 #include "connect4.h"
 #include "time.h"
 
-int main() {
+const unsigned char NOOP = 8;
+
+void interactive() {
     CConnect4 env = {
         .width = 672,
         .height = 576,
@@ -14,8 +16,7 @@ int main() {
     Client* client = make_client(env.width, env.height);
 
     while (!WindowShouldClose()) {
-        // User can take control of the paddle
-        env.actions[0] = -1;
+        env.actions[0] = NOOP;
         // user inputs 1 - 7 key pressed
         if(IsKeyPressed(KEY_ONE)) env.actions[0] = 0;
         if(IsKeyPressed(KEY_TWO)) env.actions[0] = 1;
@@ -25,17 +26,17 @@ int main() {
         if(IsKeyPressed(KEY_SIX)) env.actions[0] = 5;
         if(IsKeyPressed(KEY_SEVEN)) env.actions[0] = 6;
 
-        if (env.actions[0] != -1) {
+        if (env.actions[0] >= 0 && env.actions[0] <= 6) {
             step(&env);
         }
         render(client, &env);
     }
     close_client(client);
     free_allocated_cconnect4(&env);
-    return 0;
 }
 
-void test_performance(float test_time) {
+void performance_test() {
+    long test_time = 10;
     CConnect4 env = {
         .width = 672,
         .height = 576,
@@ -45,17 +46,20 @@ void test_performance(float test_time) {
     allocate_cconnect4(&env);
     reset(&env);
  
-    float start = time(NULL);
+    long start = time(NULL);
     int i = 0;
     while (time(NULL) - start < test_time) {
-        for (int j = 0; j < 10; j++) {
-            env.actions[0] = rand() % 7;
-        }
+        env.actions[0] = rand() % 7;
         step(&env);
         i++;
     }
-    float end = time(NULL);
-    printf("SPS: %f\n", i / (end - start));
+    long end = time(NULL);
+    printf("SPS: %ld\n", i / (end - start));
+    free_allocated_cconnect4(&env);
 }
 
-
+int main() {
+    // performance_test();
+    interactive();
+    return 0;
+}

--- a/pufferlib/environments/ocean/connect4/connect4.h
+++ b/pufferlib/environments/ocean/connect4/connect4.h
@@ -106,8 +106,7 @@ void allocate_cconnect4(CConnect4* env) {
 }
 
 void free_cconnect4(CConnect4* env) {
-    free(env->log_buffer);
-    free(env);
+    free_logbuffer(env->log_buffer);
 }
 
 void free_allocated_cconnect4(CConnect4* env) {
@@ -142,7 +141,7 @@ uint64_t swap_player(uint64_t position, uint64_t mask) {
     return position ^ mask;
 }
 
-uint64_t play(int column, u_int64_t mask) {
+uint64_t play(int column, uint64_t mask) {
     mask |= mask + bottom_mask(column);
     return mask;
 }
@@ -173,7 +172,7 @@ bool won(uint64_t position) {
     return false;
 }
 
-float minmax(u_int64_t position, u_int64_t mask, int depth, bool maximising_player) {
+float minmax(uint64_t position, uint64_t mask, int depth, bool maximising_player) {
     // https://en.wikipedia.org/wiki/Minimax
     bool has_won = won(position);
     if (depth == 0 || has_won || draw(mask)) {
@@ -189,8 +188,8 @@ float minmax(u_int64_t position, u_int64_t mask, int depth, bool maximising_play
         if (!valid_move(column, mask)) {
             continue;
         }
-        u_int64_t child_position = swap_player(position, mask);  // Swap the player
-        u_int64_t child_mask = play(column, mask);
+        uint64_t child_position = swap_player(position, mask);
+        uint64_t child_mask = play(column, mask);
         float child_value = minmax(child_position, child_mask, depth - 1, !maximising_player);
         if (maximising_player && child_value > value) {
             value = child_value;
@@ -217,8 +216,8 @@ int compute_env_move(CConnect4* env) {
     float best_value = -MAX_VALUE;
     for (uint64_t column = 0; column < 7; column ++) {
         if (!valid_move(column, env->mask)) { continue; }
-        u_int64_t child_position = env->position ^ env->mask;
-        u_int64_t child_mask = play(column, env->mask);
+        uint64_t child_position = swap_player(env->position, env->mask);
+        uint64_t child_mask = play(column, env->mask);
         
         float value = minmax(child_position, child_mask, 2, false);
         if (value == DRAW_VALUE) {
@@ -240,13 +239,14 @@ void compute_observation(CConnect4* env) {
     //  the observations vector.
     // Details: http://blog.gamesolver.org/solving-connect-four/06-bitboard/
     uint64_t p0 = env->position;
-    uint64_t p1 = env->position ^ env->mask;
+    uint64_t p1 = swap_player(env->position, env->mask);
 
     int obs_idx = 0;
     for (int i = 0; i < 49; i++) {
         // Skip the sentinel row
-        if ((i + 1) % 7 == 0) { continue; }
-        obs_idx += 1;
+        if ((i + 1) % 7 == 0) {
+            continue;
+        }
 
         int p0_bit = (p0 >> i) & 1;
         if (p0_bit == 1) {
@@ -256,6 +256,7 @@ void compute_observation(CConnect4* env) {
         if (p1_bit == 1) {
             env->observations[obs_idx] = P1;
         }
+        obs_idx += 1;
     }
 }
 
@@ -362,8 +363,9 @@ void render(Client* client, CConnect4* env) {
     int obs_idx = 0;
     for (int i = 0; i < 49; i++) {
         // TODO: Simplify this by iterating over the observation more directly
-        if ((i + 1) % 7 == 0) { continue; }
-        obs_idx += 1;
+        if ((i + 1) % 7 == 0) {
+            continue;
+        }
 
         int row = i % (ROWS + 1);
         int column = i / (ROWS + 1);
@@ -381,6 +383,7 @@ void render(Client* client, CConnect4* env) {
             piece_color = PUFF_RED;
             color_idx = 2;
         }
+        obs_idx += 1;
 
         Color board_color = (Color){0, 80, 80, 255};
         DrawRectangle(x , y , env->piece_width, env->piece_width, board_color);

--- a/pufferlib/environments/ocean/connect4/cy_connect4.pyx
+++ b/pufferlib/environments/ocean/connect4/cy_connect4.pyx
@@ -1,5 +1,6 @@
 cimport numpy as cnp
 from libc.stdlib cimport calloc, free
+from libc.stdint cimport uint64_t
 import os
 
 cdef extern from "connect4.h":
@@ -22,16 +23,14 @@ cdef extern from "connect4.h":
         unsigned char* dones
         LogBuffer* log_buffer;
         Log log;
-        int game_over
+
+        uint64_t position;
+        uint64_t mask;
+
         int piece_width;
         int piece_height;
-        float* board_x;
-        float* board_y;
-        float board_states[6][7];
-        int* longest_connected;
         int width;
         int height;
-        int pieces_placed;
 
     ctypedef struct Client
 
@@ -64,6 +63,9 @@ cdef class CyConnect4:
             cnp.ndarray actions_i
             cnp.ndarray rewards_i
             cnp.ndarray terminals_i
+        
+            uint64_t position = 0
+            uint64_t mask = 0
 
         cdef int i
         for i in range(num_envs):
@@ -77,6 +79,8 @@ cdef class CyConnect4:
                 rewards = <float*> rewards_i.data,
                 dones = <unsigned char*> terminals_i.data,
                 log_buffer=self.logs,
+                position=position,
+                mask=mask,
                 piece_width=piece_width,
                 piece_height=piece_height,
                 width=width,


### PR DESCRIPTION
I think I need some help.

I can't test rendering on linux (my setup is headless), and I get a segmentation fault when training (I guess there is a cython issue I can't find).

| platform | demo.py train | ./connect.c perf | ./connect.c interactive |
| --- | --- | --- | --- |
| linux | ❌ | ✅ | can't test |
| macOS | ✅ | ✅ | ✅ | 

TODO:
 - [x] Off-by-one error in observations
 - [x] unsigned char set to -1
 - [x] connect4.c performance test fixes
 - [x] properly free log buffer (using free_logbuffer)
 - [x] use uint64_t everywhere and import stdint.h
 - [ ] Debug train segmentation fault
 