### PR TITLE
Add FlappyGrid2 environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,12 @@ pufferlib/ocean/impulse_wars/*-release/
 pufferlib/ocean/impulse_wars/debug-*/
 pufferlib/ocean/impulse_wars/release-*/
 pufferlib/ocean/impulse_wars/benchmark/
+*.bak
+*.swp
+diagnostic.py
+fix_*.py
+patch_*.py
+__pycache__/
+.pytest_cache/
+pokegym/
+envs/

--- a/pufferlib/environments/flappygrid2/__init__.py
+++ b/pufferlib/environments/flappygrid2/__init__.py
@@ -1,0 +1,3 @@
+from pufferlib.environments.flappygrid2.environment import env_creator
+
+__all__ = ['env_creator']

--- a/pufferlib/environments/flappygrid2/environment.py
+++ b/pufferlib/environments/flappygrid2/environment.py
@@ -1,0 +1,103 @@
+import functools
+import numpy as np
+import pufferlib
+from gymnasium import spaces
+
+
+class FlappyGrid2(pufferlib.PufferEnv):
+    """PufferLib-native FlappyBird/Grid hybrid."""
+    
+    def __init__(self):
+        self.grid_size = 10
+        self.bird_pos = 5
+        self.obstacle_x = 9
+        self.obstacle_gap_y = 5
+        self.score = 0
+        
+        # PufferLib required attributes (set BEFORE super().__init__())
+        self.num_agents = 1
+        self.single_observation_space = spaces.Box(
+            low=0, high=self.grid_size, shape=(3,), dtype=np.int32
+        )
+        self.single_action_space = spaces.Discrete(2)
+        
+        super().__init__()
+        
+    def reset(self, seed=None):
+        if seed is not None:
+            np.random.seed(seed)
+        
+        self.bird_pos = 5
+        self.obstacle_x = 9
+        self.obstacle_gap_y = np.random.randint(2, 8)
+        self.score = 0
+        
+        obs = np.array([self.bird_pos, self.obstacle_x, self.obstacle_gap_y], dtype=np.int32)
+        return obs, {}
+    
+    def step(self, action):
+        if action == 1:
+            self.bird_pos = max(0, self.bird_pos - 1)
+        else:
+            self.bird_pos = min(self.grid_size - 1, self.bird_pos + 1)
+        
+        self.obstacle_x -= 1
+        done = False
+        reward = 0.1
+        
+        if self.obstacle_x == 0:
+            if abs(self.bird_pos - self.obstacle_gap_y) <= 1:
+                reward = 1.0
+                self.score += 1
+            else:
+                done = True
+                reward = -1.0
+            
+            self.obstacle_x = 9
+            self.obstacle_gap_y = np.random.randint(2, 8)
+        
+        obs = np.array([self.bird_pos, self.obstacle_x, self.obstacle_gap_y], dtype=np.int32)
+        return obs, reward, done, False, {'score': self.score}
+    
+    def close(self):
+        pass
+
+
+def make(name='flappygrid2'):
+    return FlappyGrid2()
+
+
+def env_creator(name='flappygrid2'):
+    return functools.partial(make, name)
+
+
+if __name__ == "__main__":
+    import time
+    
+    print("FlappyGrid2 Performance Test")
+    print("=" * 50)
+    
+    factory = env_creator()
+    env = factory()
+    
+    obs, info = env.reset()
+    start = time.time()
+    
+    steps = 100_000
+    episodes = 0
+    
+    for i in range(steps):
+        action = env.single_action_space.sample()
+        obs, reward, done, truncated, info = env.step(action)
+        if done:
+            obs, info = env.reset()
+            episodes += 1
+    
+    elapsed = time.time() - start
+    fps = steps / elapsed
+    
+    print(f"Steps:    {steps:,}")
+    print(f"Episodes: {episodes:,}")
+    print(f"Time:     {elapsed:.2f}s")
+    print(f"FPS:      {fps:,.0f}")
+    print("✅ Test complete")

