### PR TITLE
Make metta work with current PufferLib

### DIFF
--- a/pufferlib/environments/metta/environment.py
+++ b/pufferlib/environments/metta/environment.py
@@ -17,17 +17,11 @@ def env_creator(name='metta'):
 
 def make(name, config='pufferlib/environments/metta/metta.yaml', render_mode='auto', buf=None, seed=0, **kwargs):
     '''Metta creation function'''
-    # Debug: print all kwargs to see what's being passed
-    print(f"DEBUG: make() called with kwargs: {kwargs}")
     
     # Extract expected parameters with defaults
-    ore_reward = kwargs.pop('ore_reward', 0.25)
-    heart_reward = kwargs.pop('heart_reward', 0.5)
-    battery_reward = kwargs.pop('battery_reward', 0.25)
-    
-    # Check if there are any unexpected kwargs
-    if kwargs:
-        print(f"WARNING: Unexpected kwargs passed to make(): {kwargs}")
+    ore_reward = kwargs.pop('ore_reward', 0.17088483842567775)
+    battery_reward = kwargs.pop('battery_reward', 0.9882859711234822)
+    heart_reward = kwargs.pop('heart_reward', 1.0)
     
     OmegaConf.register_new_resolver("div", oc_divide, replace=True)
     cfg = OmegaConf.load(config)

--- a/pufferlib/environments/metta/environment.py
+++ b/pufferlib/environments/metta/environment.py
@@ -15,13 +15,9 @@ from metta.mettagrid.replay_writer import ReplayWriter
 def env_creator(name='metta'):
     return functools.partial(make, name)
 
-def make(name, config='pufferlib/environments/metta/metta.yaml', render_mode='auto', buf=None, seed=0, **kwargs):
+def make(name, config='pufferlib/environments/metta/metta.yaml', render_mode='auto', buf=None, seed=0,
+         ore_reward=0.17088483842567775, battery_reward=0.9882859711234822, heart_reward=1.0):
     '''Metta creation function'''
-    
-    # Extract expected parameters with defaults
-    ore_reward = kwargs.pop('ore_reward', 0.17088483842567775)
-    battery_reward = kwargs.pop('battery_reward', 0.9882859711234822)
-    heart_reward = kwargs.pop('heart_reward', 1.0)
     
     OmegaConf.register_new_resolver("div", oc_divide, replace=True)
     cfg = OmegaConf.load(config)

--- a/pufferlib/environments/metta/environment.py
+++ b/pufferlib/environments/metta/environment.py
@@ -15,12 +15,20 @@ from metta.mettagrid.replay_writer import ReplayWriter
 def env_creator(name='metta'):
     return functools.partial(make, name)
 
-def make(name, config='pufferlib/environments/metta/metta.yaml', render_mode='auto', buf=None, seed=0,
-         ore_reward=0.25, heart_reward=0.5, battery_reward=0.25):
-    '''Crafter creation function'''
-    #return MettaPuff(config, render_mode, buf)
-    #import mettagrid.mettagrid_env
-    #from omegaconf import OmegaConf
+def make(name, config='pufferlib/environments/metta/metta.yaml', render_mode='auto', buf=None, seed=0, **kwargs):
+    '''Metta creation function'''
+    # Debug: print all kwargs to see what's being passed
+    print(f"DEBUG: make() called with kwargs: {kwargs}")
+    
+    # Extract expected parameters with defaults
+    ore_reward = kwargs.pop('ore_reward', 0.25)
+    heart_reward = kwargs.pop('heart_reward', 0.5)
+    battery_reward = kwargs.pop('battery_reward', 0.25)
+    
+    # Check if there are any unexpected kwargs
+    if kwargs:
+        print(f"WARNING: Unexpected kwargs passed to make(): {kwargs}")
+    
     OmegaConf.register_new_resolver("div", oc_divide, replace=True)
     cfg = OmegaConf.load(config)
     

