### PR TITLE
Serial vectorization for native pufferenvs

### DIFF
--- a/config/ocean/pysquared.ini
+++ b/config/ocean/pysquared.ini
@@ -1,0 +1,21 @@
+[base]
+package = ocean
+env_name = puffer_pysquared
+policy_name = Policy
+rnn_name = Recurrent
+
+[env]
+num_envs = 1
+
+[train]
+total_timesteps = 40_000_000
+checkpoint_interval = 50
+num_envs = 12288
+num_workers = 12
+env_batch_size = 4096
+batch_size = 131072
+update_epochs = 1
+minibatch_size = 8192
+learning_rate = 0.0017
+anneal_lr = False
+device = cuda

--- a/pufferlib/emulation.py
+++ b/pufferlib/emulation.py
@@ -154,7 +154,10 @@ class GymnasiumPufferEnv(gymnasium.Env):
         self.render_modes = 'human rgb_array'.split()
 
         set_buffers(self, buf)
-        self.obs_struct = self.observations.view(self.obs_dtype)
+        if isinstance(self.env.observation_space, pufferlib.spaces.Box):
+            self.obs_struct = self.observations
+        else:
+            self.obs_struct = self.observations.view(self.obs_dtype)
  
     @property
     def render_mode(self):
@@ -253,7 +256,10 @@ class PettingZooPufferEnv:
         self.num_agents = len(self.possible_agents)
 
         set_buffers(self, buf)
-        self.obs_struct = self.observations.view(self.obs_dtype)
+        if isinstance(self.env.observation_space, pufferlib.spaces.Box):
+            self.obs_struct = self.observations
+        else:
+            self.obs_struct = self.observations.view(self.obs_dtype)
 
     @property
     def render_mode(self):
@@ -368,7 +374,7 @@ class PettingZooPufferEnv:
         for i, agent in enumerate(self.possible_agents):
             # TODO: negative padding buf
             if agent not in obs:
-                self.obs[i] = 0
+                self.observations[i] = 0
                 self.rewards[i] = 0
                 self.terminals[i] = True
                 self.truncations[i] = False
@@ -391,13 +397,6 @@ class PettingZooPufferEnv:
         rewards = pad_agent_data(rewards, self.possible_agents, 0)
         dones = pad_agent_data(dones, self.possible_agents, True) # You changed this from false to match api test... is this correct?
         truncateds = pad_agent_data(truncateds, self.possible_agents, False)
-
-        '''
-        assert self.dict_obs[1] == self.observations[0] and self.dict_obs[2] == self.observations[1]
-        assert self.rewards[0] == rewards[1] and self.rewards[1] == rewards[2]
-        assert self.terminals[0] == dones[1] and self.terminals[1] == dones[2]
-        assert self.truncations[0] == truncateds[1] and self.truncations[1] == truncateds[2]
-        '''
         return self.dict_obs, rewards, dones, truncateds, infos
 
     def render(self):

--- a/pufferlib/emulation.py
+++ b/pufferlib/emulation.py
@@ -296,9 +296,9 @@ class PettingZooPufferEnv:
                     ob, self.env.observation_space(k))
 
         # Call user featurizer and flatten the observations
+        self.observations[:] = 0
         for i, agent in enumerate(self.possible_agents):
             if agent not in obs:
-                self.observation[i] = 0
                 continue
 
             ob = obs[agent]
@@ -357,6 +357,9 @@ class PettingZooPufferEnv:
         # TODO: Can add this assert once NMMO Horizon is ported to puffer
         # assert all(dones.values()) == (len(self.env.agents) == 0)
         self.mask = {k: False for k in self.possible_agents}
+        self.rewards[:] = 0
+        self.terminals[:] = True
+        self.truncations[:] = False
         for i, agent in enumerate(self.possible_agents):
             # TODO: negative padding buf
             if agent not in obs:
@@ -384,6 +387,12 @@ class PettingZooPufferEnv:
         dones = pad_agent_data(dones, self.possible_agents, True) # You changed this from false to match api test... is this correct?
         truncateds = pad_agent_data(truncateds, self.possible_agents, False)
 
+        '''
+        assert self.dict_obs[1] == self.observations[0] and self.dict_obs[2] == self.observations[1]
+        assert self.rewards[0] == rewards[1] and self.rewards[1] == rewards[2]
+        assert self.terminals[0] == dones[1] and self.terminals[1] == dones[2]
+        assert self.truncations[0] == truncateds[1] and self.truncations[1] == truncateds[2]
+        '''
         return self.dict_obs, rewards, dones, truncateds, infos
 
     def render(self):

