### PR TITLE
Update models.py

### DIFF
--- a/pufferlib/models.py
+++ b/pufferlib/models.py
@@ -115,7 +115,8 @@ class LSTMWrapper(nn.Module):
             if "bias" in name:
                 nn.init.constant_(param, 0)
             elif "weight" in name:
-                nn.init.orthogonal_(param, 1.0)
+                if param.ndim >= 2:
+                    nn.init.orthogonal_(param, 1.0)
 
         self.lstm = nn.LSTM(input_size, hidden_size)
 


### PR DESCRIPTION
  File "/home/relh/Code/???/.venv/lib/python3.11/site-packages/pufferlib/models.py", line 144, in __init__
    nn.init.orthogonal_(param, 1.0)
  File "/home/relh/Code/???/.venv/lib/python3.11/site-packages/torch/nn/init.py", line 597, in orthogonal_
    raise ValueError("Only tensors with 2 or more dimensions are supported")
ValueError: Only tensors with 2 or more dimensions are supported

Can we add this check here to avoid this message? For those of us trying weird layers.