### PR TITLE
update heavyball

### DIFF
--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -156,13 +156,19 @@ class PuffeRL:
         elif config['optimizer'] == 'muon':
             from heavyball import ForeachMuon
             warnings.filterwarnings(action='ignore', category=UserWarning, module=r'heavyball.*')
-            import heavyball.utils
-            heavyball.utils.compile_mode = config['compile_mode'] if config['compile'] else None
+
+            # # optionally a little bit better/faster alternative to newtonschulz iteration
+            # import heavyball.utils
+            # heavyball.utils.zeroth_power_mode = 'thinky_polar_express'
+
+            # heavyball_momentum=True introduced in heavyball 2.1.1
+            # recovers heavyball-1.7.2 behaviour - previously swept hyperparameters work well
             optimizer = ForeachMuon(
                 self.policy.parameters(),
                 lr=config['learning_rate'],
                 betas=(config['adam_beta1'], config['adam_beta2']),
                 eps=config['adam_eps'],
+                heavyball_momentum=True,
             )
         else:
             raise ValueError(f'Unknown optimizer: {config["optimizer"]}')

--- a/setup.py
+++ b/setup.py
@@ -263,7 +263,7 @@ if not NO_TRAIN:
         'rich_argparse',
         'imageio',
         'pyro-ppl',
-        'heavyball<2.0.0',
+        'heavyball>=2.2.0', # contains relevant fixes compared to 1.7.2 and 2.1.1
         'neptune',
         'wandb',
     ]


### PR DESCRIPTION
Bumps heavyball requirement to 2.2.0, which contains a bunch of fixes.
The change includes "heavyball_momentum=True" to recover ForeachMuon behaviour from 1.7.2 for compatibility with already swept hyperparameters in pufferlib configs.

```heavyball.utils.compile_mode = config['compile_mode'] if config['compile'] else None```
Has been removed as heavyball handles compilation correctly by default - compiles when compilation is enabled.