### PR TITLE
modernize pynvml dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,7 @@ if not NO_TRAIN:
     install_requires += [
         'torch',
         'psutil',
-        'pynvml',
+        'nvidia-ml-py',
         'rich',
         'rich_argparse',
         'imageio',


### PR DESCRIPTION
easy deprecation win, similar to https://github.com/PufferAI/PufferLib/pull/323

(for context, the deprecation notice is
```
/home/kendell/Documents/Projects/PufferLib/.venv/lib/python3.13/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
```
)