### PR TITLE
clean up includes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -177,8 +177,8 @@ class TorchBuildExt(cpp_extension.BuildExtension):
         self.extensions = [e for e in self.extensions if e.name == "pufferlib._C"]
         super().run()
 
+INCLUDE = [f'{BOX2D_NAME}/include', f'{BOX2D_NAME}/src']
 RAYLIB_A = f'{RAYLIB_NAME}/lib/libraylib.a'
-INCLUDE = [numpy.get_include(), f'{BOX2D_NAME}/include', f'{BOX2D_NAME}/src']
 extension_kwargs = dict(
     include_dirs=INCLUDE,
     extra_compile_args=extra_compile_args,

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ class TorchBuildExt(cpp_extension.BuildExtension):
         super().run()
 
 RAYLIB_A = f'{RAYLIB_NAME}/lib/libraylib.a'
-INCLUDE = [numpy.get_include(), 'raylib/include', f'{BOX2D_NAME}/include', f'{BOX2D_NAME}/src']
+INCLUDE = [numpy.get_include(), f'{BOX2D_NAME}/include', f'{BOX2D_NAME}/src']
 extension_kwargs = dict(
     include_dirs=INCLUDE,
     extra_compile_args=extra_compile_args,


### PR DESCRIPTION
**the problem**
we include the nonexistent `raylib/include` and double-include numpy

**how `raylib/include` got there**
when [raylib was added to setup.py](https://github.com/PufferAI/PufferLib/commit/1e5b6a82a4a4467160d50a209a7a7751bea4c9af), the dirs were called `raylib` and `raylib_wasm`.
then [we started using static linking and descriptive names](https://github.com/PufferAI/PufferLib/commit/dcff24311459fe55a809d0e063100b37fdbbdb9d), eg now we have `raylib-version_os_arch` instead of `raylib`, so switched to `RAYLIB_INCLUDE`
then, in [a botched merge](https://github.com/PufferAI/PufferLib/commit/3b5ab6a74d2e7e8d76fe4e965c08e922b35e6d62#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R289) of @l1onh3art88's work, this was undone, incorrectly bringing back `raylib/include`

**how the double `numpy.get_include()` got there**
when [the first custom Extension was added](https://github.com/PufferAI/PufferLib/commit/ee92684ee43e0bb065363f00ba9b37e46d58109a), it repeated all include_dirs for some reason. this stuck and it's how we got to today

**new data flow**
```mermaid
graph TD
    subgraph raylib["raylib-version_os_arch"]
        libraylib["lib/libraylib.a"]
        include["include/"]
    end
    
    dist_pkg["distributed package"]
    compilation["compilation"]

    numpy_include[numpy get_include]
    numpy_include2["numpy get_include 2 (duplicate; removed here)"]
    
    %% Crossed out nonexistent path
    raylib_include["raylib/include (nonexistent; removed here)"]
    
    %% Main arrows
    libraylib -->|package_data| dist_pkg
    include -->|general include_dirs| compilation
    numpy_include --> |general include_dirs| compilation
    libraylib -->|extension extra_objects| compilation
    
    %% Crossed out arrow (dashed and red)
    numpy_include2 -.-> |per-extension include_dirs| compilation
    raylib_include -.->|per-extension include_dirs| compilation
    
    %% Styling for crossed out elements
    classDef crossed fill:#ff000044,stroke:#ff0000,stroke-width:2px,stroke-dasharray: 5 5
    class raylib_include crossed
    class numpy_include2 crossed
```
