### PR TITLE
Else block fails because slice is unhashable type

### DIFF
--- a/clean_pufferl.py
+++ b/clean_pufferl.py
@@ -113,9 +113,16 @@ def create(config, vecenv, policy, optimizer=None, wandb=None, neptune=None):
     # TODO: This breaks compile
     if isinstance(policy, torch.nn.LSTM):
         assert total_agents > 0
-        shape = (total_agents, policy.hidden_size)
-        lstm_h = torch.zeros(shape).to(config.device)
-        lstm_c = torch.zeros(shape).to(config.device)
+        if config.env_batch_size > 1:
+            shape = (total_agents, policy.hidden_size)
+            lstm_h = torch.zeros(shape).to(config.device)
+            lstm_c = torch.zeros(shape).to(config.device)
+        else:
+            # TODO: Doesn't exist in native envs
+            n = vecenv.agents_per_batch
+            shape = (n, policy.hidden_size)
+            lstm_h = {(i*n, (i+1)*n):torch.zeros(shape).to(config.device) for i in range(total_agents//n)}
+            lstm_c = {(i*n, (i+1)*n):torch.zeros(shape).to(config.device) for i in range(total_agents//n)}
 
     minibatch_size = min(config.minibatch_size, config.max_minibatch_size)
     uncompiled_policy = policy
@@ -256,8 +263,12 @@ def evaluate(data):
         h = None
         c = None
         if lstm_h is not None:
-            h = lstm_h[gpu_env_id]
-            c = lstm_c[gpu_env_id]
+            if config.env_batch_size == 1:
+                h = lstm_h[(gpu_env_id.start, gpu_env_id.stop)]
+                c = lstm_c[(gpu_env_id.start, gpu_env_id.stop)]
+            else:
+                h = lstm_h[gpu_env_id]
+                c = lstm_c[gpu_env_id]
 
         profile('eval_forward', epoch)
         with torch.no_grad():
@@ -280,8 +291,12 @@ def evaluate(data):
         profile('eval_copy', epoch)
         with torch.no_grad():
             if lstm_h is not None:
-                lstm_h[gpu_env_id] = state.lstm_h
-                lstm_c[gpu_env_id] = state.lstm_c
+                if config.env_batch_size == 1:
+                    lstm_h[(gpu_env_id.start, gpu_env_id.stop)] = state.lstm_h
+                    lstm_c[(gpu_env_id.start, gpu_env_id.stop)] = state.lstm_c
+                else:
+                    lstm_h[gpu_env_id] = state.lstm_h
+                    lstm_c[gpu_env_id] = state.lstm_c
 
             o = o if config.cpu_offload else o_device
             actions = store(data, state, o, value, action, logprob, r, d, gpu_env_id, mask)

--- a/clean_pufferl.py
+++ b/clean_pufferl.py
@@ -113,16 +113,9 @@ def create(config, vecenv, policy, optimizer=None, wandb=None, neptune=None):
     # TODO: This breaks compile
     if isinstance(policy, torch.nn.LSTM):
         assert total_agents > 0
-        if config.env_batch_size > 1:
-            shape = (total_agents, policy.hidden_size)
-            lstm_h = torch.zeros(shape).to(config.device)
-            lstm_c = torch.zeros(shape).to(config.device)
-        else:
-            # TODO: Doesn't exist in native envs
-            n = vecenv.agents_per_batch
-            shape = (n, policy.hidden_size)
-            lstm_h = {slice(i*n, (i+1)*n):torch.zeros(shape).to(config.device) for i in range(total_agents//n)}
-            lstm_c = {slice(i*n, (i+1)*n):torch.zeros(shape).to(config.device) for i in range(total_agents//n)}
+        shape = (total_agents, policy.hidden_size)
+        lstm_h = torch.zeros(shape).to(config.device)
+        lstm_c = torch.zeros(shape).to(config.device)
 
     minibatch_size = min(config.minibatch_size, config.max_minibatch_size)
     uncompiled_policy = policy


### PR DESCRIPTION
Hi! I'm just playing with PufferLib and I found an error when running this command: 

`python demo.py --env puffer_snake --mode train --track`

This patch is (maybe) a fix for this, though I naively don't know what's important about the else branch here. The errors I were getting were:

```
│ /home/relh/Code/PufferLib/clean_pufferl.py:124 in <dictcomp>                                     │
│                                                                                                  │
│    121 │   │   │   # TODO: Doesn't exist in native envs                                          │
│    122 │   │   │   n = vecenv.agents_per_batch                                                   │
│    123 │   │   │   shape = (n, policy.hidden_size)                                               │
│ ❱  124 │   │   │   lstm_h = {slice(i*n, (i+1)*n):torch.zeros(shape).to(config.device) for i in   │
│    125 │   │   │   lstm_c = {slice(i*n, (i+1)*n):torch.zeros(shape).to(config.device) for i in   │
│    126 │                                                                                         │
│    127 │   minibatch_size = min(config.minibatch_size, config.max_minibatch_size)                │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: unhashable type: 'slice'
```

I tried changing to a tuple but I get this, so rather than making everything ugly I tried deleting the else branch and now things run again (but unclear on if they work). 

```
│    598 │                                                                                         │
│    599 │   # Fast path for fully vectorized envs                                                 │
│    600 │   if data.config.env_batch_size == 1:                                                   │
│ ❱  601 │   │   l = data.ep_lengths[env_id.start].item()                                          │
│    602 │   │   batch_rows = slice(data.ep_indices[env_id.start].item(), 1+data.ep_indices[env_i  │
│    603 │   else:                                                                                 │
│    604 │   │   l = data.ep_lengths[env_id]                                                       │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'tuple' object has no attribute 'start'
```