### PR TITLE
cartpole pr

### DIFF
--- a/config/ocean/cartpole.ini
+++ b/config/ocean/cartpole.ini
@@ -1,0 +1,88 @@
+[base]
+package = ocean
+env_name = puffer_cartpole
+vec = native
+policy_name = Policy
+rnn_name = Recurrent
+
+[env]
+num_envs = 512
+
+[train]
+anneal_lr = True
+batch_size = 16384
+bptt_horizon = 8
+checkpoint_interval = 50
+clip_coef = 0.2
+clip_vloss = True
+compile = False
+compile_mode = reduce-overhead
+cpu_offload = False
+data_dir = experiments
+device = cuda
+ent_coef = 0.00003900277311898606
+env_batch_size = 1
+gae_lambda = 0.8175218896853491
+gamma = 0.95
+learning_rate = 0.00025
+max_grad_norm = 1.877352899116142
+minibatch_size = 256
+norm_adv = True
+num_envs = 1
+num_workers = 1
+seed = 1
+torch_deterministic = True
+total_timesteps = 13000000
+update_epochs = 1
+vf_clip_coef = 0.2
+vf_coef = 0.9341430639021528
+zero_copy = True
+optimizer = adam
+
+[sweep]
+method = protein
+name = sweep
+
+[sweep.metric]
+goal = maximize
+name = episode_length
+min = 0
+max = 205
+
+[sweep.train.total_timesteps]
+distribution = log_normal
+min = 1e6
+max = 1e7
+mean = 5e6
+scale = 0.5
+
+[sweep.train.gamma]
+distribution = log_normal
+min = 0.9
+max = 0.999
+mean = 0.97
+
+[sweep.train.gae_lambda]
+distribution = log_normal
+min = 0.7
+max = 0.999
+mean = 0.95
+
+[sweep.train.learning_rate]
+distribution = log_normal
+min = 0.0001
+max = 0.001
+mean = 0.00025
+scale = 0.5
+
+[sweep.train.batch_size]
+min = 32768
+max = 131072
+mean = 65536
+scale = 0.5
+
+[sweep.train.minibatch_size]
+min = 512
+max = 2048
+mean = 1024
+scale = 0.5

--- a/pufferlib/ocean/cartpole/cartpole.c
+++ b/pufferlib/ocean/cartpole/cartpole.c
@@ -1,0 +1,89 @@
+// local compile/eval not implemented
+// eval with python demo.py --mode eval --env puffer_cartpole --eval-mode-path <path to model>
+
+#include <math.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <time.h>
+#include "cartpole.h"
+#include "puffernet.h"
+
+#define NUM_WEIGHTS 133123
+#define OBSERVATIONS_SIZE 4
+#define ACTIONS_SIZE 2
+#define CONTINUOUS 1
+const char* WEIGHTS_PATH = "/puffertank/pufferlib/pufferlib/resources/cartpole/cartpole_weights.bin";
+
+float movement(int discrete_action, int userControlMode) {
+    if (userControlMode) {
+        return (IsKeyDown(KEY_RIGHT) || IsKeyDown(KEY_D)) ? 1.0f : -1.0f;
+    } else {
+        return (discrete_action == 1) ? 1.0f : -1.0f;
+    }
+}
+
+void demo() {
+    Weights* weights = load_weights(WEIGHTS_PATH, NUM_WEIGHTS);
+    LinearLSTM* net;
+    
+    if (CONTINUOUS) {
+        net = make_linearlstm_float(weights, 1, OBSERVATIONS_SIZE, ACTIONS_SIZE, ACTION_TYPE_FLOAT);
+    } else {
+        net = make_linearlstm(weights, 1, OBSERVATIONS_SIZE, ACTIONS_SIZE, ACTION_TYPE_INT);
+    }
+
+    CartPole env = {0};
+    env.continuous = CONTINUOUS;
+    allocate(&env);
+    Client* client = make_client(&env);
+    c_reset(&env);
+
+    SetTargetFPS(60);
+    int episode_steps = 0;
+    float episode_return = 0.0f;
+
+    while (!WindowShouldClose()) {
+        int userControlMode = IsKeyDown(KEY_LEFT_SHIFT);
+
+        if (!userControlMode) {
+            if (CONTINUOUS) {
+                forward_linearlstm_float(net, env.observations, env.actions);
+                env.actions[0] = tanhf(env.actions[0]);
+            } else {
+                int action_value;
+                forward_linearlstm_int(net, env.observations, &action_value);
+                env.actions[0] = movement(action_value, 0);
+            }
+        } else {
+            env.actions[0] = movement(env.actions[0], userControlMode);
+        }   
+
+        c_step(&env);
+        episode_return += env.rewards[0];
+        episode_steps++;
+
+        BeginDrawing();
+        ClearBackground(RAYWHITE);
+        c_render(client, &env);
+        DrawText("Evaluating policy...", 10, 160, 20, DARKGRAY);
+        EndDrawing();
+
+        if (env.dones[0]) {
+            printf("Episode done. Steps: %d, Return: %.2f\n\n", episode_steps, episode_return);
+            episode_steps = 0;
+            episode_return = 0.0f;
+            c_reset(&env);
+        }
+    }
+
+    free_linearlstm(net);
+    free(weights);
+    close_client(client);
+    free_allocated(&env);
+}
+
+int main() {
+    srand(time(NULL));
+    demo();
+    return 0;
+}

