### PR TITLE
Fix pyproject.toml license configuration for modern setuptools compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ version = "3.0.0"
 description = "Fast and sane reinforcement learning"
 requires-python = ">=3.9"
 readme = {file = "README.md", content-type = "text/markdown"}
-license = "MIT"
-license-files = ["LICENSE"]
+license = {text = "MIT"}
 authors = [{ name = "Joseph Suarez", email = "jsuarez@puffer.ai" }]
 classifiers=[
     "Intended Audience :: Science/Research",
@@ -246,3 +245,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.uv]
 no-build-isolation-package = ["torch"]
+
+[tool.setuptools]
+license-files = ["LICENSE"]


### PR DESCRIPTION
## Problem
The current `pyproject.toml` configuration causes build failures with modern versions of setuptools:
1. `license = "MIT"` uses deprecated string format
2. `license-files` is not allowed in `[project]` section per PEP 621

## Error Messages

**First error:**

```
ValueError: invalid pyproject.toml config: `project.license`.
configuration error: `project.license` must be valid exactly by one definition
```

**Second error:**

```
ValueError: invalid pyproject.toml config: `project`.
configuration error: `project` must not contain {'license-files'} properties
```

## Solution
- Changed `license = "MIT"` to `license = {text = "MIT"}` (PEP 621 compliant)
- Removed `license-files` from `[project]` section

## Testing
Verified installation works with:
- `uv pip install -e . --no-build-isolation`
- Python 3.12.7
- setuptools 75.6.0

## Related
This affects all users trying to install PufferLib in development mode on systems with setuptools>=61.0.0.