### PR TITLE
modernize license declaration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "3.0.0"
 description = "Fast and sane reinforcement learning"
 requires-python = ">=3.9"
 readme = {file = "README.md", content-type = "text/markdown"}
-license= {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Joseph Suarez", email = "jsuarez@puffer.ai" }]
 classifiers=[
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
this fixes the

> ********************************************************************************
> Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
> 
> By 2026-Feb-18, you need to update your project and remove deprecated calls
> or your builds will no longer be supported.
> 
> See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
> ********************************************************************************

warning