### PR TITLE
fixes build warnings treated as errors on Mac M1 Pro

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,9 @@ if system == 'Linux':
     download_raylib('raylib-5.5_linux_amd64', '.tar.gz')
 elif system == 'Darwin':
     extra_compile_args += [
+        '-Wno-error=int-conversion',
+        '-Wno-error=incompatible-function-pointer-types',
+        '-Wno-error=implicit-function-declaration',
     ]
     extra_link_args += [
         '-framework', 'Cocoa',


### PR DESCRIPTION
I tried installing PufferLib on an Macbook M1 Pro and clang was treating some of the warnings as errors, so I took the liberty to fix it by making it not treat those warnings as errors. If these changes make sense, feel free to merge right away. 


Also, boids is still giving me reward trouble (even when I tried your version with only the margin rewards turned on, the policy doesn't train well for me). I'm not giving up though, I will try to figure it out by myself as much as I can.