### PR TITLE
fix inadvertent reward assignment in target env

### DIFF
--- a/pufferlib/ocean/target/target.h
+++ b/pufferlib/ocean/target/target.h
@@ -64,6 +64,9 @@ void init(Target* env) {
 }
 
 void update_goals(Target* env) {
+    // Track which goals need to be reset
+    int* goals_to_reset = calloc(env->num_goals, sizeof(int));
+    
     for (int a=0; a<env->num_agents; a++) {
         Agent* agent = &env->agents[a];
         for (int g=0; g<env->num_goals; g++) {
@@ -74,8 +77,8 @@ void update_goals(Target* env) {
             if (dist > 32) {
                 continue;
             }
-            goal->x = rand() % env->width;
-            goal->y = rand() % env->height;
+            // Mark this goal for reset instead of resetting immediately
+            goals_to_reset[g] = 1;
             env->rewards[a] = 1.0f;
             env->log.perf += 1.0f;
             env->log.score += 1.0f;
@@ -85,6 +88,16 @@ void update_goals(Target* env) {
             env->log.n++;
         }
     }
+    
+    // Reset goals after all agents have been checked
+    for (int g=0; g<env->num_goals; g++) {
+        if (goals_to_reset[g]) {
+            env->goals[g].x = rand() % env->width;
+            env->goals[g].y = rand() % env->height;
+        }
+    }
+    
+    free(goals_to_reset);
 }
 
 /* Recommended to have an observation function of some kind because


### PR DESCRIPTION
not sure the original design is a bug but I interpreted it to be


In the update_goals function, a goal could have its position reset prior to all of the agents having been looped through. Therefore, it is plausible that an agent could take a bad action away from all of the targets but still be assigned a reward of +1 because a certain goal had its position reset to be near the agent earlier in the for loop over each agent. 

To fix this:

- I allocate an array of ints of size env->num_goals in which an element will be 1 if that goal needs to be reset.
- In the for loop across agents, if the agent is near the j’th goal, then the j’th element of the array is set to 1 but not reset yet.
- After looping across agents, I use the array of ints to determine which goals need to be reset and then actually go about resetting them. 