--- a/pufferlib/ocean/cartpole/cartpole.h
+++ b/pufferlib/ocean/cartpole/cartpole.h
@@ -1,0 +1,244 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <math.h>
+#include <time.h>
+#include "raylib.h"
+
+#define GRAVITY 9.8f
+#define MASSCART 1.0f
+#define MASSPOLE 0.1f
+#define TOTAL_MASS (MASSPOLE + MASSCART)
+#define LENGTH 0.5f // half pole length
+#define POLEMASS_LENGTH (MASSPOLE * LENGTH)
+#define FORCE_MAG 10.0f
+#define TAU 0.02f // timestep duration
+
+#define X_THRESHOLD 2.4f
+#define THETA_THRESHOLD_RADIANS (12 * 2 * M_PI / 360)
+#define MAX_STEPS 200
+#define WIDTH 600
+#define HEIGHT 800
+#define SCALE 100 // scaling for rendering
+
+typedef struct Log {
+    float episode_return;
+    float episode_length;
+    int x_threshold_termination;
+    int pole_angle_termination;
+    int max_steps_termination;
+} Log;
+
+typedef struct LogBuffer {
+    Log* logs;
+    int length;
+    int idx;
+} LogBuffer;
+
+LogBuffer* allocate_logbuffer(int size) {
+    LogBuffer* logs = (LogBuffer*)calloc(1, sizeof(LogBuffer));
+    logs->logs = (Log*)calloc(size, sizeof(Log));
+    logs->length = size;
+    logs->idx = 0;
+    return logs;
+}
+
+void free_logbuffer(LogBuffer* buffer) {
+    if (buffer) {
+        free(buffer->logs);
+        free(buffer);
+    }
+}
+
+void add_log(LogBuffer* logs, Log* log) {
+    if (logs->idx == logs->length) {
+        return;
+    }
+    logs->logs[logs->idx] = *log;
+    logs->idx++;
+}
+
+Log aggregate_and_clear(LogBuffer* logs) {
+    Log log = {0};
+    if (logs->idx == 0) {
+        return log;
+    }
+    for (int i = 0; i < logs->idx; i++) {
+        log.episode_return += logs->logs[i].episode_return;
+        log.episode_length += logs->logs[i].episode_length;
+        log.x_threshold_termination += logs->logs[i].x_threshold_termination;
+        log.pole_angle_termination += logs->logs[i].pole_angle_termination;
+        log.max_steps_termination += logs->logs[i].max_steps_termination;
+    }
+    log.episode_return /= logs->idx;
+    log.episode_length /= logs->idx;
+    log.x_threshold_termination /= logs->idx;
+    log.pole_angle_termination /= logs->idx;
+    log.max_steps_termination /= logs->idx;
+    logs->idx = 0;
+    return log;
+}
+
+typedef struct CartPole {
+    float* observations;      // [x, x_dot, theta, theta_dot]
+    float* actions;             // float for cont support. action: 0 (L) or 1 (R)
+    float* rewards;
+    unsigned char* dones;
+    LogBuffer* log_buffer;
+    Log log;
+
+    // Environment state variables
+    float x;         // cart position
+    float x_dot;     // cart velocity
+    float theta;     // pole angle
+    float theta_dot; // pole angular velocity
+
+    int steps_beyond_done;  // -1 means not done yet, 0 means just done, >0 means stepping after done
+    int steps;              // step counter for current episode
+
+    // Control parameters
+    int continuous; // set in cartpole.py
+} CartPole;
+
+typedef struct Client {
+} Client;
+
+void init(CartPole* env) {
+    env->steps = 0;
+    env->steps_beyond_done = -1;
+    if (!env->log_buffer)
+        env->log_buffer = allocate_logbuffer(1024);
+}
+
+void free_initialized(CartPole* env) {
+    if (env->log_buffer) {
+        free_logbuffer(env->log_buffer);
+        env->log_buffer = NULL;
+    }
+}
+
+void allocate(CartPole* env) {
+    init(env);
+    env->observations = (float*)calloc(4, sizeof(float));
+    env->actions = (float*)calloc(1, sizeof(float));
+    env->rewards = (float*)calloc(1, sizeof(float));
+    env->dones = (unsigned char*)calloc(1, sizeof(unsigned char));
+    if (!env->log_buffer)
+        env->log_buffer = allocate_logbuffer(1024);
+}
+
+void free_allocated(CartPole* env) {
+    free(env->observations);
+    free(env->actions);
+    free(env->rewards);
+    free(env->dones);
+    free_initialized(env);
+}
+
+Client* make_client(CartPole* env) {
+    Client* client = (Client*)calloc(1, sizeof(Client));
+    InitWindow(WIDTH, HEIGHT, "puffer cartpole");
+    SetTargetFPS(60);
+    return client;
+}
+
+void close_client(Client* client) {
+    CloseWindow();
+    free(client);
+}
+
+void c_render(Client* client, CartPole* env) {
+    if (IsKeyDown(KEY_ESCAPE))
+        exit(0);
+    if (IsKeyPressed(KEY_TAB))
+        ToggleFullscreen();
+
+    BeginDrawing();
+    ClearBackground((Color){230, 230, 230, 255});
+
+    // Draw track: a horizontal line through the middle
+    DrawLine(0, HEIGHT / 2, WIDTH, HEIGHT / 2, BLACK);
+
+    // Calculate cart position in pixels (centered)
+    float cart_x = WIDTH / 2 + env->x * SCALE;
+    float cart_y = HEIGHT / 2;
+
+    // Draw cart as a rectangle (40x20)
+    DrawRectangle((int)(cart_x - 20), (int)(cart_y - 10), 40, 20, BLACK);
+
+    // Draw pole as a red line. Pole length = 2 * 0.5 scaled.
+    float pole_length = 2.0f * 0.5f * SCALE;
+    float pole_x2 = cart_x + sinf(env->theta) * pole_length;
+    float pole_y2 = cart_y - cosf(env->theta) * pole_length;
+    DrawLineEx((Vector2){cart_x, cart_y}, (Vector2){pole_x2, pole_y2}, 5, RED);
+
+    // Draw info text
+    DrawText(TextFormat("Steps: %i", env->steps), 10, 10, 20, BLACK);
+    DrawText(TextFormat("Cart Position: %.2f", env->x), 10, 40, 20, BLACK);
+    DrawText(TextFormat("Pole Angle: %.2f", env->theta * 180.0f / M_PI), 10, 70, 20, BLACK);
+
+    EndDrawing();
+}
+
+void compute_observations(CartPole* env) {
+    env->observations[0] = env->x;
+    env->observations[1] = env->x_dot;
+    env->observations[2] = env->theta;
+    env->observations[3] = env->theta_dot;
+}
+
+void c_reset(CartPole* env) {
+    env->x = ((float)rand() / (float)RAND_MAX) * 0.08f - 0.04f;
+    env->x_dot = ((float)rand() / (float)RAND_MAX) * 0.08f - 0.04f;
+    env->theta = ((float)rand() / (float)RAND_MAX) * 0.08f - 0.04f;
+    env->theta_dot = ((float)rand() / (float)RAND_MAX) * 0.08f - 0.04f;
+    env->steps = 0;
+
+    compute_observations(env);
+}
+
+void c_step(CartPole* env) {
+    float force = 0.0;
+    if (env->continuous) {
+        force = env->actions[0] * FORCE_MAG;
+    } else {
+        force = (env->actions[0] > 0.5f) ? FORCE_MAG : -FORCE_MAG; 
+    }
+
+    float costheta = cosf(env->theta);
+    float sintheta = sinf(env->theta);
+
+    float temp = (force + POLEMASS_LENGTH * env->theta_dot * env->theta_dot * sintheta) / TOTAL_MASS;
+    float thetaacc = (GRAVITY * sintheta - costheta * temp) / 
+                     (LENGTH * (4.0f / 3.0f - MASSPOLE * costheta * costheta / TOTAL_MASS));
+    float xacc = temp - POLEMASS_LENGTH * thetaacc * costheta / TOTAL_MASS;
+
+    env->x += TAU * env->x_dot;
+    env->x_dot += TAU * xacc;
+    env->theta += TAU * env->theta_dot;
+    env->theta_dot += TAU * thetaacc;
+
+    bool done = env->x < -X_THRESHOLD || env->x > X_THRESHOLD ||
+                env->theta < -THETA_THRESHOLD_RADIANS || env->theta > THETA_THRESHOLD_RADIANS ||
+                env->steps >= MAX_STEPS;
+
+    env->rewards[0] = done ? 0.0f : 1.0f;
+    env->dones[0] = done ? 1 : 0;
+
+    env->steps += 1;
+
+    if (done) {
+        env->log.episode_return += env->steps;
+        env->log.episode_length = env->steps;
+        env->log.x_threshold_termination += (env->x < -X_THRESHOLD || env->x > X_THRESHOLD);
+        env->log.pole_angle_termination += (env->theta < -THETA_THRESHOLD_RADIANS || env->theta > THETA_THRESHOLD_RADIANS);
+        env->log.max_steps_termination += (env->steps >= MAX_STEPS);
+
+        add_log(env->log_buffer, &env->log);
+        c_reset(env);
+        memset(&env->log, 0, sizeof(Log));
+    }
+
+    compute_observations(env);
+}

