### PR TITLE
Make infos length consistent

### DIFF
--- a/pufferlib/vector.py
+++ b/pufferlib/vector.py
@@ -128,7 +128,6 @@ class Serial:
             else:
                 o, r, d, t, i = env.step(atns)
 
-            if i:
                 if isinstance(i, list):
                     self.infos.extend(i)
                 else:
@@ -388,9 +387,8 @@ class Multiprocessing:
 
         infos = []
         for i in s_range:
-            if self.infos[i]:
-                infos.extend(self.infos[i])
-                self.infos[i] = []
+            infos.extend(self.infos[i])
+            self.infos[i] = []
 
         agent_ids = self.agent_ids[w_slice].ravel()
         m = buf.masks[w_slice].ravel()

--- a/pufferlib/vector.py
+++ b/pufferlib/vector.py
@@ -128,10 +128,10 @@ class Serial:
             else:
                 o, r, d, t, i = env.step(atns)
 
-                if isinstance(i, list):
-                    self.infos.extend(i)
-                else:
-                    self.infos.append(i)
+            if isinstance(i, list):
+                self.infos.extend(i)
+            else:
+                self.infos.append(i)
 
             ptr = end
 


### PR DESCRIPTION
The current vector environments will not send infos that are empty ({} or []). If the environment ever returns {} for infos they will not be added to the infos list, causing it to have fewer elements and making it  impossible to determine which environment each info dictionary belongs to. You're likely to run into this issue if you use infos to send crucial training information that isn't available during reset, or while debugging an environment that uses infos.

This PR removes the checks that prevent empty infos from being sent. I'm not sure what issue they were originally supposed to prevent, but I think it is good practice to have the infos length always equal the number of environments.