### PR TITLE
save_checkpoint: use os.replace

### DIFF
--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -527,7 +527,7 @@ class PuffeRL:
         }
         state_path = os.path.join(path, 'trainer_state.pt')
         torch.save(state, state_path + '.tmp')
-        os.rename(state_path + '.tmp', state_path)
+        os.replace(state_path + '.tmp', state_path)
         return model_path
 
     def print_dashboard(self, clear=False, idx=[0],


### PR DESCRIPTION
replace acts as future proofing and is more semantic than os.rename. from os.rename docs:

> If you want cross-platform overwriting of the destination, use [replace()](https://docs.python.org/3/library/os.html#os.replace).