### PR TITLE
New baseline for G2048

### DIFF
--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -73,7 +73,6 @@ prune_pareto = True
 #distribution = uniform_pow2
 #min = 1
 #max = 16
-#mean = 8
 #scale = auto
 
 # TODO: Elim from base
@@ -81,48 +80,41 @@ prune_pareto = True
 distribution = log_normal
 min = 3e7
 max = 1e10
-mean = 2e8
 scale = time
 
 [sweep.train.bptt_horizon]
 distribution = uniform_pow2
 min = 16
 max = 64
-mean = 64
 scale = auto
 
 [sweep.train.minibatch_size]
 distribution = uniform_pow2
 min = 8192
 max = 65536
-mean = 32768
 scale = auto
 
 [sweep.train.learning_rate]
 distribution = log_normal
 min = 0.00001
-mean = 0.01
 max = 0.1
 scale = 0.5
 
 [sweep.train.ent_coef]
 distribution = log_normal
 min = 0.00001
-mean = 0.01
 max = 0.2
 scale = auto
 
 [sweep.train.gamma]
 distribution = logit_normal
 min = 0.8
-mean = 0.98
 max = 0.9999
 scale = auto
 
 [sweep.train.gae_lambda]
 distribution = logit_normal
 min = 0.6
-mean = 0.95
 max = 0.995
 scale = auto
 
@@ -130,28 +122,24 @@ scale = auto
 distribution = uniform
 min = 0.1
 max = 5.0
-mean = 1.0
 scale = auto
 
 [sweep.train.vtrace_c_clip]
 distribution = uniform
 min = 0.1
 max = 5.0
-mean = 1.0
 scale = auto
 
 #[sweep.train.update_epochs]
 #distribution = int_uniform
 #min = 1
 #max = 8
-#mean = 1
 #scale = 2.0
 
 [sweep.train.clip_coef]
 distribution = uniform
 min = 0.01
 max = 1.0
-mean = 0.2
 scale = auto
 
 # Optimal vf clip can be lower than 0.1,
@@ -160,54 +148,46 @@ scale = auto
 distribution = uniform
 min = 0.1
 max = 5.0
-mean = 0.2
 scale = auto
 
 [sweep.train.vf_coef]
 distribution = uniform
 min = 0.1
 max = 5.0
-mean = 2.0
 scale = auto
 
 [sweep.train.max_grad_norm]
 distribution = uniform
 min = 0.1
-mean = 1.0
 max = 5.0
 scale = auto
 
 [sweep.train.adam_beta1]
 distribution = logit_normal
 min = 0.5
-mean = 0.9
 max = 0.999
 scale = auto
 
 [sweep.train.adam_beta2]
 distribution = logit_normal
 min = 0.9
-mean = 0.999
 max = 0.99999
 scale = auto
 
 [sweep.train.adam_eps]
 distribution = log_normal
 min = 1e-14
-mean = 1e-8
 max = 1e-4
 scale = auto
 
 [sweep.train.prio_alpha]
 distribution = logit_normal
 min = 0.1
-mean = 0.85
 max = 0.99
 scale = auto
 
 [sweep.train.prio_beta0]
 distribution = logit_normal
 min = 0.1
-mean = 0.85
 max = 0.99
 scale = auto

--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -3,7 +3,6 @@ package = None
 env_name = None
 policy_name = Policy
 rnn_name = None
-max_suggestion_cost = 3600
 
 [vec]
 backend = Multiprocessing
@@ -26,10 +25,11 @@ torch_deterministic = True
 cpu_offload = False
 device = cuda
 optimizer = muon
-anneal_lr = True
 precision = float32
 total_timesteps = 10_000_000
 learning_rate = 0.015
+anneal_lr = True
+min_learning_rate = 0.0
 gamma = 0.995
 gae_lambda = 0.90
 update_epochs = 1
@@ -64,6 +64,7 @@ prio_beta0 = 0.2
 method = Protein 
 metric = score
 goal = maximize
+max_suggestion_cost = 3600
 downsample = 5
 use_gpu = True
 prune_pareto = True
@@ -127,14 +128,14 @@ scale = auto
 
 [sweep.train.vtrace_rho_clip]
 distribution = uniform
-min = 0.0
+min = 0.1
 max = 5.0
 mean = 1.0
 scale = auto
 
 [sweep.train.vtrace_c_clip]
 distribution = uniform
-min = 0.0
+min = 0.1
 max = 5.0
 mean = 1.0
 scale = auto
@@ -164,14 +165,14 @@ scale = auto
 
 [sweep.train.vf_coef]
 distribution = uniform
-min = 0.0
+min = 0.1
 max = 5.0
 mean = 2.0
 scale = auto
 
 [sweep.train.max_grad_norm]
 distribution = uniform
-min = 0.0
+min = 0.1
 mean = 1.0
 max = 5.0
 scale = auto

--- a/pufferlib/config/ocean/g2048.ini
+++ b/pufferlib/config/ocean/g2048.ini
@@ -1,68 +1,177 @@
 [base]
 package = ocean
 env_name = puffer_g2048
-policy_name = Policy
+policy_name = G2048
 rnn_name = Recurrent
 
 [policy]
-hidden_size = 256
+; hidden_size = 256
+hidden_size = 512
 
 [rnn]
-input_size = 256
-hidden_size = 256
+; input_size = 256
+; hidden_size = 256
+input_size = 512
+hidden_size = 512
 
 [vec]
 num_envs = 4
 
 [env]
 num_envs = 4096
+reward_scaler = 0.67
+endgame_env_prob = 0.05
+scaffolding_ratio = 0.67
+use_heuristic_rewards = True
+snake_reward_weight = 0.0005
 
 [train]
-# https://wandb.ai/kywch/pufferlib/runs/n8xml0u9?nw=nwuserkywch
-total_timesteps = 3_000_000_000
+# 256 hidden: https://wandb.ai/kywch/pufferlib/runs/nvd0pfuj?nw=nwuserkywch
+# 512 hidden: https://wandb.ai/kywch/pufferlib/runs/2ch3my60?nw=nwuserkywch
+total_timesteps = 6_767_676_767
+; total_timesteps = 1_000_000_000
 anneal_lr = True
+min_learning_rate = 0.00005
 batch_size = auto
 bptt_horizon = 64
-minibatch_size = 65536
+minibatch_size = 32768
 
-adam_beta1 = 0.99
-adam_beta2 = 0.96
-adam_eps = 1.0e-10
-clip_coef = 0.1
-ent_coef = 0.02
-gae_lambda = 0.6
-gamma = 0.985
-learning_rate = 0.001
-max_grad_norm = 1.0
-prio_alpha = 0.99
-prio_beta0 = 0.40
-vf_clip_coef = 0.1
+clip_coef = 0.067
+ent_coef = 0.0267
+gae_lambda = 0.67
+gamma = 0.99567
+vf_clip_coef = 0.167
 vf_coef = 2.0
-vtrace_c_clip = 4.3
-vtrace_rho_clip = 1.6
 
+# for 256 hidden
+; learning_rate = 0.0005
+; max_grad_norm = 0.5
+
+# for 512 hidden
+learning_rate = 0.000467
+max_grad_norm = 0.5
+
+
+# These are newer puffer PPO params. Need more sweeping.
+adam_beta1 = 0.99
+adam_beta2 = 0.9999
+adam_eps = 0.0001
+prio_alpha = 0.8
+prio_beta0 = 0.1
+vtrace_c_clip = 2.0
+vtrace_rho_clip = 1.1
+
+
+### Targeted sweep
 
 [sweep]
 metric = score
 goal = maximize
+max_suggestion_cost = 7200
+sweep_only = endgame_env_prob, scaffolding_ratio, snake_reward_weight, learning_rate, max_grad_norm
+downsample = 1
 
-[sweep.train.total_timesteps]
-distribution = log_normal
-min = 3e8
-max = 1e10
-mean = 1e9
-scale = time
+[sweep.env.endgame_env_prob]
+distribution = uniform
+min = 0.0
+mean = 0.03
+max = 0.2
+scale = auto
+
+[sweep.env.scaffolding_ratio]
+distribution = uniform
+min = 0.1
+mean = 0.5
+max = 0.8
+scale = auto
+
+[sweep.env.snake_reward_weight]
+distribution = uniform
+min = 0.0001
+mean = 0.0007
+max = 0.0050
+scale = auto
 
 [sweep.train.learning_rate]