--- a/pufferlib/environments/metta/environment.py
+++ b/pufferlib/environments/metta/environment.py
@@ -23,24 +23,13 @@ def make(name, config='pufferlib/environments/metta/metta.yaml', render_mode='au
     #from omegaconf import OmegaConf
     OmegaConf.register_new_resolver("div", oc_divide, replace=True)
     cfg = OmegaConf.load(config)
-    reward_cfg = cfg['game']['agent']['rewards']
-    '''
-    env_overrides = {
-        'game': {
-            'agent': {
-                'rewards': {
-                    'ore.red': 0.25,
-                    'ore.blue': 0.25,
-                    'ore.green': 0.25,
-                    'heart': 0.5,
-                    'battery': 0.25,
-                }
-            }
-        }
-    '''
-    reward_cfg['ore.red'] = float(ore_reward)
-    reward_cfg['heart'] = float(heart_reward)
-    reward_cfg['battery.red'] = float(battery_reward)
+    
+    # Update rewards under the new structure: agent.rewards.inventory
+    inventory_rewards = cfg['game']['agent']['rewards']['inventory']
+    inventory_rewards['ore_red'] = float(ore_reward)
+    inventory_rewards['heart'] = float(heart_reward)
+    inventory_rewards['battery_red'] = float(battery_reward)
+    
     cfg = SingleTaskCurriculum('puffer', cfg)
     return MettaPuff(cfg, render_mode=render_mode, buf=buf)
 

--- a/pufferlib/environments/metta/metta.yaml
+++ b/pufferlib/environments/metta/metta.yaml
@@ -21,7 +21,7 @@ game:
     - laser
     - blueprint
 
-  num_agents: 512
+  num_agents: 64
   obs_width: 11
   obs_height: 11
   num_observation_tokens: 200
@@ -234,16 +234,16 @@ game:
 
     room:
       _target_: metta.mettagrid.room.random.Random
-      width: 256
-      height: 256
+      width: 64
+      height: 64
       border_width: 0
 
-      agents: 512
+      agents: 64
 
       objects:
-        mine_red: 1024
-        generator_red: 512
-        altar: 256
+        mine_red: 128
+        generator_red: 64
+        altar: 32
         armory: 0
         lasery: 0
         lab: 0

--- a/pufferlib/environments/metta/metta.yaml
+++ b/pufferlib/environments/metta/metta.yaml
@@ -38,7 +38,7 @@ game:
   recipe_details_obs: false
 
   agent:
-    default_resource_limit: 10
+    default_resource_limit: 50
     resource_limits:
       heart: 255
     freeze_duration: 10
@@ -46,26 +46,7 @@ game:
     
     rewards:
       inventory:
-        ore_red: 0.25
-        ore_blue: 0.0
-        ore_green: 0.0
-        ore_red_max: 1000
-        ore_blue_max: 0
-        ore_green_max: 0
-        battery_red: 0.5
-        battery_blue: 0.0
-        battery_green: 0.0
-        battery_red_max: 1000
-        battery_blue_max: 0
-        battery_green_max: 0
-        heart: 1.0
-        heart_max: 1000
-        armor: 0.0
-        armor_max: 0
-        laser: 0.0
-        laser_max: 0
-        blueprint: 0.0
-        blueprint_max: 0
+        heart: 1
       stats: {}
 
   groups:
@@ -74,43 +55,9 @@ game:
       sprite: 0
       props: {}
 
-    team_1:
-      id: 1
-      sprite: 1
-      group_reward_pct: 0.5
-      props: {}
-
-    team_2:
-      id: 2
-      sprite: 4
-      group_reward_pct: 0.5
-      props: {}
-
-    team_3:
-      id: 3
-      sprite: 8
-      group_reward_pct: 0.5
-      props: {}
-
-    team_4:
-      id: 4
-      sprite: 1
-      group_reward_pct: 0.5
-      props: {}
-
-    prey:
-      id: 5
-      sprite: 12
-      props: {}
-
-    predator:
-      id: 6
-      sprite: 6
-      props: {}
-
   objects:
     altar:
-      type_id: 1
+      type_id: 8
       input_resources:
         battery_red: 3
       output_resources:
@@ -120,38 +67,43 @@ game:
       cooldown: 10
       initial_resource_count: 0
 
+    wall:
+      type_id: 1
+      swappable: false
+
+    block:
+      type_id: 14
+      swappable: true
+
     mine_red:
       type_id: 2
       output_resources:
         ore_red: 1
-      input_resources: {}
       color: 0
       max_output: 5
-      conversion_ticks: 50
-      cooldown: 1
-      initial_resource_count: 1
+      conversion_ticks: 1
+      cooldown: 50
+      initial_resource_count: 0
 
     mine_blue:
       type_id: 3
       color: 1
       output_resources:
         ore_blue: 1
-      input_resources: {}
       max_output: 5
       conversion_ticks: 1
-      cooldown: 1
-      initial_resource_count: 1
+      cooldown: 50
+      initial_resource_count: 0
 
     mine_green:
       type_id: 4
       output_resources:
         ore_green: 1
-      input_resources: {}
       color: 2
       max_output: 5
       conversion_ticks: 1
-      cooldown: 1
-      initial_resource_count: 1
+      cooldown: 50
+      initial_resource_count: 0
 
     generator_red:
       type_id: 5
@@ -174,8 +126,8 @@ game:
       color: 1
       max_output: 5
       conversion_ticks: 1
-      cooldown: 1
-      initial_resource_count: 1
+      cooldown: 25
+      initial_resource_count: 0
 
     generator_green:
       type_id: 7
@@ -186,22 +138,22 @@ game:
       color: 2
       max_output: 5
       conversion_ticks: 1
-      cooldown: 1
-      initial_resource_count: 1
+      cooldown: 25
+      initial_resource_count: 0
 
     armory:
-      type_id: 8
+      type_id: 9
       input_resources:
         ore_red: 3
       output_resources:
         armor: 1
       max_output: 5
       conversion_ticks: 1
-      cooldown: 1
-      initial_resource_count: 1
+      cooldown: 10
+      initial_resource_count: 0
 
     lasery:
-      type_id: 9
+      type_id: 10
       input_resources:
         ore_red: 1
         battery_red: 2
@@ -209,11 +161,11 @@ game:
         laser: 1
       max_output: 5
       conversion_ticks: 1
-      cooldown: 1
-      initial_resource_count: 1
+      cooldown: 10
+      initial_resource_count: 0
 
     lab:
-      type_id: 10
+      type_id: 11
       input_resources:
         ore_red: 3
         battery_red: 3
@@ -221,11 +173,11 @@ game:
         blueprint: 1
       max_output: 5
       conversion_ticks: 1
-      cooldown: 1
-      initial_resource_count: 1
+      cooldown: 5
+      initial_resource_count: 0
 
     factory:
-      type_id: 11
+      type_id: 12
       input_resources:
         blueprint: 1
         ore_red: 5
@@ -235,11 +187,11 @@ game:
         laser: 5
       max_output: 5
       conversion_ticks: 1
-      cooldown: 1
-      initial_resource_count: 1
+      cooldown: 5
+      initial_resource_count: 0
 
     temple:
-      type_id: 12
+      type_id: 13
       input_resources:
         heart: 1
         blueprint: 1
@@ -247,16 +199,8 @@ game:
         heart: 5
       max_output: 5
       conversion_ticks: 1
-      cooldown: 1
-      initial_resource_count: 1
-
-    wall:
-      type_id: 13
-      swappable: false
-
-    block:
-      type_id: 14
-      swappable: true
+      cooldown: 5
+      initial_resource_count: 0
 
   actions:
     noop:
@@ -297,8 +241,8 @@ game:
       agents: 512
 
       objects:
-        mine: 1024
-        generator: 512
+        mine_red: 1024
+        generator_red: 512
         altar: 256
         armory: 0
         lasery: 0

--- a/pufferlib/environments/metta/metta.yaml
+++ b/pufferlib/environments/metta/metta.yaml
@@ -6,42 +6,67 @@ normalize_rewards: false
 
 sampling: 0
 desync_episodes: true
+
 game:
+  # Required list of inventory items
+  inventory_item_names:
+    - ore_red
+    - ore_blue
+    - ore_green
+    - battery_red
+    - battery_blue
+    - battery_green
+    - heart
+    - armor
+    - laser
+    - blueprint
+
   num_agents: 512
   obs_width: 11
   obs_height: 11
-  num_observation_tokens: 128
+  num_observation_tokens: 200
   max_steps: 1000
 
-  diversity_bonus:
-    enabled: false
-    similarity_coef: 0.5  # Coefficient for within-group similarity
-    diversity_coef: 0.5   # Coefficient for between-group diversity
+  # Global observation tokens configuration
+  global_obs:
+    episode_completion_pct: true
+    last_action: true
+    last_reward: true
+    resource_rewards: false
+
+  # Show recipe inputs in observations for all converters
+  recipe_details_obs: false
 
   agent:
-    default_item_max: 10
-    # the agent should be able to pick up as many hearts as they want, even if
-    # "normal" item limits are lower
-    heart_max: 255
+    default_resource_limit: 10
+    resource_limits:
+      heart: 255
     freeze_duration: 10
+    action_failure_penalty: 0.0
+    
     rewards:
-      # action_failure_penalty: 0.00001
-      action_failure_penalty: 0
-
-      ore.red: 0.25
-      ore.blue: 0.0
-      ore.green: 0.0
-      ore.red_max: 1000
-      ore.blue_max: 0
-      ore.green_max: 0
-      battery.red: 0.5
-      battery.blue: 0.0
-      battery.green: 0.0
-      battery.red_max: 1000
-      battery.blue_max: 0
-      battery.green_max: 0
-      heart: 1.0
-      heart_max: 1000
+      inventory:
+        ore_red: 0.25
+        ore_blue: 0.0
+        ore_green: 0.0
+        ore_red_max: 1000
+        ore_blue_max: 0
+        ore_green_max: 0
+        battery_red: 0.5
+        battery_blue: 0.0
+        battery_green: 0.0
+        battery_red_max: 1000
+        battery_blue_max: 0
+        battery_green_max: 0
+        heart: 1.0
+        heart_max: 1000
+        armor: 0.0
+        armor_max: 0
+        laser: 0.0
+        laser_max: 0
+        blueprint: 0.0
+        blueprint_max: 0
+      stats: {}
 
   groups:
     agent:
@@ -85,114 +110,152 @@ game:
 
   objects:
     altar:
-      input_battery.red: 3
-      output_heart: 1
+      type_id: 1
+      input_resources:
+        battery_red: 3
+      output_resources:
+        heart: 1
       max_output: 5
       conversion_ticks: 1
       cooldown: 10
-      initial_items: 0
+      initial_resource_count: 0
 
     mine_red:
-      output_ore.red: 1
+      type_id: 2
+      output_resources:
+        ore_red: 1
+      input_resources: {}
       color: 0
       max_output: 5
       conversion_ticks: 50
       cooldown: 1
-      initial_items: 1
+      initial_resource_count: 1
 
     mine_blue:
+      type_id: 3
       color: 1
-      output_ore.blue: 1
+      output_resources:
+        ore_blue: 1
+      input_resources: {}
       max_output: 5
       conversion_ticks: 1
       cooldown: 1
-      initial_items: 1
+      initial_resource_count: 1
 
     mine_green:
-      output_ore.green: 1
+      type_id: 4
+      output_resources:
+        ore_green: 1
+      input_resources: {}
       color: 2
       max_output: 5
       conversion_ticks: 1
       cooldown: 1
-      initial_items: 1
+      initial_resource_count: 1
 
     generator_red:
-      input_ore.red: 1
-      output_battery.red: 1
+      type_id: 5
+      input_resources:
+        ore_red: 1
+      output_resources:
+        battery_red: 1
       color: 0
       max_output: 5
       conversion_ticks: 1
       cooldown: 25
-      initial_items: 0
+      initial_resource_count: 0
 
     generator_blue:
-      input_ore.blue: 1
-      output_battery.blue: 1
+      type_id: 6
+      input_resources:
+        ore_blue: 1
+      output_resources:
+        battery_blue: 1
       color: 1
       max_output: 5
       conversion_ticks: 1
       cooldown: 1
-      initial_items: 1
+      initial_resource_count: 1
 
     generator_green:
-      input_ore.green: 1
-      output_battery.green: 1
+      type_id: 7
+      input_resources:
+        ore_green: 1
+      output_resources:
+        battery_green: 1
       color: 2
       max_output: 5
       conversion_ticks: 1
       cooldown: 1
-      initial_items: 1
+      initial_resource_count: 1
 
     armory:
-      input_ore.red: 3
-      output_armor: 1
+      type_id: 8
+      input_resources:
+        ore_red: 3
+      output_resources:
+        armor: 1
       max_output: 5
       conversion_ticks: 1
       cooldown: 1
-      initial_items: 1
+      initial_resource_count: 1
 
     lasery:
-      input_ore.red: 1
-      input_battery.red: 2
-      output_laser: 1
+      type_id: 9
+      input_resources:
+        ore_red: 1
+        battery_red: 2
+      output_resources:
+        laser: 1
       max_output: 5
       conversion_ticks: 1
       cooldown: 1
-      initial_items: 1
+      initial_resource_count: 1
 
     lab:
-      input_ore.red: 3
-      input_battery.red: 3
-      output_blueprint: 1
+      type_id: 10
+      input_resources:
+        ore_red: 3
+        battery_red: 3
+      output_resources:
+        blueprint: 1
       max_output: 5
       conversion_ticks: 1
       cooldown: 1
-      initial_items: 1
+      initial_resource_count: 1
 
     factory:
-      input_blueprint: 1
-      input_ore.red: 5
-      input_battery.red: 5
-      output_armor: 5
-      output_laser: 5
+      type_id: 11
+      input_resources:
+        blueprint: 1
+        ore_red: 5
+        battery_red: 5
+      output_resources:
+        armor: 5
+        laser: 5
       max_output: 5
       conversion_ticks: 1
       cooldown: 1
-      initial_items: 1
+      initial_resource_count: 1
 
     temple:
-      input_heart: 1
-      input_blueprint: 1
-      output_heart: 5
+      type_id: 12
+      input_resources:
+        heart: 1
+        blueprint: 1
+      output_resources:
+        heart: 5
       max_output: 5
       conversion_ticks: 1
       cooldown: 1
-      initial_items: 1
+      initial_resource_count: 1
 
     wall:
+      type_id: 13
       swappable: false
 
     block:
+      type_id: 14
       swappable: true
 
   actions:
@@ -207,22 +270,18 @@ game:
     get_items:
       enabled: true
     attack:
-      enabled: false
+      enabled: true
+      consumed_resources:
+        laser: 1
+      defense_resources:
+        armor: 1
     swap:
-      enabled: false
+      enabled: true
     change_color:
       enabled: false
-
-  reward_sharing:
-    groups:
-      team_1:
-        team_1: 0.5
-      team_2:
-        team_2: 0.5
-      team_3:
-        team_3: 0.5
-      team_4:
-        team_4: 0.5
+    change_glyph:
+      enabled: false
+      number_of_glyphs: 4
 
   map_builder:
     _target_: metta.mettagrid.room.multi_room.MultiRoom

--- a/pufferlib/environments/metta/torch.py
+++ b/pufferlib/environments/metta/torch.py
@@ -86,7 +86,11 @@ class Policy(nn.Module):
         )
         batch_indices = torch.arange(B * TT, device=token_observations.device).unsqueeze(-1).expand_as(atr_values)
 
+        # Add bounds checking to prevent out-of-bounds access
         valid_tokens = coords_byte != 0xFF
+        valid_tokens = valid_tokens & (x_coord_indices < self.out_width) & (y_coord_indices < self.out_height)
+        valid_tokens = valid_tokens & (atr_indices < 22)  # Also check attribute indices
+        
         box_obs[
             batch_indices[valid_tokens],
             atr_indices[valid_tokens],


### PR DESCRIPTION
Metta repository has changed a lot, to get `puffer train metta` working on the current checkout of `metta/` I made this diff.