### PR TITLE
metta changed their obs space this is the new one

### DIFF
--- a/pufferlib/environments/metta/torch.py
+++ b/pufferlib/environments/metta/torch.py
@@ -17,7 +17,7 @@ class Policy(nn.Module):
 
         self.network= nn.Sequential(
             pufferlib.pytorch.layer_init(
-                nn.Conv2d(34, cnn_channels, 5, stride=3)),
+                nn.Conv2d(26, cnn_channels, 5, stride=3)),
             nn.ReLU(),
             pufferlib.pytorch.layer_init(
                 nn.Conv2d(cnn_channels, cnn_channels, 3, stride=1)),
@@ -28,11 +28,11 @@ class Policy(nn.Module):
         )
 
         self.self_encoder = nn.Sequential(
-            pufferlib.pytorch.layer_init(nn.Linear(34, hidden_size//2)),
+            pufferlib.pytorch.layer_init(nn.Linear(26, hidden_size//2)),
             nn.ReLU(),
         )
 
-        max_vec = torch.tensor([1, 10, 30, 1, 1, 255, 100, 100, 100, 100, 100, 100, 100, 100, 1, 1, 1, 10, 1, 100, 100, 100, 100, 100, 100, 100, 100, 1, 1, 1, 1, 1, 1, 1]).float().view(1, 34, 1, 1)
+        max_vec = torch.tensor([1, 10, 30, 1, 1, 255, 100, 100, 100, 100, 100, 100, 100, 100, 1, 1, 1, 10, 1, 1, 1, 1, 1, 1, 1, 1]).float().view(1, 26, 1, 1)
         self.register_buffer('max_vec', max_vec)
 
         action_nvec = env.single_action_space.nvec


### PR DESCRIPTION
Hi, Metta changed their observation space as per here:

https://github.com/Metta-AI/metta/commit/1af886ae0093c528b0e3e18537db730547115086

I went and checked their obs_norm to get the new updated 26 dimensional feature (instead of 34):

```
> /home/relh/Code/metta/metta/agent/lib/observation_normalizer.py(72)_initialize()
-> self.register_buffer("obs_norm", obs_norm)
(Pdb) obs_norm
tensor([[[[  1.]],

         [[ 10.]],

         [[ 30.]],

         [[  1.]],

         [[  1.]],

         [[255.]],

         [[100.]],

         [[100.]],

         [[100.]],

         [[100.]],

         [[100.]],

         [[100.]],

         [[100.]],

         [[100.]],

         [[  1.]],

         [[  1.]],

         [[  1.]],

         [[ 10.]],

         [[  1.]],

         [[  1.]],

         [[  1.]],

         [[  1.]],

         [[  1.]],

         [[  1.]],

         [[  1.]],

         [[  1.]]]])
```