--- a/pufferlib/emulation.py
+++ b/pufferlib/emulation.py
@@ -73,6 +73,10 @@ def dtype_from_space(space):
         dtype = []
         for k, value in space.items():
             dtype.append((k, dtype_from_space(value)))
+    elif isinstance(space, (pufferlib.spaces.Discrete)):
+        dtype = (np.int32, ())
+    elif isinstance(space, (pufferlib.spaces.MultiDiscrete)):
+        dtype = (np.int32, (len(space.nvec),))
     else:
         dtype = (space.dtype, space.shape)
 
@@ -111,9 +115,10 @@ def emulate_observation_space(space):
     return emulated_space, emulated_dtype
 
 def emulate_action_space(space):
-    if isinstance(space, (pufferlib.spaces.Discrete,
-            pufferlib.spaces.MultiDiscrete, pufferlib.spaces.Box)):
+    if isinstance(space, pufferlib.spaces.Box):
         return space, space.dtype
+    elif isinstance(space, (pufferlib.spaces.Discrete, pufferlib.spaces.MultiDiscrete)):
+        return space, np.int32
 
     emulated_dtype = dtype_from_space(space)
     leaves = flatten_space(space)

--- a/pufferlib/environments/atari/environment.py
+++ b/pufferlib/environments/atari/environment.py
@@ -16,7 +16,7 @@ def env_creator(name='breakout'):
 
 def make(name, obs_type='grayscale', frameskip=4,
         full_action_space=False, framestack=1,
-        repeat_action_probability=0.0, render_mode='rgb_array'):
+        repeat_action_probability=0.0, render_mode='rgb_array', buf=None):
     '''Atari creation function'''
     pufferlib.environments.try_import('ale_py', 'AtariEnv')
 
@@ -51,7 +51,7 @@ def make(name, obs_type='grayscale', frameskip=4,
         env = AtariPostprocessor(env) # Don't use standard postprocessor
 
     env = pufferlib.postprocess.EpisodeStats(env)
-    env = pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    env = pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
     return env
 
 class AtariPostprocessor(gym.Wrapper):

--- a/pufferlib/environments/box2d/environment.py
+++ b/pufferlib/environments/box2d/environment.py
@@ -11,11 +11,11 @@ import pufferlib.postprocess
 def env_creator(name='car-racing'):
     return functools.partial(make, name=name)
 
-def make(name, domain_randomize=True, continuous=False, render_mode='rgb_array'):
+def make(name, domain_randomize=True, continuous=False, render_mode='rgb_array', buf=None):
     if name == 'car-racing':
         name = 'CarRacing-v2'
 
     env = gymnasium.make(name, render_mode=render_mode,
         domain_randomize=domain_randomize, continuous=continuous)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)

--- a/pufferlib/environments/bsuite/environment.py
+++ b/pufferlib/environments/bsuite/environment.py
@@ -11,7 +11,7 @@ from bsuite.utils import gym_wrapper
 def env_creator(name='bandit/0'):
     return functools.partial(make, name)
 
-def make(name='bandit/0', results_dir='experiments/bsuite', overwrite=True):
+def make(name='bandit/0', results_dir='experiments/bsuite', overwrite=True, buf=None):
     '''BSuite environments'''
     bsuite = pufferlib.environments.try_import('bsuite')
     from bsuite.utils import gym_wrapper
@@ -19,7 +19,7 @@ def make(name='bandit/0', results_dir='experiments/bsuite', overwrite=True):
     env = gym_wrapper.GymFromDMEnv(env)
     env = BSuiteStopper(env)
     env = pufferlib.wrappers.GymToGymnasium(env)
-    env = pufferlib.emulation.GymnasiumPufferEnv(env)
+    env = pufferlib.emulation.GymnasiumPufferEnv(env, buf=buf)
     return env
 
 class BSuiteStopper:

--- a/pufferlib/environments/butterfly/environment.py
+++ b/pufferlib/environments/butterfly/environment.py
@@ -9,7 +9,7 @@ import pufferlib.environments
 def env_creator(name='cooperative_pong_v5'):
     return functools.partial(make, name)
 
-def make(name):
+def make(name, buf=None):
     pufferlib.environments.try_import('pettingzoo.butterfly', 'butterfly')
     if name == 'cooperative_pong_v5':
         from pettingzoo.butterfly import cooperative_pong_v5 as pong