--- a/pufferlib/ocean/cartpole/cartpole.py
+++ b/pufferlib/ocean/cartpole/cartpole.py
@@ -1,0 +1,96 @@
+import numpy as np
+import gymnasium
+import pufferlib
+from pufferlib.ocean.cartpole.cy_cartpole import CyCartPole
+
+class Cartpole(pufferlib.PufferEnv):
+    def __init__(self, num_envs=1, render_mode='human', report_interval=1, continuous=False, buf=None):
+        self.render_mode = render_mode
+        self.num_agents = num_envs
+        self.report_interval = report_interval
+        self.tick = 0
+        self.is_continuous = continuous
+
+        self.num_obs = 4
+        self.single_observation_space = gymnasium.spaces.Box(
+            low=-np.inf, high=np.inf, shape=(self.num_obs,), dtype=np.float32
+        )
+        if self.is_continuous:
+            self.single_action_space = gymnasium.spaces.Box(
+                low=-1.0, high=1.0, shape=(1,), dtype=np.float32
+            )
+        else:
+            self.single_action_space = gymnasium.spaces.Discrete(2)
+
+        super().__init__(buf=buf)
+        
+        self.actions = np.zeros(self.num_agents, dtype=np.float32)
+        self.terminals = np.zeros(self.num_agents, dtype=np.uint8)
+        self.truncations = np.zeros(self.num_agents, dtype=np.uint8)
+
+        self.c_envs = CyCartPole(
+            self.observations,
+            self.actions,
+            self.rewards,
+            self.terminals,
+            num_envs,
+            int(self.is_continuous),
+        )
+   
+    def reset(self, seed=None):
+        self.tick = 0
+        self.c_envs.reset()
+        return self.observations, []
+   
+    def step(self, actions):
+        if self.is_continuous:
+            self.actions[:] = np.clip(actions.flatten(), -1.0, 1.0)
+        else:
+            self.actions[:] = actions
+            
+        self.c_envs.step()
+        info = []
+        if self.tick % self.report_interval == 0:
+            log = self.c_envs.log()
+            if log['episode_length'] > 0:
+                info.append(log)
+        self.tick += 1
+        
+        return (
+            self.observations,
+            self.rewards,
+            self.terminals,
+            self.truncations,
+            info
+        )
+   
+    def render(self):
+        if self.render_mode == 'human':
+            self.c_envs.render()
+   
+    def close(self):
+        self.c_envs.close()
+
+def test_performance(timeout=10, atn_cache=8192, is_continuous=True):
+    """Benchmark environment performance."""
+    num_envs = 4096
+    env = Cartpole(num_envs=num_envs, continuous=is_continuous)
+    env.reset()
+    tick = 0
+
+    if env.is_continuous:
+        actions = np.random.uniform(-1, 1, (atn_cache, num_envs, 1)).astype(np.float32)
+    else:
+        actions = np.random.randint(0, env.single_action_space.n, (atn_cache, num_envs)).astype(np.int8)
+
+    import time
+    start = time.time()
+    while time.time() - start < timeout:
+        atn = actions[tick % atn_cache]
+        env.step(atn)
+        tick += 1
+    sps = num_envs * tick / (time.time() - start)
+    print(f'SPS: {sps:,}')
+
+if __name__ == '__main__':
+    test_performance()

