### PR TITLE
PZ observation space/emulation (Box) fix

### DIFF
--- a/pufferlib/emulation.py
+++ b/pufferlib/emulation.py
@@ -256,7 +256,7 @@ class PettingZooPufferEnv:
         self.num_agents = len(self.possible_agents)
 
         set_buffers(self, buf)
-        if isinstance(self.env.observation_space, pufferlib.spaces.Box):
+        if isinstance(self.env_single_observation_space, pufferlib.spaces.Box):
             self.obs_struct = self.observations
         else:
             self.obs_struct = self.observations.view(self.obs_dtype)


### PR DESCRIPTION
Previous check was made with a gymansium logic, and not for a PZ dictionary observation. Reassigned it to the single agent observation space as defined - 

line 243:
self.env_single_observation_space = self.env.observation_space(single_agent)