@@ -22,4 +22,4 @@ def make(name):
 
     env = env_cls()
     env = aec_to_parallel_wrapper(env)
-    return pufferlib.emulation.PettingZooPufferEnv(env=env)
+    return pufferlib.emulation.PettingZooPufferEnv(env=env, buf=buf)

--- a/pufferlib/environments/classic_control/environment.py
+++ b/pufferlib/environments/classic_control/environment.py
@@ -15,7 +15,7 @@ ALIASES = {
 def env_creator(name='cartpole'):
     return functools.partial(make, name)
 
-def make(name, render_mode='rgb_array'):
+def make(name, render_mode='rgb_array', buf=None):
     '''Create an environment by name'''
 
     if name in ALIASES:
@@ -30,7 +30,7 @@ def make(name, render_mode='rgb_array'):
     #env = gymnasium.wrappers.NormalizeReward(env, gamma=gamma)
     env = gymnasium.wrappers.TransformReward(env, lambda reward: np.clip(reward, -1, 1))
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
 class MountainCarWrapper(gymnasium.Wrapper):
     def step(self, action):

--- a/pufferlib/environments/classic_control_continuous/environment.py
+++ b/pufferlib/environments/classic_control_continuous/environment.py
@@ -9,7 +9,7 @@ import pufferlib.postprocess
 def env_creator(name='MountainCarContinuous-v0'):
     return functools.partial(make, name)
 
-def make(name, render_mode='rgb_array'):
+def make(name, render_mode='rgb_array', buf=None):
     '''Create an environment by name'''
     env = gymnasium.make(name, render_mode=render_mode)
     if name == 'MountainCarContinuous-v0':
@@ -17,7 +17,7 @@ def make(name, render_mode='rgb_array'):
 
     env = pufferlib.postprocess.ClipAction(env)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
 class MountainCarWrapper(gymnasium.Wrapper):
     def step(self, action):

--- a/pufferlib/environments/crafter/environment.py
+++ b/pufferlib/environments/crafter/environment.py
@@ -19,7 +19,7 @@ class TransposeObs(gym.Wrapper):
 def env_creator(name='crafter'):
     return functools.partial(make, name)
 
-def make(name):
+def make(name, buf=None):
     '''Crafter creation function'''
     if name == 'crafter':
         name = 'CrafterReward-v1'
@@ -31,7 +31,7 @@ def make(name):
     env = RenderWrapper(env)
     env = TransposeObs(env)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
 class RenderWrapper(gym.Wrapper):
     def __init__(self, env):

--- a/pufferlib/environments/dm_control/environment.py
+++ b/pufferlib/environments/dm_control/environment.py
@@ -16,9 +16,9 @@ def env_creator(name='walker'):
     not support continuous action spaces.'''
     return functools.partial(make, name)
 
-def make(name, task_name='walk'):
-    '''No PufferLib support for continuous actions yet.'''
+def make(name, task_name='walk', buf=None):
+    '''Untested. Let us know in Discord if you want to use dmc in PufferLib.'''
     dm_control = pufferlib.environments.try_import('dm_control.suite', 'dmc')
     env = dm_control.suite.load(name, task_name)
     env = shimmy.DmControlCompatibilityV0(env=env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env, buf=buf)

--- a/pufferlib/environments/dm_lab/environment.py
+++ b/pufferlib/environments/dm_lab/environment.py
@@ -14,10 +14,11 @@ def env_creator(name='seekavoid_arena_01'):
     dm-lab requires extensive setup. Use PufferTank.'''
     return functools.partial(make, name=name)
 
-def make(name):
+def make(name, buf=None):
     '''Deepmind Lab binding creation function
-    dm-lab requires extensive setup. Use PufferTank.'''
+    dm-lab requires extensive setup. Currently dropped frop PufferTank.
+    Let us know if you need this for your work.'''
     dm_lab = pufferlib.environments.try_import('deepmind_lab', 'dm-lab')
     env = dm_lab.Lab(name, ['RGB_INTERLEAVED'])
     env = shimmy.DmLabCompatibilityV0(env=env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)

--- a/pufferlib/environments/griddly/environment.py
+++ b/pufferlib/environments/griddly/environment.py
@@ -17,7 +17,7 @@ def env_creator(name='spiders'):
     return functools.partial(make, name)
 
 # TODO: fix griddly
-def make(name):
+def make(name, buf=None):
     '''Griddly creation function
 
     Note that Griddly environments do not have observation spaces until
@@ -34,4 +34,4 @@ def make(name):
 
     env = shimmy.GymV21CompatibilityV0(env=env)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env, buf=buf)