--- a/tests/pool/test_flappygrid2_pool.py
+++ b/tests/pool/test_flappygrid2_pool.py
@@ -1,0 +1,50 @@
+from pufferlib.vector import Multiprocessing
+from pufferlib.environments import flappygrid2
+import numpy as np
+import time
+
+
+def test_flappygrid2_multiprocessing():
+    """Test FlappyGrid2 with multiprocessing vectorization."""
+    num_envs = 4
+    
+    def env_factory(*args, **kwargs):
+        kwargs.pop('buf', None)
+        kwargs.pop('seed', None)
+        factory = flappygrid2.env_creator()
+        return factory(*args, **kwargs)
+    
+    env_factories = [env_factory for _ in range(num_envs)]
+    
+    pool = Multiprocessing(
+        env_factories,
+        env_args=[() for _ in range(num_envs)],
+        env_kwargs=[{} for _ in range(num_envs)],
+        num_envs=num_envs,
+        envs_per_worker=1,
+        envs_per_batch=2,
+        env_pool=True,
+    )
+    
+    pool.async_reset()
+    
+   # Even better - let the pool tell you the right shape
+    a = pool.action_space.sample()
+    start = time.time()
+    
+    steps = 1000
+    for _ in range(steps):
+        o, r, d, t, i, mask, env_id = pool.recv()
+        pool.send(a)
+    
+    end = time.time()
+    steps_per_second = 2 * steps / (end - start)
+    print(f'Multiprocessing FPS: {steps_per_second:,.0f}')
+    
+    pool.close()
+    assert steps_per_second > 1000
+    print("✅ Multiprocessing test passed")
+
+
+if __name__ == "__main__":
+    test_flappygrid2_multiprocessing()

--- a/tests/test_flappygrid2.py
+++ b/tests/test_flappygrid2.py
@@ -1,0 +1,52 @@
+import pytest
+from pufferlib.environments import flappygrid2
+
+
+def test_flappygrid2_basic():
+    """Test basic env functionality."""
+    factory = flappygrid2.env_creator()
+    env = factory()
+    
+    # Test reset
+    obs, info = env.reset()
+    assert obs.shape == (3,), f"Expected obs shape (3,), got {obs.shape}"
+    
+    # Test step
+    for _ in range(100):
+        action = env.single_action_space.sample()
+        obs, reward, done, truncated, info = env.step(action)
+        assert obs.shape == (3,)
+        assert isinstance(reward, (int, float))
+        assert isinstance(done, bool)
+        
+        if done:
+            obs, info = env.reset()
+    
+    env.close()
+    print("✅ FlappyGrid2 basic test passed")
+
+
+def test_flappygrid2_episodes():
+    """Test multiple episodes complete correctly."""
+    factory = flappygrid2.env_creator()
+    env = factory()
+    
+    obs, info = env.reset()
+    episodes_completed = 0
+    
+    for _ in range(10000):
+        action = env.single_action_space.sample()
+        obs, reward, done, truncated, info = env.step(action)
+        
+        if done:
+            episodes_completed += 1
+            obs, info = env.reset()
+    
+    assert episodes_completed > 0, "No episodes completed"
+    print(f"✅ Completed {episodes_completed} episodes")
+    env.close()
+
+
+if __name__ == "__main__":
+    test_flappygrid2_basic()
+    test_flappygrid2_episodes()


### PR DESCRIPTION
Adds a simple FlappyBird-style environment on a grid. Built to learn PufferLib's native API patterns.

What's included:
- Environment: `pufferlib/environments/flappygrid2/`
- Tests: `tests/test_flappygrid2.py`
- Performance: ~372k FPS single-threaded

Testing:
```bash
pytest tests/test_flappygrid2.py -vv
python pufferlib/environments/flappygrid2/environment.py

Runs clean on Ubuntu 22.04, Python 3.10.

Implementation notes:
- Uses PufferLib native API (no Gymnasium wrappers)
- Sets `num_agents`, `single_observation_space`, `single_action_space` before calling `super().__init__()`
- No external dependencies beyond core PufferLib