### PR TITLE
Heavyball

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,7 @@ if not NO_TRAIN:
         'rich_argparse',
         'imageio',
         'pyro-ppl',
-        'heavyball',
+        'heavyball<2.0.0',
         'neptune',
         'wandb',
     ]


### PR DESCRIPTION
Heavyball is broken update to 2.0 as there is no version specified a new puffer  it pulls latest. This PR constrains <2.0. 