--- a/pufferlib/ocean/cartpole/cy_cartpole.pyx
+++ b/pufferlib/ocean/cartpole/cy_cartpole.pyx
@@ -1,0 +1,104 @@
+from libc.stdlib cimport calloc, free
+
+cdef extern from "cartpole.h":
+    ctypedef struct Log:
+        float episode_return
+        float episode_length
+        int x_threshold_termination
+        int pole_angle_termination
+        int max_steps_termination
+
+    ctypedef struct LogBuffer:
+        Log* logs
+        int length
+        int idx
+
+    LogBuffer* allocate_logbuffer(int)
+    void free_logbuffer(LogBuffer*)
+    Log aggregate_and_clear(LogBuffer*)
+
+    ctypedef struct CartPole:
+        float* observations
+        float* actions
+        float* rewards
+        unsigned char* dones
+        LogBuffer* log_buffer
+        Log log
+        float x
+        float x_dot
+        float theta
+        float theta_dot
+        int steps_beyond_done
+        int steps
+        int continuous
+
+    ctypedef struct Client
+
+    void init(CartPole* env)
+    void free_initialized(CartPole* env)
+    void allocate(CartPole* env)
+    void free_allocated(CartPole* env)
+    Client* make_client(CartPole* env)
+    void close_client(Client* client)
+    void c_render(Client* client, CartPole* env)
+    void c_reset(CartPole* env)
+    void c_step(CartPole* env)
+
+cdef class CyCartPole:
+    cdef:
+        Client* client
+        CartPole* envs
+        LogBuffer* logs
+        int num_envs
+
+    def __init__(self, float[:, :] observations, float[:] actions, float[:] rewards,
+                 unsigned char[:] dones, int num_envs, int continuous=0):
+        self.num_envs = num_envs
+        self.envs = <CartPole*> calloc(num_envs, sizeof(CartPole))
+        self.logs = allocate_logbuffer(1024)
+        self.client = NULL
+
+        cdef int i
+        for i in range(num_envs):
+            self.envs[i].observations = &observations[i, 0]
+            self.envs[i].actions = &actions[i]
+            self.envs[i].rewards = &rewards[i]
+            self.envs[i].dones = &dones[i]
+            self.envs[i].log_buffer = self.logs
+            self.envs[i].continuous = continuous
+            init(&self.envs[i])
+
+    def reset(self):
+        cdef int i
+        for i in range(self.num_envs):
+            c_reset(&self.envs[i])
+
+    def step(self):
+        cdef int i
+        for i in range(self.num_envs):
+            c_step(&self.envs[i])
+
+    def render(self):
+        cdef CartPole* env = &self.envs[0]
+        if self.client == NULL:
+            import os
+            cwd = os.getcwd()
+            os.chdir(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+            self.client = make_client(env)
+            os.chdir(cwd)
+        c_render(self.client, env)
+
+    def close(self):
+        if self.client != NULL:
+            close_client(self.client)
+            self.client = NULL
+        if self.envs != NULL:
+            free(self.envs)
+            self.envs = NULL
+        if self.logs != NULL:
+            free_logbuffer(self.logs)
+            self.logs = NULL
+
+    def log(self):
+        cdef Log log = aggregate_and_clear(self.logs)
+        return log

--- a/pufferlib/ocean/environment.py
+++ b/pufferlib/ocean/environment.py
@@ -121,6 +121,7 @@ MAKE_FNS = {
     'blastar':       lambda: lazy_import('pufferlib.ocean.blastar.blastar', 'Blastar'),
     'pong':          lambda: lazy_import('pufferlib.ocean.pong.pong', 'Pong'),
     'enduro':        lambda: lazy_import('pufferlib.ocean.enduro.enduro', 'Enduro'),
+    'cartpole':      lambda: lazy_import('pufferlib.ocean.cartpole.cartpole', 'Cartpole'),
     'moba':          lambda: lazy_import('pufferlib.ocean.moba.moba', 'Moba'),
     'nmmo3':         lambda: lazy_import('pufferlib.ocean.nmmo3.nmmo3', 'NMMO3'),
     'snake':         lambda: lazy_import('pufferlib.ocean.snake.snake', 'Snake'),

--- a/setup.py
+++ b/setup.py
@@ -267,6 +267,7 @@ extension_paths = [
     'pufferlib/ocean/snake/cy_snake',
     #'pufferlib/ocean/pong/cy_pong',
     # 'pufferlib/ocean/breakout/cy_breakout',
+    'pufferlib/ocean/cartpole/cy_cartpole',
     'pufferlib/ocean/enduro/cy_enduro',
     'pufferlib/ocean/blastar/cy_blastar',
     'pufferlib/ocean/connect4/cy_connect4',


### PR DESCRIPTION
specify discrete vs continuous in cartpole.py. adam optimizer for compatibility on 2080 SUPER - other optimizers untested. https://wandb.ai/xinpw8/pufferlib/runs/ndtvr7vi - continuous; https://wandb.ai/xinpw8/pufferlib/runs/gi1j07l7 - discrete. eval with python demo.py --mode eval --env puffer_cartpole --eval-mode-path <path to model> as local compile is not implemented w/ pufferlib for continuous.