-distribution = log_normal
-min = 0.00001
-mean = 0.001
-max = 0.1
+distribution = uniform
+min = 0.0001
+mean = 0.0005
+max = 0.0030
 scale = 0.5
 
-[sweep.train.gae_lambda]
-distribution = logit_normal
-min = 0.01
-mean = 0.6
-max = 0.995
+[sweep.train.max_grad_norm]
+distribution = uniform
+min = 0.1
+mean = 0.5
+max = 2.0
+scale = 0.5
+
+[sweep.train.vf_clip_coef]
+distribution = uniform
+min = 0.05
+max = 0.5
+mean = 0.2
 scale = auto
+
+
+### Broad sweep
+
+; [sweep]
+; metric = score
+; goal = maximize
+
+; [sweep.env.reward_scaler]
+; distribution = uniform
+; min = 0.1
+; mean = 0.5
+; max = 1.0
+; scale = auto
+
+; [sweep.env.scaffolding_ratio]
+; distribution = uniform
+; min = 0.0
+; mean = 0.5
+; max = 0.8
+; scale = auto
+
+; [sweep.env.snake_reward_weight]
+; distribution = uniform
+; min = 0.00001
+; mean = 0.00005
+; max = 0.0002
+; scale = auto
+
+; [sweep.train.total_timesteps]
+; distribution = log_normal
+; min = 3e8
+; max = 1e10
+; mean = 1e9
+; scale = time
+
+; [sweep.train.learning_rate]
+; distribution = log_normal
+; min = 0.00001
+; mean = 0.001
+; max = 0.1
+; scale = 0.5
+
+; [sweep.train.gamma]
+; distribution = logit_normal
+; min = 0.8
+; mean = 0.995
+; max = 0.9999
+; scale = auto
+
+; [sweep.train.gae_lambda]
+; distribution = logit_normal
+; min = 0.01
+; mean = 0.7
+; max = 0.995
+; scale = auto
+
+; [sweep.train.clip_coef]
+; distribution = log_normal
+; min = 0.001
+; max = 0.5
+; mean = 0.05
+; scale = auto

--- a/pufferlib/config/ocean/g2048.ini
+++ b/pufferlib/config/ocean/g2048.ini
@@ -5,12 +5,9 @@ policy_name = G2048
 rnn_name = Recurrent
 
 [policy]
-; hidden_size = 256
 hidden_size = 512
 
 [rnn]
-; input_size = 256
-; hidden_size = 256
 input_size = 512
 hidden_size = 512
 
@@ -26,10 +23,8 @@ use_heuristic_rewards = True
 snake_reward_weight = 0.0005
 
 [train]
-# 256 hidden: https://wandb.ai/kywch/pufferlib/runs/nvd0pfuj?nw=nwuserkywch
-# 512 hidden: https://wandb.ai/kywch/pufferlib/runs/2ch3my60?nw=nwuserkywch
+# 512 hidden: https://wandb.ai/kywch/pufferlib/runs/5thsjr61?nw=nwuserkywch
 total_timesteps = 6_767_676_767
-; total_timesteps = 1_000_000_000
 anneal_lr = True
 min_learning_rate = 0.00005
 batch_size = auto
@@ -43,11 +38,6 @@ gamma = 0.99567
 vf_clip_coef = 0.167
 vf_coef = 2.0
 
-# for 256 hidden
-; learning_rate = 0.0005
-; max_grad_norm = 0.5
-
-# for 512 hidden
 learning_rate = 0.000467
 max_grad_norm = 0.5
 

--- a/pufferlib/ocean/g2048/binding.c
+++ b/pufferlib/ocean/g2048/binding.c
@@ -3,9 +3,15 @@
 #define Env Game
 #include "../env_binding.h"
 
-// g2048.h does not have a 'size' field, so my_init can just return 0
 static int my_init(Env* env, PyObject* args, PyObject* kwargs) {
-    // No custom initialization needed for 2048
+    env->can_go_over_65536 = unpack(kwargs, "can_go_over_65536");
+    env->reward_scaler = unpack(kwargs, "reward_scaler");
+    env->endgame_env_prob = unpack(kwargs, "endgame_env_prob");
+    env->scaffolding_ratio = unpack(kwargs, "scaffolding_ratio");
+    env->use_heuristic_rewards = unpack(kwargs, "use_heuristic_rewards");
+    env->snake_reward_weight = unpack(kwargs, "snake_reward_weight");
+    env->use_sparse_reward = unpack(kwargs, "use_sparse_reward");
+    init(env);
     return 0;
 }
 
@@ -15,5 +21,11 @@ static int my_log(PyObject* dict, Log* log) {
     assign_to_dict(dict, "merge_score", log->merge_score);
     assign_to_dict(dict, "episode_return", log->episode_return);
     assign_to_dict(dict, "episode_length", log->episode_length);
+    assign_to_dict(dict, "lifetime_max_tile", log->lifetime_max_tile);
+    assign_to_dict(dict, "reached_32768", log->reached_32768);
+    assign_to_dict(dict, "reached_65536", log->reached_65536);
+    assign_to_dict(dict, "monotonicity_reward", log->monotonicity_reward);
+    assign_to_dict(dict, "snake_state", log->snake_state);
+    assign_to_dict(dict, "snake_reward", log->snake_reward);
     return 0;
 }

--- a/pufferlib/ocean/g2048/eval.py
+++ b/pufferlib/ocean/g2048/eval.py
@@ -88,5 +88,18 @@ def finetune(env_name, load_model_path):
     pufferl.train(env_name, args)
 
 if __name__ == '__main__':
-    evaluate('puffer_g2048', load_model_path='puffer_g2048_5thsjr61.pt')
+    import os
+    import wandb
+
+    # https://wandb.ai/kywch/pufferlib/runs/5thsjr61?nw=nwuserkywch
+    wandb_run_id = '5thsjr61'
+    wandb.init(id=wandb_run_id, project='pufferlib', entity='kywch')
+
+    artifact = wandb.use_artifact(f'{wandb_run_id}:latest')
+    data_dir = artifact.download()
+    model_file = max(os.listdir(data_dir))
+    model_path = f'{data_dir}/{model_file}'
+    wandb.finish()
+
+    evaluate('puffer_g2048', load_model_path=model_path)
     # finetune('puffer_g2048', load_model_path='puffer_g2048_256_base.pt')

--- a/pufferlib/ocean/g2048/eval.py
+++ b/pufferlib/ocean/g2048/eval.py
@@ -57,7 +57,15 @@ def evaluate(env_name, load_model_path):
     Episode length -- Avg: 21539.7, Max: 29680.3
     Merge score -- Avg: 618011.8, Max: 918755.8
     Reached 32768 prob: 68.25 %
