### PR TITLE
Use cpu-only pytorch for github tests

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -47,12 +47,8 @@ jobs:
         run: python -m pip install -U pip
 
       - name: Install build dependencies
-        run: pip install "numpy<2.0" setuptools wheel
+        run: pip install --upgrade "setuptools>=69.0.0" "numpy<2.0" wheel
 
-      - name: Install PyTorch CPU
-        if: matrix.env == 'conda'
-        run: conda install pytorch cpuonly -c pytorch
-      
       - name: Install PyTorch CPU  
         if: matrix.env == 'pip'
         run: pip install torch --index-url https://download.pytorch.org/whl/cpu

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install -U pip
 
+      - name: Install build dependencies
+        run: pip install "numpy<2.0" setuptools wheel
+
       - name: Install PyTorch CPU
         if: matrix.env == 'conda'
         run: conda install pytorch cpuonly -c pytorch

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -50,7 +50,6 @@ jobs:
         run: pip install --upgrade "setuptools>=69.0.0" "numpy<2.0" wheel
 
       - name: Install PyTorch CPU  
-        if: matrix.env == 'pip'
         run: pip install torch --index-url https://download.pytorch.org/whl/cpu
       
       - name: Install pufferlib

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -43,5 +43,13 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install -U pip
 
+      - name: Install PyTorch CPU
+        if: matrix.env == 'conda'
+        run: conda install pytorch cpuonly -c pytorch
+      
+      - name: Install PyTorch CPU  
+        if: matrix.env == 'pip'
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+      
       - name: Install pufferlib
-        run: pip install -e .
+        run: pip install -e . --no-build-isolation

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -44,7 +44,7 @@ jobs:
         run: python -m pip install -U pip
 
       - name: Install build dependencies
-        run: pip install --upgrade "setuptools>=69.0.0" "numpy<2.0" wheel
+        run: pip install --upgrade "setuptools>=69.0.0" "packaging>=24.2" "numpy<2.0" wheel
 
       - name: Install PyTorch CPU  
         run: pip install torch --index-url https://download.pytorch.org/whl/cpu

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -8,6 +8,9 @@ jobs:
   test:
     name: test ${{ matrix.py }} - ${{ matrix.os }} - ${{ matrix.env }}
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -8,9 +8,6 @@ jobs:
   test:
     name: test ${{ matrix.py }} - ${{ matrix.os }} - ${{ matrix.env }}
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash -el {0}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
GitHub Actions tests were failing due to insufficient disk space when installing CUDA dependencies. Since GitHub runners don't have GPU access anyway, switched to CPU-only PyTorch installation.