### PR TITLE
fix demo minigrid

### DIFF
--- a/pufferlib/models.py
+++ b/pufferlib/models.py
@@ -35,7 +35,7 @@ class Default(nn.Module):
 
         if self.is_dict_obs:
             self.dtype = pufferlib.pytorch.nativize_dtype(env.emulated)
-            input_size = sum(np.prod(v.shape) for v in env.env.observation_space.values())
+            input_size = sum(int(np.prod(v.shape)) for v in env.env.observation_space.values())
             self.encoder = nn.Linear(input_size, self.hidden_size)
         else:
             self.encoder = nn.Linear(np.prod(env.single_observation_space.shape), hidden_size)

--- a/pufferlib/vector.py
+++ b/pufferlib/vector.py
@@ -372,7 +372,7 @@ class Multiprocessing:
                 target=_worker_process,
                 args=(env_creators[start:end], env_args[start:end],
                     env_kwargs[start:end], obs_shape, obs_dtype,
-                    atn_shape, atn_dtype, envs_per_worker, driver_env.num_agents,
+                    atn_shape, atn_dtype, envs_per_worker, agents_per_worker,
                     num_workers, i, w_send_pipes[i], w_recv_pipes[i],
                     self.shm, is_native)
             )


### PR DESCRIPTION
fix two issues trying to run the commands from dev branch
```
python demo.py --env minigrid --mode train 
python demo.py --env minigrid --mode train  --vec multiprocessing
```

1. `Discrete` has shape `()` and `np.prod(()) = 1.0` so need to cast to int when building network
2. set num agents correctly in `MultiProcessing`

however it does look like dev branch is slower (35k vs 50k sps)
1.0
<img width="1537" alt="Screenshot 2024-10-25 at 4 02 51 PM" src="https://github.com/user-attachments/assets/b9b9a5a4-f613-47e6-ba88-0c3036cf7785">
dev
<img width="1539" alt="Screenshot 2024-10-25 at 4 04 05 PM" src="https://github.com/user-attachments/assets/257aad38-91a8-409d-aa1d-bf8450fbc0cc">


For the `vector.py` change my understanding is
- `MultiProcessing` spawn `num_workers` workers 'sees' a portion of the buffer
- The outer buffer has dimension `(num_workers, agents_per_worker, *obs_shape)` concretely let's say this is `(6, 8, 160)`
- So each worker should get a 'slice' of shape of shape `(agents_per_worker, *obs_shape) = (8, 160)`. Before this change the are only getting a slice of `(1, 160)` because `driver_env.num_agents` is 1. 
- From my understanding, `driver_env` is like the first env; in the worker process we use `Serial` so it's like one of the envs in `Serial`. 
- If the slice of observations is shape `(1, 160)` instead of `(8, 160)`, then in `Serial._assign_buffers` when we assign parts of the buffer to the worker we will end up assigning empty slices and will see errors downstream