### PR TITLE
Use the default value 0 instead of None for seed in ocean environments 

### DIFF
--- a/pufferlib/ocean/blastar/blastar.py
+++ b/pufferlib/ocean/blastar/blastar.py
@@ -27,7 +27,7 @@ class Blastar(pufferlib.PufferEnv):
             num_obs=self.num_obs
         )
 
-    def reset(self, seed=None):
+    def reset(self, seed=0):
         self.tick = 0
         binding.vec_reset(self.c_envs, seed)
         return self.observations, []

--- a/pufferlib/ocean/cpr/cpr.py
+++ b/pufferlib/ocean/cpr/cpr.py
@@ -56,7 +56,7 @@ class PyCPR(pufferlib.PufferEnv):
 
         self.c_envs = binding.vectorize(*c_envs)
 
-    def reset(self, seed=None):
+    def reset(self, seed=0):
         self.tick = 0
         binding.vec_reset(self.c_envs, seed)
         return self.observations, []

--- a/pufferlib/ocean/drone/drone.py
+++ b/pufferlib/ocean/drone/drone.py
@@ -50,7 +50,7 @@ class Drone(pufferlib.PufferEnv):
 
         self.c_envs = binding.vectorize(*c_envs)
 
-    def reset(self, seed=None):
+    def reset(self, seed=0):
         self.tick = 0
         binding.vec_reset(self.c_envs, seed)
         return self.observations, []

--- a/pufferlib/ocean/enduro/enduro.py
+++ b/pufferlib/ocean/enduro/enduro.py
@@ -37,7 +37,7 @@ class Enduro(pufferlib.PufferEnv):
             frameskip=frameskip, continuous=continuous
         )
 
-    def reset(self, seed=None):
+    def reset(self, seed=0):
         binding.vec_reset(self.c_envs, seed)
         self.tick = 0
         return self.observations, []

--- a/pufferlib/ocean/go/go.py
+++ b/pufferlib/ocean/go/go.py
@@ -49,7 +49,7 @@ class Go(pufferlib.PufferEnv):
             reward_move_valid=reward_move_valid, reward_player_capture=reward_player_capture,
             reward_opponent_capture=reward_opponent_capture)
 
-    def reset(self, seed=None):
+    def reset(self, seed=0):
         binding.vec_reset(self.c_envs, seed)
         self.tick = 0
         return self.observations, []

--- a/pufferlib/ocean/grid/grid.py
+++ b/pufferlib/ocean/grid/grid.py
@@ -26,7 +26,7 @@ class Grid(pufferlib.PufferEnv):
             state=self.c_state, max_size=max_size, num_maps=num_maps)
         pass
 
-    def reset(self, seed=None):
+    def reset(self, seed=0):
         self.tick = 0
         binding.vec_reset(self.c_envs, seed)
         return self.observations, []

--- a/pufferlib/ocean/pacman/pacman.py
+++ b/pufferlib/ocean/pacman/pacman.py
@@ -53,7 +53,7 @@ class Pacman(pufferlib.PufferEnv):
             chase_mode_length = chase_mode_length,
         )
 
-    def reset(self, seed=None):
+    def reset(self, seed=0):
         binding.vec_reset(self.c_envs, seed)
         self.tick = 0
         return self.observations, []

--- a/pufferlib/ocean/terraform/terraform.py
+++ b/pufferlib/ocean/terraform/terraform.py
@@ -39,7 +39,7 @@ class Terraform(pufferlib.PufferEnv):
 
         self.c_envs = binding.vectorize(*c_envs)
  
-    def reset(self, seed=None):
+    def reset(self, seed=0):
         binding.vec_reset(self.c_envs, seed)
         self.tick = 0
         return self.observations, []

--- a/pufferlib/ocean/tower_climb/tower_climb.py
+++ b/pufferlib/ocean/tower_climb/tower_climb.py
@@ -29,7 +29,7 @@ class TowerClimb(pufferlib.PufferEnv):
             reward_fall_row=reward_fall_row, reward_illegal_move=reward_illegal_move,
             reward_move_block=reward_move_block, state=self.c_state)
 
-    def reset(self, seed=None):
+    def reset(self, seed=0):
         binding.vec_reset(self.c_envs, seed)
         self.tick = 0
         return self.observations, []

--- a/pufferlib/ocean/trash_pickup/trash_pickup.py
+++ b/pufferlib/ocean/trash_pickup/trash_pickup.py
@@ -78,7 +78,7 @@ class TrashPickupEnv(pufferlib.PufferEnv):
 
         self.c_envs = binding.vectorize(*c_envs)
 
-    def reset(self, seed=None):
+    def reset(self, seed=0):
         binding.vec_reset(self.c_envs, seed)
         self.tick = 0
         return self.observations, []


### PR DESCRIPTION
In the function `binding.vec_reset` the `seed` argument must an integer. Using the value `None` would result in the error `TypeError: seed must be an integer`. The default values oceans are usually 0 but some are still `None` and aren't handled appropriately. We change the default values for those to be zero as well.