-    Reached 65536 prob: 13.09 %    
+    Reached 65536 prob: 13.09 %
+
+    # hidden 512 (replication): https://wandb.ai/kywch/pufferlib/runs/5thsjr61?nw=nwuserkywch
+    Num episodes: 115652
+    Max tile avg: 31773.2
+    Episode length -- Avg: 22196.4, Max: 30316.5
+    Merge score -- Avg: 639395.6, Max: 909969.8
+    Reached 32768 prob: 71.22 %
+    Reached 65536 prob: 14.75 %
     """
 
 def finetune(env_name, load_model_path):
@@ -80,5 +88,5 @@ def finetune(env_name, load_model_path):
     pufferl.train(env_name, args)
 
 if __name__ == '__main__':
-    evaluate('puffer_g2048', load_model_path='puffer_g2048_2ch3my60.pt')
+    evaluate('puffer_g2048', load_model_path='puffer_g2048_5thsjr61.pt')
     # finetune('puffer_g2048', load_model_path='puffer_g2048_256_base.pt')

--- a/pufferlib/ocean/g2048/eval.py
+++ b/pufferlib/ocean/g2048/eval.py
@@ -1,0 +1,84 @@
+from pufferlib import pufferl
+
+def evaluate(env_name, load_model_path):
+    args = pufferl.load_config(env_name)
+    args['vec']['num_envs'] = 1
+    args['env']['num_envs'] = 4096
+    args['load_model_path'] = load_model_path
+    # Turn off endgame_envs and scaffolding episodes, which do not report results
+    args['env']['endgame_env_prob'] = 0
+    args['env']['scaffolding_ratio'] = 0
+    args['env']['can_go_over_65536'] = True
+
+    vecenv = pufferl.load_env(env_name, args)
+    policy = pufferl.load_policy(args, vecenv, env_name)
+    trainer = pufferl.PuffeRL(args['train'], vecenv, policy)
+
+    # Each evaluate runs for 64 ticks. NOTE: bppt horizon might be short for g2048?
+    # Avg episode length from the current model is ~18000, so it takes ~300 epochs for an avg episode.
+    # It's hard to get the single best score because stats are already averaged across done envs.
+    for i in range(10000):
+        stats = trainer.evaluate()
+
+        trainer.epoch += 1
+        if i % 20 == 0:
+            trainer.print_dashboard()
+
+    trainer.close()
+
+    # Get the estimates
+    num_episodes = sum(stats['n'])
+    episode_lengths = sum(n * l for n, l in zip(stats['n'], stats['episode_length'])) / num_episodes
+    max_tiles = sum(n * m for n, m in zip(stats['n'], stats['score'])) / num_episodes
+    merge_scores = sum(n * s for n, s in zip(stats['n'], stats['merge_score'])) / num_episodes
+    reached_32768 = sum(n * s for n, s in zip(stats['n'], stats['reached_32768'])) / num_episodes
+    reached_65536 = sum(n * s for n, s in zip(stats['n'], stats['reached_65536'])) / num_episodes
+
+    print(f"Num episodes: {int(num_episodes)}")
+    print(f"Max tile avg: {max_tiles:.1f}")
+    # The stats from vecenv are averaged across envs that were done in the same tick. Cannot get the single max.
+    print(f"Episode length -- Avg: {episode_lengths:.1f}, Max: {max(stats['episode_length']):.1f}")
+    print(f"Merge score -- Avg: {merge_scores:.1f}, Max: {max(stats['merge_score']):.1f}")
+    print(f"Reached 32768 prob: {reached_32768*100:.2f} %")
+    print(f"Reached 65536 prob: {reached_65536*100:.2f} %")
+
+    """
+    # hidden 256: https://wandb.ai/kywch/pufferlib/runs/nvd0pfuj?nw=nwuserkywch
+    Num episodes: 154406
+    Max tile avg: 22532.9
+    Episode length -- Avg: 16667.2, Max: 26659.1
+    Merge score -- Avg: 462797.9, Max: 744224.9
+    Reached 32768 prob: 46.08 %
+    Reached 65536 prob: 3.53 %
+
+    # hidden 512: https://wandb.ai/kywch/pufferlib/runs/2ch3my60?nw=nwuserkywch
+    Num episodes: 119243
+    Max tile avg: 30662.2
+    Episode length -- Avg: 21539.7, Max: 29680.3
+    Merge score -- Avg: 618011.8, Max: 918755.8
+    Reached 32768 prob: 68.25 %
+    Reached 65536 prob: 13.09 %    
+    """
+
+def finetune(env_name, load_model_path):
+    args = pufferl.load_config(env_name)
+    args['load_model_path'] = load_model_path
+    # args['env']['use_sparse_reward'] = True
+    args['env']['scaffolding_ratio'] = 0.85
+
+    # args['policy']['hidden_size'] = 512
+    # args['rnn']['input_size'] = 512
+    # args['rnn']['hidden_size'] = 512
+
+    args['train']['total_timesteps'] = 1_000_000_000
+    args['train']['learning_rate'] = 0.00005
+    args['train']['anneal_lr'] = False
+
+    args['wandb'] = True
+    args['tag'] = 'pg2048'
+
+    pufferl.train(env_name, args)
+
+if __name__ == '__main__':
+    evaluate('puffer_g2048', load_model_path='puffer_g2048_2ch3my60.pt')
+    # finetune('puffer_g2048', load_model_path='puffer_g2048_256_base.pt')

--- a/pufferlib/ocean/g2048/g2048.h
+++ b/pufferlib/ocean/g2048/g2048.h
@@ -5,7 +5,9 @@
 #include <math.h>
 #include <string.h>
 #include "raylib.h"
-#define max(a, b) (((a) > (b)) ? (a) : (b))
+
+static inline int min(int a, int b) { return a < b ? a : b; }
+static inline int max(int a, int b) { return a > b ? a : b; }
 
 #define SIZE 4
 #define EMPTY 0
@@ -13,15 +15,29 @@
 #define DOWN 2
 #define LEFT 3
 #define RIGHT 4
-#define BASE_MAX_TICKS 2000
+#define BASE_MAX_TICKS 1000
 
-// Precomputed constants
-#define REWARD_MULTIPLIER 0.0625f
+// These work well
+#define MERGE_REWARD_WEIGHT 0.0625f
 #define INVALID_MOVE_PENALTY -0.05f
 #define GAME_OVER_PENALTY -1.0f
 
-// To normalize perf from 0 to 1. Reachable with hidden size 256.
-#define OBSERVED_MAX_TILE 4096.0f
+// These may need experimenting, but work for now
+#define STATE_REWARD_WEIGHT 0.01f // Fixed, small reward for maintaining "desirable" states
+#define MONOTONICITY_REWARD_WEIGHT 0.00003f
+
+// Features: 18 per cell
+// 1. Normalized tile value (current_val / max_val)
+// 2. One-hot for empty (1 if empty, 0 if occupied)
+// 3-18. One-hot for tile values 2^1 to 2^16 (16 features)
+#define NUM_FEATURES 18
+
+static inline float calculate_perf(unsigned char max_tile) {
+    // Reaching 65k -> 1.0, 32k -> 0.8, 16k -> 0.4, 8k -> 0.2, 4k -> 0.1, 2k -> 0.05
+    float perf = 0.8f * (float)(1 << max_tile) / 32768.0f;
+    if (perf > 1.0f) perf = 1.0f;
+    return perf;
+}
 
 typedef struct {
     float perf;
@@ -29,6 +45,12 @@ typedef struct {
     float merge_score;
     float episode_return;
     float episode_length;
+    float lifetime_max_tile;
+    float reached_32768;
+    float reached_65536;
+    float snake_state;
+    float monotonicity_reward;
+    float snake_reward;
     float n;
 } Log;
 
@@ -38,13 +60,32 @@ typedef struct {
     int* actions;                   // Required
     float* rewards;                 // Required
     unsigned char* terminals;       // Required
+
+    bool can_go_over_65536;         // Set false for training, true for eval
+    float reward_scaler;            // Pufferlib clips rew from -1 to 1, adjust the resulting rew accordingly
+
+    float endgame_env_prob;         // The prob of env being initialized as an endgame-only env
+    bool is_endgame_env;
+    float scaffolding_ratio;        // The ratio for "scaffolding" runs, in which higher blocks are spawned
+    bool is_scaffolding_episode;
+    bool use_heuristic_rewards;
+    float snake_reward_weight;
+    bool use_sparse_reward;         // Ignore all rewards and provide 1 for reaching 16k, 32k, 65k
+
     int score;
     int tick;
     unsigned char grid[SIZE][SIZE];
+    unsigned char lifetime_max_tile;
+    unsigned char max_tile;         // Episode max tile
     float episode_reward;           // Accumulate episode reward
+    float monotonicity_reward;
+    float snake_reward;
     int moves_made;
     int max_episode_ticks;          // Dynamic max_ticks based on score
-    
+    bool is_snake_state;
+    int snake_state_tick;
+    bool stop_at_65536;
+
     // Cached values to avoid recomputation
     int empty_count;
     bool game_over_cached;
@@ -57,80 +98,194 @@ const Color PUFF_WHITE = (Color){241, 241, 241, 241};
 const Color PUFF_RED = (Color){187, 0, 0, 255};
 const Color PUFF_CYAN = (Color){0, 187, 187, 255};
 
-static Color tile_colors[12] = {
+static Color tile_colors[17] = {
     {6, 24, 24, 255}, // Empty/background
     {187, 187, 187, 255}, // 2
     {170, 187, 187, 255}, // 4
     {150, 187, 187, 255}, // 8
     {130, 187, 187, 255},  // 16
     {110, 187, 187, 255},  // 32
-    {90, 187, 187, 255},   // 64
-    {70, 187, 187, 255}, // 128
-    {50, 187, 187, 255},  // 256
-    {30, 187, 187, 255},  // 512
-    {10, 187, 187, 255},  // 1024
-    {0, 187, 187, 255}   // 2048+
+    {90, 187, 187, 255},   // 64 (Getting more cyan)
+    {70, 187, 187, 255},   // 128
+    {50, 187, 187, 255},   // 256
+    {30, 187, 187, 255},   // 512
+    {0, 187, 187, 255},    // 1024 (PUFF_CYAN)
+    {0, 150, 187, 255},    // 2048
+    {0, 110, 187, 255},    // 4096
+    {0, 70, 187, 255},     // 8192
+    {187, 0, 0, 255},      // 16384 (PUFF_RED)
+    {204, 173, 17, 255},   // 32768 (Gold)
+    {6, 24, 24, 255},      // 65536+ (Invisible)
+};
+
+// Precomputed pow(x, 1.5) lookup table for x in [0, 19] to avoid expensive pow() calls.
+static const unsigned char pow_1_5_lookup[20] = {
+    0, 1, 2, 5, 8, 11, 14, 18, 22, 27, 31, 36, 41, 46, 52, 57, 64, 69, 75, 81
 };
 
 // --- Logging ---
 void add_log(Game* game);
 
 // --- Required functions for env_binding.h ---
-void c_reset(Game* env);
-void c_step(Game* env);
-void c_render(Game* env);
-void c_close(Game* env);
+void c_reset(Game* game);
+void c_step(Game* game);
+void c_render(Game* game);
+void c_close(Game* game);
 
-// Inline function for updating observations (avoid function call overhead)
-static inline void update_observations(Game* game) {
-    for (int i = 0; i < SIZE; i++) {
-        for (int j = 0; j < SIZE; j++) {
-            game->observations[i * SIZE + j] = game->grid[i][j];
-        }
-    }
+void init(Game* game) {
+    game->lifetime_max_tile = 0;
+    game->is_endgame_env = (rand() / (float)RAND_MAX) < game->endgame_env_prob;
 }
 
-// Cache empty cell count during grid operations
-static inline void update_empty_count(Game* game) {
-    int count = 0;
-    for (int i = 0; i < SIZE; i++) {
-        for (int j = 0; j < SIZE; j++) {
-            if (game->grid[i][j] == EMPTY) count++;
-        }
-    }
-    game->empty_count = count;
-}
+void update_observations(Game* game) {
+    // Observation: 4x4 grid, 18 features per cell
+    // 1. Normalized tile value (current_val / max_val)
+    // 2. One-hot for empty (1 if empty, 0 if occupied)
+    // 3. One-hot for tile values 2^1 to 2^16 (16 features)
+    // 4. Additional obs: is_snake_state (1)
 
-static inline unsigned char get_max_tile(Game* game) {
-    unsigned char max_tile = 0;
-    // Unroll loop for better performance
+    int num_cell = SIZE * SIZE;
+    int num_additional_obs = 1;
+    memset(game->observations, 0, (num_cell * NUM_FEATURES + num_additional_obs) * sizeof(unsigned char));
     for (int i = 0; i < SIZE; i++) {
         for (int j = 0; j < SIZE; j++) {
-            if (game->grid[i][j] > max_tile) {
-                max_tile = game->grid[i][j];
+            int feat1_idx = (i * SIZE + j);
+            int feat2_idx = num_cell + feat1_idx;
+            int feat3_idx = 2 * num_cell + 16 * feat1_idx;
+            unsigned char grid_val = game->grid[i][j];
+
+            // Feature 1: The original tile values ** 1.5, to make a bit superlinear within uint8
+            game->observations[feat1_idx] = pow_1_5_lookup[grid_val];
+
+            // Feature 2: One-hot for empty
+            game->observations[feat2_idx] = (grid_val == EMPTY) ? 1 : 0;
+
+            // Features 3-18: One-hot for tile values
+            // NOTE: If this ever gets close to 131072, revisit this
+            if (grid_val > 0) {
+                grid_val = min(grid_val, 16);
+                game->observations[feat3_idx + grid_val - 1] = 1;
             }
         }
     }
-    return max_tile;
+    // Additional obs
+    int offset = num_cell * NUM_FEATURES;
+    game->observations[offset] = game->is_snake_state;
 }
 
 void add_log(Game* game) {
-    unsigned char s = get_max_tile(game);
-    game->log.score += (float)(1 << s);
-    game->log.perf += (float)(1 << s) / OBSERVED_MAX_TILE;
+    // Scaffolding runs will distort stats, so skip logging
+    if (game->is_endgame_env || game->is_scaffolding_episode) return;
+
+    // Update the lifetime best
+    if (game->max_tile > game->lifetime_max_tile) {
+        game->lifetime_max_tile = game->max_tile;
+    }
+    
+    game->log.score += (float)(1 << game->max_tile);
+    game->log.perf += calculate_perf(game->max_tile);
     game->log.merge_score += (float)game->score;
     game->log.episode_length += game->tick;
     game->log.episode_return += game->episode_reward;
+    game->log.lifetime_max_tile += (float)(1 << game->lifetime_max_tile);
+    game->log.reached_32768 += (game->max_tile >= 15);
+    game->log.reached_65536 += (game->max_tile >= 16);
+    game->log.snake_state += (float)game->snake_state_tick / (float)game->tick;
+    game->log.monotonicity_reward += game->monotonicity_reward * MONOTONICITY_REWARD_WEIGHT * game->reward_scaler;
+    game->log.snake_reward += game->snake_reward * game->snake_reward_weight * game->reward_scaler;
     game->log.n += 1;
 }
 
-void c_reset(Game* game) {
+static inline unsigned char get_new_tile(void) {
+    // 10% chance of 2, 90% chance of 1
+    return (rand() % 10 == 0) ? 2 : 1;
+}
+
+static inline void place_tile_at_random_cell(Game* game, unsigned char tile) {
+    if (game->empty_count == 0) return;
+
+    int target = rand() % game->empty_count;
+    int pos = 0;
     for (int i = 0; i < SIZE; i++) {
         for (int j = 0; j < SIZE; j++) {
-            game->grid[i][j] = EMPTY;
+            if (game->grid[i][j] == EMPTY) {
+                if (pos == target) {
+                    game->grid[i][j] = tile;
+                    game->empty_count--;
+                    return;
+                }
+                pos++;
+            }
         }
     }
+}
 
+void set_scaffolding_curriculum(Game* game) {
+    game->stop_at_65536 = true;
+
+    if (game->lifetime_max_tile < 14) {
+        int curriculum = rand() % 5;
+
+        // Spawn one high tiles from 8192, 16384, 32768, 65536
+        unsigned char high_tile = max(12 + curriculum, game->lifetime_max_tile);
+        place_tile_at_random_cell(game, high_tile);
+        if (high_tile >= 16) game->stop_at_65536 = false;
+
+    } else {
+        int curriculum = rand() % 8;
+
+        if (curriculum < 2) { // curriculum 0, 1
+            place_tile_at_random_cell(game, 14 + curriculum); // Spawn one of 16384 or 32768
+
+        } else if (curriculum == 2) {
+            // Place the tiles in the second row, so that they can be moved up in the first move
+            unsigned char tiles[] = {14, 13};
+            memcpy(game->grid[1], tiles, 2);
+            game->empty_count -= 2;
+        } else if (curriculum == 3) {  // harder
+            game->grid[1][0] = 14; game->empty_count--;
+            place_tile_at_random_cell(game, 13);
+
+        } else if (curriculum == 4) {
+            unsigned char tiles[] = {15, 14};
+            memcpy(game->grid[1], tiles, 2);
+            game->empty_count -= 2;
+        } else if (curriculum == 5) {  // harder
+            game->grid[1][0] = 15; game->empty_count--;
+            place_tile_at_random_cell(game, 14);
+
+        } else if (curriculum == 6) {
+            unsigned char tiles[] = {15, 14, 13};
+            memcpy(game->grid[1], tiles, 3);
+            game->empty_count -= 3;
+        } else if (curriculum == 7) {  // harder
+            game->grid[1][0] = 15; game->empty_count--;
+            place_tile_at_random_cell(game, 14);
+            place_tile_at_random_cell(game, 13);
+        }
+    }
+}
+
+void set_endgame_curriculum(Game* game) {
+    game->stop_at_65536 = true;
+    int curriculum = rand() % 4;
+
+    // Place the tiles in the second-third rows, so that they can be moved up in the first move
+    unsigned char tiles[] = {15, 14, 13, 12};
+    memcpy(game->grid[1], tiles, 4);
+    game->empty_count -= 4;
+
+    if (curriculum >= 1) { game->grid[2][3] = 11; game->empty_count--; }
+    if (curriculum >= 2) { 
+        game->grid[2][2] = 10;
+        game->grid[2][1] = 9;
+        game->grid[2][0] = 8;
+        game->empty_count -= 3;
+    }
+}
+
+void c_reset(Game* game) {
+    memset(game->grid, EMPTY, SIZE * SIZE);
     game->score = 0;
     game->tick = 0;
     game->episode_reward = 0;
@@ -139,56 +294,39 @@ void c_reset(Game* game) {
     game->grid_changed = true;
     game->moves_made = 0;
     game->max_episode_ticks = BASE_MAX_TICKS;
-    
-    if (game->terminals) game->terminals[0] = 0;
-    
-    // Add two random tiles at the start - optimized version
-    for (int added = 0; added < 2; ) {
-        int pos = rand() % (SIZE * SIZE);
-        int i = pos / SIZE;
-        int j = pos % SIZE;
-        if (game->grid[i][j] == EMPTY) {
-            game->grid[i][j] = (rand() % 10 == 0) ? 2 : 1;
-            added++;
-            game->empty_count--;
-        }
-    }
-    
-    update_observations(game);
-}
+    game->max_tile = 0;
+    game->snake_state_tick = 0;
+    game->monotonicity_reward = 0;
+    game->snake_reward = 0;
+    game->is_snake_state = false;
+    game->stop_at_65536 = game->can_go_over_65536;
 
-void add_random_tile(Game* game) {
-    if (game->empty_count == 0) return;
-    
-    // Use reservoir sampling for better performance
-    int chosen_pos = -1;
-    int count = 0;
-    
-    for (int pos = 0; pos < SIZE * SIZE; pos++) {
-        int i = pos / SIZE;
-        int j = pos % SIZE;
-        if (game->grid[i][j] == EMPTY) {
-            count++;
-            if (rand() % count == 0) {
-                chosen_pos = pos;
+    if (game->terminals) game->terminals[0] = 0;
+
+    // End game envs only do endgame curriculum
+    if (game->is_endgame_env) {
+        set_endgame_curriculum(game);
+
+    } else {
+        // Higher tiles are spawned in scaffolding episodes
+        // Having high tiles saves moves to get there, allowing agents to experience it faster
+        game->is_scaffolding_episode = (rand() / (float)RAND_MAX) < game->scaffolding_ratio;
+        if (game->is_scaffolding_episode) {
+            set_scaffolding_curriculum(game);
+
+        } else {
+            // Add two random tiles at the start
+            for (int i = 0; i < 2; i++) {
+                place_tile_at_random_cell(game, get_new_tile());
             }
         }
     }
-    
-    if (chosen_pos >= 0) {
-        int i = chosen_pos / SIZE;
-        int j = chosen_pos % SIZE;
-        // Implement the 90% 2, 10% 4 rule
-        game->grid[i][j] = (rand() % 10 == 0) ? 2 : 1;
-        game->empty_count--;
-        game->grid_changed = true;
-    }
-    
+
     update_observations(game);
 }
 
 // Optimized slide and merge with fewer memory operations
-static inline bool slide_and_merge(unsigned char* row, float* reward, float* score_increase) {
+static inline bool slide_and_merge(Game* game, unsigned char* row, float* reward, float* score_increase) {
     bool moved = false;
     int write_pos = 0;
     
@@ -208,7 +346,7 @@ static inline bool slide_and_merge(unsigned char* row, float* reward, float* sco
     for (int i = 0; i < SIZE - 1; i++) {
         if (row[i] != EMPTY && row[i] == row[i + 1]) {
             row[i]++;
-            *reward += ((float)row[i]) * REWARD_MULTIPLIER;
+            *reward += ((float)row[i]) * MERGE_REWARD_WEIGHT;
             *score_increase += (float)(1 << (int)row[i]);
             // Shift remaining elements left
             for (int j = i + 1; j < SIZE - 1; j++) {
@@ -234,7 +372,7 @@ bool move(Game* game, int direction, float* reward, float* score_increase) {
                 temp[i] = game->grid[idx][col];
             }
             
-            if (slide_and_merge(temp, reward, score_increase)) {
+            if (slide_and_merge(game, temp, reward, score_increase)) {
                 moved = true;
                 // Write back column
                 for (int i = 0; i < SIZE; i++) {
@@ -251,7 +389,7 @@ bool move(Game* game, int direction, float* reward, float* score_increase) {
                 temp[i] = game->grid[row][idx];
             }
             
-            if (slide_and_merge(temp, reward, score_increase)) {
+            if (slide_and_merge(game, temp, reward, score_increase)) {
                 moved = true;
                 // Write back row
                 for (int i = 0; i < SIZE; i++) {
@@ -305,41 +443,187 @@ bool is_game_over(Game* game) {
     return true;
 }
 
+// Combined grid stats and heuristic calculation for performance
+float update_stats_and_get_heuristic_rewards(Game* game) {
+    int empty_count = 0;
+    int top_row_count = 0;
+    unsigned char max_tile = 0;
+    unsigned char second_max_tile = 0;
+    unsigned char max_tile_in_row234 = 0;
+    float heuristic_state_reward = 0.0f;
+    float monotonicity_reward = 0.0f;
+    float snake_reward = 0.0f;
+    game->is_snake_state = false;
+    
+    for (int i = 0; i < SIZE; i++) {
+        for (int j = 0; j < SIZE; j++) {
+            unsigned char val = game->grid[i][j];
+            
+            // Update empty count and max tile
+            if (val == EMPTY) empty_count++;
+
+            // Count filled cells in the top row
+            if (i == 0 && val != EMPTY) top_row_count++;
+            
+            // Allow max and the second max tile to be the same
+            if (val >= max_tile) {
+                second_max_tile = max_tile;
+                max_tile = val;
+            } else if (val > second_max_tile && val < max_tile) {
+                second_max_tile = val;
+            }
+
+            // Get the max tile in the 2nd, 3rd, 4th row
+            if (i > 0 && val > max_tile_in_row234) max_tile_in_row234 = val;
+        }
+    }
+
+    game->empty_count = empty_count;
+    game->max_tile = max_tile;
+
+    /* Heuristic rewards */
+
+    // Filled top row reward: A simple nudge to keep the top row filled
+    if (top_row_count == SIZE) heuristic_state_reward += STATE_REWARD_WEIGHT;
+
+    bool max_in_top_left = (game->grid[0][0] == max_tile);
+
+    // Corner reward: A simple nudge to keep the max tiles horizontally in the top row, left corner.
+    // When agents learn to put the max tile on the other corners, or put max tiles vertically
+    // they miss out snake rew, and this does happen sometimes.
+    if (max_in_top_left && game->grid[0][1] == second_max_tile && max_tile > 4) {
+        heuristic_state_reward += STATE_REWARD_WEIGHT;
+    }
+
+    // Snake reward: look for the snake pattern, only when the max tile is at top left
+    if (max_in_top_left) {
+        monotonicity_reward += pow_1_5_lookup[max_tile];
+        int evidence_for_snake = 0;
+
+        for (int i = 0; i < 2; i++) {
+            unsigned char row_min = 32;
+            unsigned char next_row_max = 0;
+            for (int j = 0; j < SIZE; j++) {
+                unsigned char val = game->grid[i][j];
+
+                // Check horizontal monotonicity (snake pattern) for top two rows only
+                if (j < SIZE - 1) {
+                    unsigned char next_col = game->grid[i][j+1];
+                    if (val != EMPTY && next_col != EMPTY) {
+                        // Row 0: Reward decreasing left to right, e.g., 12-11-10-9
+                        if (i == 0 && val > next_col) {
+                            monotonicity_reward += pow_1_5_lookup[next_col];
+                            evidence_for_snake++;
+                        }
+                        // Row 1: Reward increasing left to right, e.g., 5-6-7-8
+                        else if (i == 1 && val < next_col) {
+                            monotonicity_reward += pow_1_5_lookup[val];
+                        }
+                    }
+                }
+
+                // Vertical monotonicity: give score after row scanning for min/max is done
+                if (val != EMPTY && val < row_min) row_min = val;
+                unsigned char next_row = game->grid[i+1][j];
+                if (next_row != EMPTY && next_row > next_row_max) next_row_max = next_row;
+                // // Small column-level vertical reward
+                if (val != EMPTY && next_row != EMPTY && val > next_row) monotonicity_reward += next_row;
+            }
+            // Large row-level vertical reward
+            if (i < 2 && row_min < 20 && next_row_max > 0 && row_min > next_row_max) {
+                monotonicity_reward += 4 * pow_1_5_lookup[row_min];
+                if (i == 0) evidence_for_snake++;
+            }
+        }
+
+        // Snake bonus: sorted top row + the max_tile_in_row234 in the second row right
+        // For example, top row: 14-13-12-11, second row: ()-()-()-10
+        unsigned char snake_tail = game->grid[1][3];
+        if (evidence_for_snake >= 4 && snake_tail == max_tile_in_row234) {
+            game->is_snake_state = true;
+            game->snake_state_tick++;
+            snake_reward = snake_tail * snake_tail;
+        }
+    }
+
+    // Trained models need game->is_snake_state as obs
+    if (!game->use_heuristic_rewards) return 0.0f;
+
+    game->monotonicity_reward += monotonicity_reward;
+    game->snake_reward += snake_reward;
+    
+    return heuristic_state_reward + monotonicity_reward * MONOTONICITY_REWARD_WEIGHT + snake_reward * game->snake_reward_weight;
+}
+
 void c_step(Game* game) {
     float reward = 0.0f;
     float score_add = 0.0f;
+    unsigned char prev_max_tile = game->max_tile;
     bool did_move = move(game, game->actions[0] + 1, &reward, &score_add);
     game->tick++;
-    
+
     if (did_move) {
         game->moves_made++;
-        add_random_tile(game);
+        place_tile_at_random_cell(game, get_new_tile());
         game->score += score_add;
-        update_empty_count(game); // Update after adding tile
-        // This is to limit infinite invalid moves during eval
-        // Don't need to be tight. Don't need to show to user?
-        game->max_episode_ticks = max(BASE_MAX_TICKS, game->score / 10);
+
+        // Add heuristic rewards/penalties and update grid stats
+        reward += update_stats_and_get_heuristic_rewards(game);
+        reward *= game->reward_scaler;
+
+        update_observations(game); // Observations only change if the grid changes
+        
+        // This is to limit infinite invalid moves during eval (happens for noob agents)
+        // Don't need to be tight. Don't need to show to human player.
+        int tick_multiplier = max(1, game->lifetime_max_tile - 8); // practically no limit for competent agent
+        game->max_episode_ticks = max(BASE_MAX_TICKS * tick_multiplier, game->score / 4);
+
     } else {
         reward = INVALID_MOVE_PENALTY;
+        // No need to update observations if the grid hasn't changed
     }
 
     bool game_over = is_game_over(game);
     bool max_ticks_reached = game->tick >= game->max_episode_ticks;
-    game->terminals[0] = (game_over || max_ticks_reached) ? 1 : 0;
+    bool max_level_reached = game->stop_at_65536 && game->max_tile >= 16;
+    game->terminals[0] = (game_over || max_ticks_reached || max_level_reached) ? 1 : 0;
 
+    // Game over penalty overrides other rewards
     if (game_over) {
         reward = GAME_OVER_PENALTY;
     }
-    
+
+    if (game->use_sparse_reward) {
+        reward = 0; // Ignore all previous reward
+        if (game->max_tile >= 14 && game->max_tile > prev_max_tile) reward = 1;
+    }
+
     game->rewards[0] = reward;
     game->episode_reward += reward;
-
-    update_observations(game);
 
     if (game->terminals[0]) {
         add_log(game);
         c_reset(game);
     }
+}
+
+// Stepping for client/eval: no reward, no reset
+void step_without_reset(Game* game) {
+    float score_add = 0.0f;
+    float reward = 0.0f;
+    bool did_move = move(game, game->actions[0] + 1, &reward, &score_add);
+    game->tick++;
+
+    if (did_move) {
+        game->moves_made++;
+        place_tile_at_random_cell(game, get_new_tile());
+        game->score += score_add;
+        update_stats_and_get_heuristic_rewards(game); // The reward is ignored.
+        update_observations(game); // Observations only change if the grid changes
+    }
+
+    bool game_over = is_game_over(game);
+    game->terminals[0] = (game_over) ? 1 : 0;
 }
 
 // Rendering optimizations
@@ -368,9 +652,8 @@ void c_render(Game* game) {
             int val = game->grid[i][j];
             
             // Use precomputed colors
-            Color color = (val == 0) ? tile_colors[0] : 
-                         (val <= 11) ? tile_colors[val] : 
-                         (Color){60, 60, 60, 255};
+            int color_idx = min(val, 16); // Cap at the max index of our color array
+            Color color = tile_colors[color_idx];
             
             DrawRectangle(j * px, i * px, px - 5, px - 5, color);
             
@@ -378,11 +661,20 @@ void c_render(Game* game) {
                 int display_val = 1 << val; // Power of 2
                 // Pre-format text to avoid repeated formatting
                 snprintf(score_text, sizeof(score_text), "%d", display_val);
-                if (display_val < 1000) {
-                    DrawText(score_text, j * px + 30, i * px + 40, 32, PUFF_WHITE);
-                } else {
-                    DrawText(score_text, j * px + 20, i * px + 40, 32, PUFF_WHITE);
+
+                int font_size = 32;
+                int x_offset = 20; // Default for 4-digit numbers
+                if (display_val < 10) x_offset = 40; // 1-digit
+                else if (display_val < 100) x_offset = 35; // 2-digit
+                else if (display_val < 1000) x_offset = 25; // 3-digit
+                else if (display_val < 10000) x_offset = 15; // 4-digit
+                else if (display_val < 100000) x_offset = 2; // 5-digit
+                else {
+                    font_size = 24;
+                    x_offset = 5;
                 }
+
+                DrawText(score_text, j * px + x_offset, i * px + 34, font_size, PUFF_WHITE);
             }
         }
     }

--- a/pufferlib/ocean/g2048/g2048.py
+++ b/pufferlib/ocean/g2048/g2048.py
@@ -7,19 +7,37 @@ import pufferlib
 from pufferlib.ocean.g2048 import binding
 
 class G2048(pufferlib.PufferEnv):
-    def __init__(self, num_envs=1, render_mode=None, log_interval=128, buf=None, seed=0):
+    def __init__(self, num_envs=1, reward_scaler=1.0,
+                 can_go_over_65536=False, endgame_env_prob=0.0, scaffolding_ratio=0.0,
+                 use_heuristic_rewards=False, snake_reward_weight=0.0, use_sparse_reward=False,
+                 render_mode=None, log_interval=128, buf=None, seed=0):
         self.single_observation_space = gymnasium.spaces.Box(
-            low=0, high=100, shape=(4,4), dtype=np.uint8
+            low=0, high=100, shape=(16*18 + 1,), dtype=np.uint8
         )
         self.single_action_space = gymnasium.spaces.Discrete(4)
         self.render_mode = render_mode
         self.num_agents = num_envs
         self.log_interval = log_interval
 
+        self.can_go_over_65536 = can_go_over_65536
+        self.reward_scaler = reward_scaler
+        self.endgame_env_prob = endgame_env_prob
+        self.scaffolding_ratio = scaffolding_ratio
+        self.use_heuristic_rewards = use_heuristic_rewards
+        self.snake_reward_weight = snake_reward_weight
+        self.use_sparse_reward = use_sparse_reward
+
         super().__init__(buf)
         self.c_envs = binding.vec_init(
             self.observations, self.actions, self.rewards,
-            self.terminals, self.truncations, num_envs, seed
+            self.terminals, self.truncations, num_envs, seed,
+            can_go_over_65536 = self.can_go_over_65536,
+            reward_scaler = self.reward_scaler,
+            endgame_env_prob = self.endgame_env_prob,
+            scaffolding_ratio = self.scaffolding_ratio,
+            use_heuristic_rewards = self.use_heuristic_rewards,
+            snake_reward_weight = self.snake_reward_weight,
+            use_sparse_reward = self.use_sparse_reward
         )
 
     def reset(self, seed=0):
@@ -67,3 +85,5 @@ if __name__ == '__main__':
         i += 1
 
     print('2048 SPS:', int(steps / (time.time() - start)))
+
+    env.close()

--- a/pufferlib/ocean/g2048/g2048_net.h
+++ b/pufferlib/ocean/g2048/g2048_net.h
@@ -1,0 +1,104 @@
+#include "puffernet.h"
+
+typedef struct G2048Net G2048Net;
+
+struct G2048Net {
+    int hidden_dim;
+    float* obs;
+    Linear* layer1;
+    GELU* gelu1;
+    Linear* layer2;
+    GELU* gelu2;
+    Linear* layer3;
+    GELU* gelu3;
+    Linear* actor_hidden;
+    GELU* gelu_actor;
+    Linear* actor_head;
+    Linear* value_hidden;
+    GELU* gelu_value;
+    Linear* value_head;
+    LSTM* lstm;
+    Multidiscrete* multidiscrete;
+};
+
+G2048Net* make_g2048net(Weights* weights, int input_dim, int hidden_dim) {
+    G2048Net* net = calloc(1, sizeof(G2048Net));
+    const int num_agents = 1;
+    const int num_actions = 1;
+    const int atn_sum = 4;
+
+    int logit_sizes[1] = {4};
+    net->obs = calloc(num_agents*input_dim, sizeof(float));
+    net->hidden_dim = hidden_dim;
+
+    if (hidden_dim <= 256) {
+        net->layer1 = make_linear(weights, num_agents, input_dim, 512);
+        net->gelu1 = make_gelu(num_agents, 512);
+        net->layer2 = make_linear(weights, num_agents, 512, 256);
+        net->gelu2 = make_gelu(num_agents, 256);
+        net->layer3 = make_linear(weights, num_agents, 256, hidden_dim);
+        net->gelu3 = make_gelu(num_agents, hidden_dim);
+    } else {
+        net->layer1 = make_linear(weights, num_agents, input_dim, 2*hidden_dim);
+        net->gelu1 = make_gelu(num_agents, 2*hidden_dim);
+        net->layer2 = make_linear(weights, num_agents, 2*hidden_dim, hidden_dim);
+        net->gelu2 = make_gelu(num_agents, hidden_dim);
+        net->layer3 = make_linear(weights, num_agents, hidden_dim, hidden_dim);
+        net->gelu3 = make_gelu(num_agents, hidden_dim);
+    }
+
+    net->actor_hidden = make_linear(weights, num_agents, hidden_dim, hidden_dim);
+    net->gelu_actor = make_gelu(num_agents, hidden_dim);
+    net->actor_head = make_linear(weights, num_agents, hidden_dim, atn_sum);
+
+    net->value_hidden = make_linear(weights, num_agents, hidden_dim, hidden_dim);
+    net->gelu_value = make_gelu(num_agents, hidden_dim);
+    net->value_head = make_linear(weights, num_agents, hidden_dim, 1);
+
+    net->lstm = make_lstm(weights, num_agents, hidden_dim, hidden_dim);
+    net->multidiscrete = make_multidiscrete(num_agents, logit_sizes, num_actions);
+    return net;
+}
+
+void free_g2048net(G2048Net* net) {
+    free(net->obs);
+    free(net->layer1);
+    free(net->gelu1);
+    free(net->layer2);
+    free(net->gelu2);
+    free(net->layer3);
+    free(net->gelu3);
+
+    free(net->actor_hidden);
+    free(net->gelu_actor);
+    free(net->actor_head);
+    free(net->value_hidden);
+    free(net->gelu_value);
+    free(net->value_head);
+
+    free(net->lstm);
+    free(net->multidiscrete);
+    free(net);
+}
+
+void forward_g2048net(G2048Net* net, unsigned char* observations, int* actions) {
+    for (int i = 0; i < net->layer1->input_dim; i++) {
+        net->obs[i] = (float)observations[i];
+        if (i < 16) net->obs[i] /= 100.0f;
+    }
+
+    linear(net->layer1, net->obs);
+    gelu(net->gelu1, net->layer1->output);
+    linear(net->layer2, net->gelu1->output);
+    gelu(net->gelu2, net->layer2->output);
+    linear(net->layer3, net->gelu2->output);
+    gelu(net->gelu3, net->layer3->output);
+
+    lstm(net->lstm, net->gelu3->output);
+
+    // Actor only. Don't need critic in inference
+    linear(net->actor_hidden, net->lstm->state_h);
+    gelu(net->gelu_actor, net->actor_hidden->output);
+    linear(net->actor_head, net->gelu_actor->output);
+    softmax_multidiscrete(net->multidiscrete, net->actor_head->output, actions);
+}

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -184,7 +184,8 @@ class PuffeRL:
 
         # Learning rate scheduler
         epochs = config['total_timesteps'] // config['batch_size']
-        self.scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
+        self.scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer, T_max=epochs, eta_min=config['min_learning_rate'])
         self.total_epochs = epochs
 
         # Automatic mixed precision
@@ -1055,7 +1056,10 @@ def sweep(args=None, env_name=None):
         np.random.seed(seed)
         torch.manual_seed(seed)
 
-        sweep.suggest(args)
+        # In the first run, skip sweep and use the train args specified in the config
+        if i > 0:
+            sweep.suggest(args)
+
         all_logs = train(env_name, args=args, should_stop_early=stop_if_loss_nan)
         all_logs = [e for e in all_logs if target_key in e]
 

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1040,6 +1040,7 @@ def sweep(args=None, env_name=None):
     args = args or load_config(env_name)
     if not args['wandb'] and not args['neptune']:
         raise pufferlib.APIUsageError('Sweeps require either wandb or neptune')
+    args['no_model_upload'] = True  # Uploading trained model during sweep crashed wandb
 
     method = args['sweep'].pop('method')
     try:

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -17,6 +17,7 @@ from gpytorch.mlls import ExactMarginalLogLikelihood
 from gpytorch.priors import LogNormalPrior
 from scipy.stats.qmc import Sobol
 from scipy.spatial import KDTree
+from sklearn.linear_model import LogisticRegression
 
 EPSILON = 1e-6
 
@@ -126,17 +127,24 @@ class Logit(Space):
         log_spaced = zero_one*(math.log(1-self.max, self.base) - math.log(1-self.min, self.base)) + math.log(1-self.min, self.base)
         return 1 - self.base**log_spaced
 
-def _params_from_puffer_sweep(sweep_config):
+def _params_from_puffer_sweep(sweep_config, only_include=None):
     param_spaces = {}
+
+    if 'sweep_only' in sweep_config:
+        only_include = [p.strip() for p in sweep_config['sweep_only'].split(',')]
+
     for name, param in sweep_config.items():
-        if name in ('method', 'metric', 'goal', 'downsample', 'use_gpu', 'prune_pareto'):
+        if name in ('method', 'metric', 'goal', 'downsample', 'use_gpu', 'prune_pareto', 'sweep_only', 'max_suggestion_cost'):
             continue
 
         assert isinstance(param, dict)
         if any(isinstance(param[k], dict) for k in param):
-            param_spaces[name] = _params_from_puffer_sweep(param)
+            param_spaces[name] = _params_from_puffer_sweep(param, only_include)
             continue
  
+        if only_include and not any(k in name for k in only_include):
+            continue
+
         assert 'distribution' in param
         distribution = param['distribution']
         search_center = param['mean']
@@ -232,8 +240,8 @@ class Hyperparameters:
         return idx
 
     def get_flat_idx(self, flat_key):
-        return list(self.flat_spaces.keys()).index(flat_key)
-
+        keys = list(self.flat_spaces.keys())
+        return keys.index(flat_key) if flat_key in keys else None
 
 def pareto_points(observations):
     if not observations:
@@ -421,7 +429,7 @@ class Protein:
             sweep_config,
             max_suggestion_cost = 3600,
             resample_frequency = 0,
-            num_random_samples = 30,
+            num_random_samples = 10,
             global_search_scale = 1,
             suggestions_per_pareto = 256,
             seed_with_search_center = True,
@@ -435,21 +443,27 @@ class Protein:
             cost_param = "train/total_timesteps",
             prune_pareto = True,
         ):
-        self.device = torch.device("cuda:0" if use_gpu and torch.cuda.is_available() else "cpu")
+        # Process sweep config. NOTE: sweep_config takes precedence. It's not good.
+        _use_gpu = sweep_config['use_gpu'] if 'use_gpu' in sweep_config else use_gpu
+        _prune_pareto = sweep_config['prune_pareto'] if 'prune_pareto' in sweep_config else prune_pareto
+        _max_suggestion_cost = sweep_config['max_suggestion_cost'] if 'max_suggestion_cost' in sweep_config else max_suggestion_cost
+
+        self.device = torch.device("cuda:0" if _use_gpu and torch.cuda.is_available() else "cpu")
         self.hyperparameters = Hyperparameters(sweep_config)
         self.global_search_scale = global_search_scale
         self.suggestions_per_pareto = suggestions_per_pareto
         self.seed_with_search_center = seed_with_search_center
         self.resample_frequency = resample_frequency
-        self.max_suggestion_cost = max_suggestion_cost
+        self.max_suggestion_cost = _max_suggestion_cost
         self.expansion_rate = expansion_rate
         self.gp_training_iter = gp_training_iter
         self.gp_learning_rate = gp_learning_rate
         self.optimizer_reset_frequency = optimizer_reset_frequency
-        self.prune_pareto = prune_pareto
+        self.prune_pareto = _prune_pareto
 
         self.success_observations = []
         self.failure_observations = []
+
         self.suggestion_idx = 0
         self.min_score, self.max_score = math.inf, -math.inf
         self.log_c_min, self.log_c_max = math.inf, -math.inf
@@ -462,10 +476,16 @@ class Protein:
         # self.num_random_samples = 3 * points_per_run * self.hyperparameters.num
 
         self.cost_param_idx = self.hyperparameters.get_flat_idx(cost_param)
-        self.cost_random_suggestion = self.hyperparameters.search_centers[self.cost_param_idx]
+        self.cost_random_suggestion = None
+        if self.cost_param_idx is not None:
+            self.cost_random_suggestion = self.hyperparameters.search_centers[self.cost_param_idx]
 
         self.gp_max_obs = gp_max_obs  # train time bumps after 800?
         self.infer_batch_size = infer_batch_size
+
+        # Probably useful only when downsample=1 and each run is expensive.
+        self.use_success_prob = sweep_config['downsample'] == 1
+        self.success_classifier = LogisticRegression(class_weight='balanced')
 
         # Use 64 bit for GP regression
         with default_tensor_dtype(torch.float64):
@@ -514,17 +534,29 @@ class Protein:
         if not self.success_observations:
             return []
 
+        observations = self.success_observations.copy()
+
         # Update the stats using the full data
-        y = np.array([e['output'] for e in self.success_observations])
+        y = np.array([e['output'] for e in observations])
         self.min_score, self.max_score = y.min(), y.max()
 
-        c = np.array([e['cost'] for e in self.success_observations])
+        c = np.array([e['cost'] for e in observations])
         log_c = np.log(np.maximum(c, EPSILON))
         self.log_c_min, self.log_c_max = log_c.min(), log_c.max()
 
-        params = np.array([e['input'] for e in self.success_observations])
+        # When the data is scare, also use failed observations
+        if len(observations) < 100 and self.failure_observations:
+            # Give the min score for the failed obs, so this value will keep changing.
+            for e in self.failure_observations:
+                e['output'] = self.min_score
+            
+            # NOTE: the order of obs matters since recent obs are always fed into gp training
+            # So, putting the failure obs first.
+            observations = self.failure_observations + observations
+
+        params = np.array([np.append(e['input'], [e['output'], e['cost']]) for e in observations])
         dedup_indices = self._filter_near_duplicates(params)
-        observations = [self.success_observations[i] for i in dedup_indices]
+        observations = [observations[i] for i in dedup_indices]
 
         if max_size is None:
             max_size = self.gp_max_obs
@@ -574,16 +606,19 @@ class Protein:
     def suggest(self, fill):
         info = {}
         self.suggestion_idx += 1
-        if len(self.success_observations) == 0 and self.seed_with_search_center:
-            suggestion = self.hyperparameters.search_centers
-            return self.hyperparameters.to_dict(suggestion, fill), info
+        
+        # NOTE: Changed pufferl to use the train args, NOT the sweep hyperparam search center
+        # if len(self.success_observations) == 0 and self.seed_with_search_center:
+        #     suggestion = self.hyperparameters.search_centers
+        #     return self.hyperparameters.to_dict(suggestion, fill), info
 
-        elif len(self.success_observations) < self.num_random_samples:
+        if self.suggestion_idx <= self.num_random_samples:
             # Suggest the next point in the Sobol sequence
             zero_one = self.sobol.random(1)[0]
             suggestion = 2*zero_one - 1  # Scale from [0, 1) to [-1, 1)
-            cost_suggestion = self.cost_random_suggestion + 0.1 * np.random.randn()
-            suggestion[self.cost_param_idx] = np.clip(cost_suggestion, -1, 1)  # limit the cost
+            if self.cost_param_idx is not None:
+                cost_suggestion = self.cost_random_suggestion + 0.1 * np.random.randn()
+                suggestion[self.cost_param_idx] = np.clip(cost_suggestion, -1, 1)  # limit the cost
             return self.hyperparameters.to_dict(suggestion, fill), info
 
         elif self.resample_frequency and self.suggestion_idx % self.resample_frequency == 0:
@@ -601,14 +636,13 @@ class Protein:
             self.cost_opt = torch.optim.Adam(self.gp_cost.parameters(), lr=self.gp_learning_rate, amsgrad=True)
        
         candidates, pareto_idxs = pareto_points(self.success_observations)
-
         if self.prune_pareto:
             candidates = prune_pareto_front(candidates)
 
         ### Sample suggestions
         search_centers = np.stack([e['input'] for e in candidates])
-        suggestions = self.hyperparameters.sample(
-            len(candidates)*self.suggestions_per_pareto, mu=search_centers)
+        num_sample = len(candidates) * self.suggestions_per_pareto
+        suggestions = self.hyperparameters.sample(num_sample, mu=search_centers)
 
         dedup_indices = self._filter_near_duplicates(suggestions)
         suggestions = suggestions[dedup_indices]
@@ -655,16 +689,31 @@ class Protein:
         gp_log_c = gp_log_c_norm*(self.log_c_max - self.log_c_min) + self.log_c_min
         gp_c = np.exp(gp_log_c)
 
-        max_c_mask = gp_c < self.max_suggestion_cost
+        # Maximize score. (Tried upper confidence bounds, but it did more harm because gp was noisy)
+        suggestion_scores = self.hyperparameters.optimize_direction * gp_y_norm
 
+        # Then, decide the budget for this session and favor closer suggestions
+        max_c_mask = gp_c < self.max_suggestion_cost
         target = (1 + self.expansion_rate)*np.random.rand()
         weight = 1 - abs(target - gp_log_c_norm)
+        suggestion_scores *= max_c_mask * weight
 
-        # NOTE: Tried upper confidence bounds, but it did more harm because gp was noisy
-        score = gp_y_norm
-
-        suggestion_scores = self.hyperparameters.optimize_direction * max_c_mask * (
-                score * weight)
+        # Then, consider the prob of training success, only when downsample = 1
+        # NOTE: Useful only in limited scenarios, where each data point is expensive. So turn it off by default.
+        if self.use_success_prob and len(self.success_observations) > 9 and len(self.failure_observations) > 9:
+            success_params = np.array([e['input'] for e in self.success_observations])
+            failure_params = np.array([e['input'] for e in self.failure_observations])
+            X_train = np.vstack([success_params, failure_params])
+            y_train = np.concatenate([
+                np.ones(len(success_params)),
+                np.zeros(len(failure_params))
+            ])
+            if len(np.unique(y_train)) > 1:
+                self.success_classifier.fit(X_train, y_train)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", UserWarning)
+                    p_success = self.success_classifier.predict_proba(suggestions)[:, 1]
+                suggestion_scores *= p_success
 
         best_idx = np.argmax(suggestion_scores)
         info = dict(
@@ -708,7 +757,7 @@ class Protein:
                 return
 
         # Ignore obs that are below the minimum cost
-        if params[self.cost_param_idx] <= -1:
+        if self.cost_param_idx is not None and params[self.cost_param_idx] <= -1:
             return
 
         self.success_observations.append(new_observation)

--- a/setup.py
+++ b/setup.py
@@ -288,6 +288,7 @@ if not NO_TRAIN:
         'rich_argparse',
         'imageio',
         'gpytorch',
+        'scikit-learn',
         'heavyball>=2.2.0', # contains relevant fixes compared to 1.7.2 and 2.1.1
         'neptune',
         'wandb',


### PR DESCRIPTION
The sweep/pufferl related changes are in a separate PR. Please review it first: https://github.com/PufferAI/PufferLib/pull/416

Here is the new G2048 baseline, which reaches 32k tile 71.2% and 65k tile 14.8%.

The training curves are here: https://wandb.ai/kywch/pufferlib/runs/5thsjr61?nw=nwuserkywch

The changes from the previous G2048 are:
* Augmented obs: One-hot encoding for empty spaces and each cell/tile
* Larger policy with additional layers on the encoder, actor, and critic.
* New heuristic rewards for the tile states, monotonicity, and maintaining the snake pattern
* Scaffolding curriculum: Some episodes start with big tiles, which can only be reached after 10k+ ticks.
* Endgame envs: Some envs are dedicated to only playing the short "end games", which agents can only experience after very long ticks, if any.
* A good hyperparam that was refined through ~1000 sweeps, and many blessings from 67.

<img width="422" height="505" alt="image" src="https://github.com/user-attachments/assets/62b7a4db-e583-4f46-a36e-7edbdaa362e7" />