--- a/pufferlib/environments/gvgai/environment.py
+++ b/pufferlib/environments/gvgai/environment.py
@@ -17,12 +17,12 @@ def env_creator(name='zelda'):
     return functools.partial(make, name)
 
 def make(name, obs_type='grayscale', frameskip=4, full_action_space=False,
-        repeat_action_probability=0.0, render_mode='rgb_array'):
+        repeat_action_probability=0.0, render_mode='rgb_array', buf=None):
     '''Atari creation function'''
     pufferlib.environments.try_import('gym_gvgai')
     env = gym.make(name)
     env = pufferlib.wrappers.GymToGymnasium(env)
     env = pufferlib.postprocess.EpisodeStats(env)
-    env = pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    env = pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
     return env
 

--- a/pufferlib/environments/links_awaken/environment.py
+++ b/pufferlib/environments/links_awaken/environment.py
@@ -7,9 +7,9 @@ from links_awaken import LinksAwakenV1 as env_creator
 import pufferlib.emulation
 
 
-def make_env(headless: bool = True, state_path=None):
+def make_env(headless: bool = True, state_path=None, buf=None):
     '''Links Awakening'''
     env = env_creator(headless=headless, state_path=state_path)
     env = gymnasium.wrappers.ResizeObservation(env, shape=(72, 80))
     return pufferlib.emulation.GymnasiumPufferEnv(env=env,
-        postprocessor_cls=pufferlib.emulation.BasicPostprocessor)
+        postprocessor_cls=pufferlib.emulation.BasicPostprocessor, buf=buf)

--- a/pufferlib/environments/magent/environment.py
+++ b/pufferlib/environments/magent/environment.py
@@ -11,7 +11,7 @@ def env_creator(name='battle_v4'):
     return functools.partial(make, name)
     pufferlib.environments.try_import('pettingzoo.magent', 'magent')
 
-def make(name):
+def make(name, buf=None):
     '''MAgent Battle V4 creation function'''
     if name == 'battle_v4':
         from pettingzoo.magent import battle_v4
@@ -22,4 +22,4 @@ def make(name):
     env = env_cls()
     env = aec_to_parallel_wrapper(env)
     env = pufferlib.wrappers.PettingZooTruncatedWrapper(env)
-    return pufferlib.emulation.PettingZooPufferEnv(env=env)
+    return pufferlib.emulation.PettingZooPufferEnv(env=env, buf=buf)

--- a/pufferlib/environments/microrts/environment.py
+++ b/pufferlib/environments/microrts/environment.py
@@ -12,7 +12,7 @@ import pufferlib.environments
 def env_creator(name='GlobalAgentCombinedRewardEnv'):
     return functools.partial(make, name)
 
