### PR TITLE
Numpy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,7 +233,7 @@ puffer = "pufferlib.pufferl:main"
 Homepage = "https://puffer.ai"
 
 [build-system]
-requires = ["setuptools", "wheel", "Cython", "numpy<2.0", "torch"]
+requires = ["setuptools", "wheel", "Cython", "numpy", "torch"]
 build-backend = "setuptools.build_meta"
 
 [tool.uv]

--- a/setup.py
+++ b/setup.py
@@ -247,7 +247,7 @@ for key, value in cfg_vars.items():
 
 install_requires = [
     'setuptools',
-    'numpy<2.0',
+    'numpy',
     'shimmy[gym-v21]',
     'gym==0.23',
     'gymnasium==0.29.1',


### PR DESCRIPTION
Numpy 2 seems to not break PufferLib or any other deps in my tests
However, Numpy 1 breaks on Windows

Switch to Numpy 2