### PR TITLE
fix: initialize c_extension_paths when NO_OCEAN=1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,7 @@ extension_kwargs = dict(
 
 # Find C extensions
 c_extensions = []
+c_extension_paths = []
 if not NO_OCEAN:
     c_extension_paths = glob.glob('pufferlib/ocean/**/binding.c', recursive=True)
     c_extensions = [


### PR DESCRIPTION
When NO_OCEAN=1 is set, c_extension_paths was undefined but still referenced in the setup() call, causing a NameError during package installation.

This fix initializes c_extension_paths as an empty list to ensure the variable is always defined regardless of the NO_OCEAN setting.

Fixes build issues when installing with NO_OCEAN=1 environment variable.