-def make(name):
+def make(name, buf=None):
     '''Gym MicroRTS creation function
     
     This library appears broken. Step crashes in Java.
@@ -31,7 +31,7 @@ def make(name):
 
     env = MicroRTS(env)
     env = shimmy.GymV21CompatibilityV0(env=env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
 class MicroRTS:
     def __init__(self, env):

--- a/pufferlib/environments/minerl/environment.py
+++ b/pufferlib/environments/minerl/environment.py
@@ -13,7 +13,7 @@ import pufferlib.utils
 def env_creator(name='MineRLBasaltFindCave-v0'):
     return functools.partial(make, name=name)
 
-def make(name):
+def make(name, buf=None):
     '''Minecraft environment creation function'''
 
     pufferlib.environments.try_import('minerl')
@@ -25,4 +25,4 @@ def make(name):
     env = gym.make(name)
 
     env = shimmy.GymV21CompatibilityV0(env=env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env, buf=buf)

--- a/pufferlib/environments/minigrid/environment.py
+++ b/pufferlib/environments/minigrid/environment.py
@@ -15,7 +15,7 @@ ALIASES = {
 def env_creator(name='minigrid'):
     return functools.partial(make, name=name)
 
-def make(name, render_mode='rgb_array'):
+def make(name, render_mode='rgb_array', buf=None):
     if name in ALIASES:
         name = ALIASES[name]
 
@@ -23,7 +23,7 @@ def make(name, render_mode='rgb_array'):
     env = gymnasium.make(name, render_mode=render_mode)
     env = MiniGridWrapper(env)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
 class MiniGridWrapper:
     def __init__(self, env):

--- a/pufferlib/environments/minihack/environment.py
+++ b/pufferlib/environments/minihack/environment.py
@@ -22,7 +22,7 @@ ALIASES = {
 def env_creator(name='minihack'):
     return functools.partial(make, name)
 
-def make(name):
+def make(name, buf=None):
     '''NetHack binding creation function'''
     if name in ALIASES:
         name = ALIASES[name]
@@ -33,7 +33,7 @@ def make(name):
     env = gym.make(name, observation_keys=obs_key)
     env = shimmy.GymV21CompatibilityV0(env=env)
     env = MinihackWrapper(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
 class MinihackWrapper:
     def __init__(self, env):

--- a/pufferlib/environments/mujoco/environment.py
+++ b/pufferlib/environments/mujoco/environment.py
@@ -12,7 +12,7 @@ import pufferlib.environments
 import pufferlib.postprocess
 
 
-def single_env_creator(env_name, capture_video, gamma, run_name=None, idx=None, obs_norm=True, pufferl=False):
+def single_env_creator(env_name, capture_video, gamma, run_name=None, idx=None, obs_norm=True, pufferl=False, buf=None):
     if capture_video and idx == 0:
         assert run_name is not None, "run_name must be specified when capturing videos"
         env = gymnasium.make(env_name, render_mode="rgb_array")
@@ -31,7 +31,7 @@ def single_env_creator(env_name, capture_video, gamma, run_name=None, idx=None, 
     env = gymnasium.wrappers.TransformReward(env, lambda reward: np.clip(reward, -10, 10))
 
     if pufferl is True:
-        env = pufferlib.emulation.GymnasiumPufferEnv(env=env)
+        env = pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
     return env
 

--- a/pufferlib/environments/nethack/environment.py
+++ b/pufferlib/environments/nethack/environment.py
@@ -13,7 +13,7 @@ import pufferlib.postprocess
 def env_creator(name='nethack'):
     return functools.partial(make, name)
 
-def make(name):
+def make(name, buf=None):
     '''NetHack binding creation function'''
     if name == 'nethack':
         name = 'NetHackScore-v0'
@@ -24,7 +24,7 @@ def make(name):
     env = shimmy.GymV21CompatibilityV0(env=env)
     env = NethackWrapper(env)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
 class NethackWrapper:
     def __init__(self, env):

--- a/pufferlib/environments/nmmo/environment.py
+++ b/pufferlib/environments/nmmo/environment.py
@@ -12,14 +12,14 @@ import pufferlib.postprocess
 def env_creator(name='nmmo'):
     return functools.partial(make, name)
 
-def make(name, *args, **kwargs):
+def make(name, *args, buf=None, **kwargs):
     '''Neural MMO creation function'''
     nmmo = pufferlib.environments.try_import('nmmo')
     env = nmmo.Env(*args, **kwargs)
     env = NMMOWrapper(env)
     env = pufferlib.postprocess.MultiagentEpisodeStats(env)
     env = pufferlib.postprocess.MeanOverAgents(env)
-    return pufferlib.emulation.PettingZooPufferEnv(env=env)
+    return pufferlib.emulation.PettingZooPufferEnv(env=env, buf=buf)
 
 class NMMOWrapper(pufferlib.postprocess.PettingZooWrapper):
     '''Remove task spam'''

--- a/pufferlib/environments/open_spiel/environment.py
+++ b/pufferlib/environments/open_spiel/environment.py
@@ -17,7 +17,8 @@ def make(
         multiplayer=False,
         n_rollouts=5,
         max_simulations=10,
-        min_simulations=None
+        min_simulations=None,
+        buf=None
     ):
     '''OpenSpiel creation function'''
     pyspiel = pufferlib.environments.try_import('pyspiel', 'open_spiel')
@@ -50,5 +51,6 @@ def make(
     return wrapper_cls(
         env=env,
         postprocessor_cls=pufferlib.emulation.BasicPostprocessor,
+        buf=buf,
     )
 

--- a/pufferlib/environments/pokemon_red/environment.py
+++ b/pufferlib/environments/pokemon_red/environment.py
@@ -12,12 +12,12 @@ import pufferlib.postprocess
 def env_creator(name='pokemon_red'):
     return functools.partial(make, name)
 
-def make(name, headless: bool = True, state_path=None):
+def make(name, headless: bool = True, state_path=None, buf=None):
     '''Pokemon Red'''
     env = Environment(headless=headless, state_path=state_path)
     env = RenderWrapper(env)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
 class RenderWrapper(gymnasium.Wrapper):
     def __init__(self, env):

--- a/pufferlib/environments/procgen/environment.py
+++ b/pufferlib/environments/procgen/environment.py
@@ -18,8 +18,8 @@ from stable_baselines3.common.atari_wrappers import (
 def env_creator(name='bigfish'):
     return functools.partial(make, name)
 
-def make(name, num_envs=1, num_levels=0,
-        start_level=0, distribution_mode='easy', render_mode=None):
+def make(name, num_envs=1, num_levels=0, start_level=0,
+        distribution_mode='easy', render_mode=None, buf=None):
     '''Atari creation function with default CleanRL preprocessing based on Stable Baselines3 wrappers'''
     assert int(num_envs) == float(num_envs), "num_envs must be an integer"
     num_envs = int(num_envs)
@@ -47,7 +47,7 @@ def make(name, num_envs=1, num_levels=0,
     #envs = gymnasium.wrappers.FrameStack(envs, 4)#, framestack)
     #envs = MaxAndSkipEnv(envs, skip=2)
     envs = pufferlib.postprocess.EpisodeStats(envs)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=envs)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=envs, buf=buf)
 
 class ProcgenWrapper:
     def __init__(self, env):

--- a/pufferlib/environments/slimevolley/environment.py
+++ b/pufferlib/environments/slimevolley/environment.py
@@ -15,7 +15,7 @@ import pufferlib.postprocess
 def env_creator(name='SlimeVolley-v0'):
     return functools.partial(make, name)
 
-def make(name, render_mode='rgb_array'):
+def make(name, render_mode='rgb_array', buf=None):
     if name == 'slimevolley':
         name = 'SlimeVolley-v0'
 
@@ -27,7 +27,7 @@ def make(name, render_mode='rgb_array'):
     env = SkipWrapper(env, repeat_count=4)
     env = shimmy.GymV21CompatibilityV0(env=env)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
 class SlimeVolleyMultiDiscrete(gym.Wrapper):
     def __init__(self, env):

--- a/pufferlib/environments/smac/environment.py
+++ b/pufferlib/environments/smac/environment.py
@@ -9,7 +9,7 @@ import pufferlib.wrappers
 def env_creator(name='smac'):
     return functools.partial(make, name)
 
-def make(name):
+def make(name, buf=None):
     '''Starcraft Multiagent Challenge creation function
 
     Support for SMAC is WIP because environments do not function without
