### PR TITLE
hip/rocm - build and use pufferlib cuda extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ c_*.c
 pufferlib/extensions.c
 pufferlib/puffernet.c
 
+# hipified cuda extensions dir [HIP/ROCM]
+pufferlib/extensions/hip/
+
 # Raylib
 raylib_wasm/
 

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -46,8 +46,13 @@ rich.traceback.install(show_locals=False)
 import signal # Aggressively exit on ctrl+c
 signal.signal(signal.SIGINT, lambda sig, frame: os._exit(0))
 
-# Assume advantage kernel has been built if CUDA compiler is available
-ADVANTAGE_CUDA = shutil.which("nvcc") is not None
+from torch.utils.cpp_extension import (
+    CUDA_HOME,
+    ROCM_HOME
+)
+# Assume advantage kernel has been built if torch has been compiled with CUDA or HIP support
+# and can find CUDA or HIP in the system
+ADVANTAGE_CUDA = bool(CUDA_HOME or ROCM_HOME)
 
 class PuffeRL:
     def __init__(self, config, vecenv, policy, logger=None):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,12 @@ from torch.utils.cpp_extension import (
     CUDAExtension,
     BuildExtension,
     CUDA_HOME,
+    ROCM_HOME
 )
+
+# build cuda extension if torch can find CUDA or HIP/ROCM in the system
+# may require `uv pip install --no-build-isolation` or `python setup.py build_ext --inplace`
+BUID_CUDA_EXT = bool(CUDA_HOME or ROCM_HOME)
 
 # Build with DEBUG=1 to enable debug symbols
 DEBUG = os.getenv("DEBUG", "0") == "1"
@@ -210,7 +215,7 @@ if not NO_TRAIN:
     torch_sources = [
         "pufferlib/extensions/pufferlib.cpp",
     ]
-    if shutil.which("nvcc"):
+    if BUID_CUDA_EXT:
         extension = CUDAExtension
         torch_sources.append("pufferlib/extensions/cuda/pufferlib.cu")
     else:


### PR DESCRIPTION
Enables compilation and use of cuda extension on hip/rocm systems.

Requires installing through `uv pip install --no-build-isolation` or running `python setup.py build_ext --inplace`.

There should be a better way to detect if the cuda extension exists and should be used in `pufferl.py`.

I've only tested this with an amd gpu.