@@ -19,5 +19,5 @@ def make(name):
 
     env = smac_env(1000)
     env = pufferlib.wrappers.PettingZooTruncatedWrapper(env)
-    env = pufferlib.emulation.PettingZooPufferEnv(env)
+    env = pufferlib.emulation.PettingZooPufferEnv(env, buf=buf)
     return env

--- a/pufferlib/environments/stable_retro/environment.py
+++ b/pufferlib/environments/stable_retro/environment.py
@@ -12,7 +12,7 @@ import pufferlib.environments
 def env_creator(name='Airstriker-Genesis'):
     return functools.partial(make, name)
 
-def make(name='Airstriker-Genesis', framestack=4):
+def make(name='Airstriker-Genesis', framestack=4, buf=None):
     '''Atari creation function with default CleanRL preprocessing based on Stable Baselines3 wrappers'''
     retro = pufferlib.environments.try_import('retro', 'stable-retro')
 
@@ -32,7 +32,7 @@ def make(name='Airstriker-Genesis', framestack=4):
     env = gym.wrappers.GrayScaleObservation(env)
     env = gym.wrappers.FrameStack(env, framestack)
     return pufferlib.emulation.GymnasiumPufferEnv(
-        env=env, postprocessor_cls=AtariFeaturizer)
+        env=env, postprocessor_cls=AtariFeaturizer, buf=buf)
 
 class AtariFeaturizer(pufferlib.emulation.Postprocessor):
     def reset(self, obs):

--- a/pufferlib/environments/vizdoom/environment.py
+++ b/pufferlib/environments/vizdoom/environment.py
@@ -14,7 +14,7 @@ import pufferlib.postprocess
 def env_creator(name='doom'):
     return functools.partial(make, name)
 
-def make(name, framestack=1, render_mode='rgb_array'):
+def make(name, framestack=1, render_mode='rgb_array', buf=None):
     '''Atari creation function with default CleanRL preprocessing based on Stable Baselines3 wrappers'''
     if name == 'doom':
         name = 'VizdoomHealthGatheringSupreme-v0'
@@ -44,7 +44,7 @@ def make(name, framestack=1, render_mode='rgb_array'):
     #env = ClipRewardEnv(env)
     #env = gym.wrappers.GrayScaleObservation(env)
     #env = gym.wrappers.FrameStack(env, framestack)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
 class DoomWrapper(gym.Wrapper):
     '''Gymnasium env does not expose proper options for screen scale and

--- a/pufferlib/ocean/environment.py
+++ b/pufferlib/ocean/environment.py
@@ -3,6 +3,7 @@ import pufferlib.postprocess
 
 from .snake.snake import Snake
 from .squared.squared import Squared
+from .squared.pysquared import PySquared
 from .pong.pong import Pong
 from .breakout.breakout import Breakout
 from .enduro.enduro import Enduro
@@ -129,6 +130,7 @@ MAKE_FNS = {
     'nmmo3': NMMO3,
     'snake': Snake,
     'squared': Squared,
+    'pysquared': PySquared,
     'connect4': Connect4,
     'tripletriad': TripleTriad,
     'tactical': Tactical,

--- a/pufferlib/ocean/environment.py
+++ b/pufferlib/ocean/environment.py
@@ -58,68 +58,68 @@ def make_puffergrid(render_mode='rgb_array', vision_range=3):
     from .grid import grid
     return grid.PufferGrid(render_mode, vision_range)
 
-def make_continuous(discretize=False, **kwargs):
+def make_continuous(discretize=False, buf=None, **kwargs):
     from . import sanity
     env = sanity.Continuous(discretize=discretize)
     if not discretize:
         env = pufferlib.postprocess.ClipAction(env)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
-def make_squared(distance_to_target=3, num_targets=1, **kwargs):
+def make_squared(distance_to_target=3, num_targets=1, buf=None, **kwargs):
     from . import sanity
     env = sanity.Squared(distance_to_target=distance_to_target, num_targets=num_targets, **kwargs)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env, **kwargs)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf, **kwargs)
 
-def make_bandit(num_actions=10, reward_scale=1, reward_noise=1):
+def make_bandit(num_actions=10, reward_scale=1, reward_noise=1, buf=None):
     from . import sanity
     env = sanity.Bandit(num_actions=num_actions, reward_scale=reward_scale,
         reward_noise=reward_noise)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
-def make_memory(mem_length=2, mem_delay=2, **kwargs):
+def make_memory(mem_length=2, mem_delay=2, buf=None, **kwargs):
     from . import sanity
     env = sanity.Memory(mem_length=mem_length, mem_delay=mem_delay)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
-def make_password(password_length=5, **kwargs):
+def make_password(password_length=5, buf=None, **kwargs):
     from . import sanity
     env = sanity.Password(password_length=password_length)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
-def make_performance(delay_mean=0, delay_std=0, bandwidth=1, **kwargs):
+def make_performance(delay_mean=0, delay_std=0, bandwidth=1, buf=None, **kwargs):
     from . import sanity
     env = sanity.Performance(delay_mean=delay_mean, delay_std=delay_std, bandwidth=bandwidth)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
-def make_performance_empiric(count_n=0, count_std=0, bandwidth=1, **kwargs):
+def make_performance_empiric(count_n=0, count_std=0, bandwidth=1, buf=None, **kwargs):
     from . import sanity
     env = sanity.PerformanceEmpiric(count_n=count_n, count_std=count_std, bandwidth=bandwidth)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
-def make_stochastic(p=0.7, horizon=100, **kwargs):
+def make_stochastic(p=0.7, horizon=100, buf=None, **kwargs):
     from . import sanity
     env = sanity.Stochastic(p=p, horizon=100)
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
-def make_spaces(**kwargs):
+def make_spaces(buf=None, **kwargs):
     from . import sanity
     env = sanity.Spaces()
     env = pufferlib.postprocess.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env, **kwargs)
+    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf, **kwargs)
 
-def make_multiagent(**kwargs):
+def make_multiagent(buf=None, **kwargs):
     from . import sanity
     env = sanity.Multiagent()
     env = pufferlib.postprocess.MultiagentEpisodeStats(env)
-    return pufferlib.emulation.PettingZooPufferEnv(env=env)
+    return pufferlib.emulation.PettingZooPufferEnv(env=env, buf=buf)
 
 MAKE_FNS = {
     'breakout': Breakout,

--- a/pufferlib/ocean/sanity.py
+++ b/pufferlib/ocean/sanity.py
@@ -370,7 +370,7 @@ class Spaces(gymnasium.Env):
             'image': gymnasium.spaces.Box(
                 low=0, high=1, shape=(5, 5), dtype=np.float32),
             'flat': gymnasium.spaces.Box(
-                low=0, high=1, shape=(5,), dtype=np.int8),
+                low=-1, high=1, shape=(5,), dtype=np.int8),
         })
         self.action_space = gymnasium.spaces.Dict({
             'image': gymnasium.spaces.Discrete(2),
@@ -380,7 +380,7 @@ class Spaces(gymnasium.Env):
 
     def reset(self, seed=None):
         self.observation = {
-            'image': np.random.randn(5, 5).astype(np.float32),
+            'image': np.random.rand(5, 5).astype(np.float32),
             'flat': np.random.randint(-1, 2, (5,), dtype=np.int8),
         }
         self.image_sign = np.sum(self.observation['image']) > 0

--- a/pufferlib/ocean/squared/pysquared.py
+++ b/pufferlib/ocean/squared/pysquared.py
@@ -1,0 +1,98 @@
+'''A simple sample environment. Use this as a template for your own envs.'''
+
+import gymnasium
+import numpy as np
+
+import pufferlib
+from pufferlib.ocean.squared.cy_squared import CySquared
+
+NOOP = 0
+DOWN = 1
+UP = 2
+LEFT = 3
+RIGHT = 4
+
+EMPTY = 0
+AGENT = 1
+TARGET = 2
+
+class PySquared(pufferlib.PufferEnv):
+    def __init__(self, num_envs=1, render_mode='ansi', size=11, buf=None):
+        self.single_observation_space = gymnasium.spaces.Box(low=0, high=1,
+            shape=(size*size,), dtype=np.uint8)
+        self.single_action_space = gymnasium.spaces.Discrete(5)
+        self.render_mode = render_mode
+        self.num_agents = 1
+
+        super().__init__(buf)
+        self.size = size
+
+    def reset(self, seed=None):
+        self.observations[0, :] = EMPTY
+        self.observations[0, self.size*self.size//2] = AGENT
+        self.r = self.size//2
+        self.c = self.size//2
+        self.tick = 0
+        while True:
+            target_r, target_c = np.random.randint(0, self.size, 2)
+            if target_r != self.r or target_c != self.c:
+                self.observations[0, target_r*self.size + target_c] = TARGET
+                break
+
+        return self.observations, []
+
+    def step(self, actions):
+        atn = actions[0]
+        self.terminals[0] = False
+        self.rewards[0] = 0
+
+        self.observations[0, self.r*self.size + self.c] = EMPTY
+
+        if atn == DOWN:
+            self.r += 1
+        elif atn == RIGHT:
+            self.c += 1
+        elif atn == UP:
+            self.r -= 1
+        elif atn == LEFT:
+            self.c -= 1
+
+        info = []
+        pos = self.r*self.size + self.c
+        if (self.tick > 3*self.size
+                or self.r < 0
+                or self.c < 0
+                or self.r >= self.size
+                or self.c >= self.size):
+            self.terminals[0] = True
+            self.rewards[0] = -1.0
+            info = {'reward': -1.0}
+            self.reset()
+        elif self.observations[0, pos] == TARGET:
+            self.terminals[0] = True
+            self.rewards[0] = 1.0
+            info = {'reward': 1.0}
+            self.reset()
+        else:
+            self.observations[0, pos] = AGENT
+            self.tick += 1
+
+        return self.observations, self.rewards, self.terminals, self.truncations, info
+
+    def render(self):
+        chars = []
+        grid = self.observations.reshape(self.size, self.size)
+        for row in grid:
+            for val in row:
+                if val == AGENT:
+                    color = 94
+                elif val == TARGET:
+                    color = 91
+                else:
+                    color = 90
+                chars.append(f'\033[{color}m██\033[0m')
+            chars.append('\n')
+        return ''.join(chars)
+
+    def close(self):
+        pass


### PR DESCRIPTION
Lets you prototype native PufferEnvs in Python or C without having to do your own vectorization. It will still be faster if you keep that inner loop in C, but this is good for quick tests and new users