### PR TITLE
Adaptive early-stop thresholding in sweep

### DIFF
--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -69,7 +69,7 @@ downsample = 5
 use_gpu = True
 prune_pareto = True
 early_stop_quantile = 0.3
-early_stop_min_cost = 600
+early_stop_min_cost = 30
 
 #[sweep.vec.num_envs]
 #distribution = uniform_pow2

--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -68,6 +68,7 @@ max_suggestion_cost = 3600
 downsample = 5
 use_gpu = True
 prune_pareto = True
+early_stop_quantile = 0.3
 early_stop_min_cost = 600
 
 #[sweep.vec.num_envs]

--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -68,7 +68,6 @@ max_suggestion_cost = 3600
 downsample = 5
 use_gpu = True
 prune_pareto = True
-early_stop_pareto_fraction = 0.5
 early_stop_min_cost = 600
 
 #[sweep.vec.num_envs]

--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -68,7 +68,7 @@ max_suggestion_cost = 3600
 downsample = 5
 use_gpu = True
 prune_pareto = True
-early_stop_lcb_beta = 1.5
+early_stop_lcb_beta = 1.0
 early_stop_min_cost = 600
 
 #[sweep.vec.num_envs]

--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -69,7 +69,7 @@ downsample = 5
 use_gpu = True
 prune_pareto = True
 early_stop_lcb_beta = 1.0
-early_stop_min_cost = 300
+early_stop_min_cost = 600
 
 #[sweep.vec.num_envs]
 #distribution = uniform_pow2

--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -63,13 +63,13 @@ prio_beta0 = 0.2
 [sweep]
 method = Protein 
 metric = score
+metric_distribution = linear
 goal = maximize
 max_suggestion_cost = 3600
 downsample = 5
 use_gpu = True
 prune_pareto = True
 early_stop_quantile = 0.3
-early_stop_min_cost = 30
 
 #[sweep.vec.num_envs]
 #distribution = uniform_pow2

--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -68,6 +68,8 @@ max_suggestion_cost = 3600
 downsample = 5
 use_gpu = True
 prune_pareto = True
+early_stop_lcb_beta = 1.5
+early_stop_min_cost = 600
 
 #[sweep.vec.num_envs]
 #distribution = uniform_pow2

--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -68,7 +68,7 @@ max_suggestion_cost = 3600
 downsample = 5
 use_gpu = True
 prune_pareto = True
-early_stop_lcb_beta = 1.0
+early_stop_quantile = 0.25
 early_stop_min_cost = 600
 
 #[sweep.vec.num_envs]

--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -69,7 +69,7 @@ downsample = 5
 use_gpu = True
 prune_pareto = True
 early_stop_lcb_beta = 1.0
-early_stop_min_cost = 600
+early_stop_min_cost = 300
 
 #[sweep.vec.num_envs]
 #distribution = uniform_pow2

--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -68,7 +68,7 @@ max_suggestion_cost = 3600
 downsample = 5
 use_gpu = True
 prune_pareto = True
-early_stop_quantile = 0.25
+early_stop_pareto_fraction = 0.5
 early_stop_min_cost = 600
 
 #[sweep.vec.num_envs]

--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -102,6 +102,12 @@ min = 0.00001
 max = 0.1
 scale = 0.5
 
+[sweep.train.min_lr_ratio]
+distribution = uniform
+min = 0.0
+max = 0.5
+scale = auto
+
 [sweep.train.ent_coef]
 distribution = log_normal
 min = 0.00001

--- a/pufferlib/config/ocean/breakout.ini
+++ b/pufferlib/config/ocean/breakout.ini
@@ -53,6 +53,9 @@ vf_coef = 1.6832989594296321
 vtrace_c_clip = 2.878171091654008
 vtrace_rho_clip = 0.7876748061547312
 
+[sweep]
+early_stop_min_cost = 20
+
 [sweep.train.total_timesteps]
 distribution = log_normal
 min = 3e7

--- a/pufferlib/config/ocean/breakout.ini
+++ b/pufferlib/config/ocean/breakout.ini
@@ -54,7 +54,7 @@ vtrace_c_clip = 2.878171091654008
 vtrace_rho_clip = 0.7876748061547312
 
 [sweep]
-early_stop_min_cost = 30
+early_stop_min_cost = 40
 
 [sweep.train.total_timesteps]
 distribution = log_normal

--- a/pufferlib/config/ocean/breakout.ini
+++ b/pufferlib/config/ocean/breakout.ini
@@ -54,7 +54,6 @@ vtrace_c_clip = 2.878171091654008
 vtrace_rho_clip = 0.7876748061547312
 
 [sweep]
-early_stop_min_cost = 40
 
 [sweep.train.total_timesteps]
 distribution = log_normal

--- a/pufferlib/config/ocean/breakout.ini
+++ b/pufferlib/config/ocean/breakout.ini
@@ -54,7 +54,7 @@ vtrace_c_clip = 2.878171091654008
 vtrace_rho_clip = 0.7876748061547312
 
 [sweep]
-early_stop_min_cost = 20
+early_stop_min_cost = 30
 
 [sweep.train.total_timesteps]
 distribution = log_normal

--- a/pufferlib/config/ocean/tower_climb.ini
+++ b/pufferlib/config/ocean/tower_climb.ini
@@ -9,7 +9,7 @@ num_envs = 4
 
 [env]
 num_envs = 1024
-num_maps = 500
+num_maps = 200
 reward_climb_row = 0.27
 reward_fall_row = 0
 reward_illegal_move = 0

--- a/pufferlib/config/ocean/tower_climb.ini
+++ b/pufferlib/config/ocean/tower_climb.ini
@@ -27,35 +27,30 @@ metric_distribution = percentile
 
 [sweep.train.total_timesteps]
 distribution = uniform
-min = 30_000_000
-max = 1_000_000_000
-mean = 100_000_000
+min = 20_000_000
+max = 500_000_000
 scale = 0.5
 
 [sweep.env.reward_climb_row]
 distribution = uniform
 min = 0.0
 max = 1.0
-mean = 0.5
 scale = auto
 
 [sweep.env.reward_fall_row]
 distribution = uniform
 min = -1.0
 max = 0.0
-mean = -0.5
 scale = auto
 
 [sweep.env.reward_illegal_move]
 distribution = uniform
 min = -1e-2
 max = -1e-4
-mean = -1e-3
 scale = auto
 
 [sweep.env.reward_move_block]
 distribution = uniform
 min = 0.0
 max = 1.0
-mean = 0.5
 scale = auto

--- a/pufferlib/config/ocean/tower_climb.ini
+++ b/pufferlib/config/ocean/tower_climb.ini
@@ -21,10 +21,14 @@ total_timesteps = 150_000_000
 #learning_rate = 0.05
 minibatch_size = 32768
 
+[sweep]
+metric = perf
+metric_distribution = percentile
+
 [sweep.train.total_timesteps]
 distribution = uniform
-min = 50_000_000
-max = 200_000_000
+min = 30_000_000
+max = 1_000_000_000
 mean = 100_000_000
 scale = 0.5
 

--- a/pufferlib/config/ocean/tower_climb.ini
+++ b/pufferlib/config/ocean/tower_climb.ini
@@ -9,7 +9,7 @@ num_envs = 4
 
 [env]
 num_envs = 1024
-num_maps = 50
+num_maps = 500
 reward_climb_row = 0.27
 reward_fall_row = 0
 reward_illegal_move = 0

--- a/pufferlib/config/ocean/tower_climb.ini
+++ b/pufferlib/config/ocean/tower_climb.ini
@@ -5,21 +5,41 @@ policy_name = TowerClimb
 rnn_name = TowerClimbLSTM
 
 [vec]
-num_envs = 8
+num_envs = 4
 
 [env]
 num_envs = 1024
 num_maps = 50
-reward_climb_row = 0.636873185634613
-reward_fall_row = -0.15898257493972778
-reward_illegal_move = -0.003928301855921745
-reward_move_block = 0.235064297914505
+reward_climb_row = 0.27
+reward_fall_row = 0
+reward_illegal_move = 0
+reward_move_block = 0.18
 
 [train]
-total_timesteps = 150_000_000
-#gamma = 0.98
-#learning_rate = 0.05
-minibatch_size = 32768
+# https://wandb.ai/kywch/pufferlib/runs/8r3l9l1h?nw=nwuserkywch
+total_timesteps = 30_000_000
+anneal_lr = True
+batch_size = auto
+bptt_horizon = 64
+minibatch_size = 65536
+
+clip_coef = 1.0
+ent_coef = 0.2
+gae_lambda = 0.96
+gamma = 0.92
+vf_clip_coef = 0.1
+vf_coef = 0.34
+
+learning_rate = 0.029
+max_grad_norm = 0.8
+
+adam_beta1 = 0.89
+adam_beta2 = 0.999
+adam_eps = 2e-11
+prio_alpha = 0.86
+prio_beta0 = 0.30
+vtrace_c_clip = 0.92
+vtrace_rho_clip = 1.44
 
 [sweep]
 metric = perf
@@ -27,8 +47,8 @@ metric_distribution = percentile
 
 [sweep.train.total_timesteps]
 distribution = uniform
-min = 20_000_000
-max = 500_000_000
+min = 10_000_000
+max = 200_000_000
 scale = 0.5
 
 [sweep.env.reward_climb_row]

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -958,6 +958,7 @@ def train(env_name, args=None, vecenv=None, policy=None, logger=None, should_sto
                 all_logs.append(logs)
 
             if should_stop_early is not None and should_stop_early(logs):
+                all_logs.append({'early_stop': True})
                 model_path = pufferl.close()
                 pufferl.logger.close(model_path)
                 return all_logs
@@ -971,6 +972,7 @@ def train(env_name, args=None, vecenv=None, policy=None, logger=None, should_sto
             break
 
     logs = pufferl.mean_and_log()
+    logs.update({'early_stop': False})
     if logs is not None:
         all_logs.append(logs)
 

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1063,8 +1063,8 @@ def sweep(args=None, env_name=None):
         raise pufferlib.APIUsageError(f'Invalid sweep method {method}. See pufferlib.sweep')
 
     sweep = sweep_cls(args['sweep'])
-    points_per_run = args['sweep']['downsample']
     target_key = f'environment/{args["sweep"]["metric"]}'
+    max_score = 0
 
     def stop_if_perf_below(logs):
         if stop_if_loss_nan(logs):
@@ -1085,9 +1085,12 @@ def sweep(args=None, env_name=None):
         np.random.seed(seed)
         torch.manual_seed(seed)
 
+        points_per_run = args['sweep']['downsample']
         # In the first run, skip sweep and use the train args specified in the config
+        # Then, sample a lot of points to get the starting pareto curve
         if i > 0:
             sweep.suggest(args)
+            points_per_run *= 3
 
         all_logs = train(env_name, args=args, early_stop_fn=stop_if_perf_below)
         all_logs = [e for e in all_logs if target_key in e]
@@ -1096,13 +1099,19 @@ def sweep(args=None, env_name=None):
             sweep.observe(args, 0, 0, is_failure=True)
             continue
 
+        is_final_loss_nan = all_logs[-1].get('is_loss_nan', False)
+        curr_score = all_logs[-1][target_key]
+        if not is_final_loss_nan and curr_score > max_score:
+            max_score = curr_score
+            # Sample more points from the new best run
+            points_per_run *= 3
+
         total_timesteps = args['train']['total_timesteps']
 
         scores = downsample([log[target_key] for log in all_logs], points_per_run)
         costs = downsample([log['uptime'] for log in all_logs], points_per_run)
         timesteps = downsample([log['agent_steps'] for log in all_logs], points_per_run)
 
-        is_final_loss_nan = all_logs[-1].get('is_loss_nan', False)
         if is_final_loss_nan:
             s = scores.pop()
             c = costs.pop()

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1068,7 +1068,7 @@ def sweep(args=None, env_name=None):
             return True
 
         if ('uptime' in logs and target_key in logs):
-            threshold = sweep.query_early_stop_threshold(logs['uptime'])
+            threshold = sweep.get_early_stop_threshold(logs['uptime'])
             logs['early_stop_treshold'] = max(threshold, 0)  # clipping for visualization
             if logs[target_key] < threshold:
                 return True

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1078,7 +1078,7 @@ def sweep(args=None, env_name=None):
             threshold = sweep.get_early_stop_threshold(logs['uptime'])
             logs['early_stop_treshold'] = max(threshold, 0)  # clipping for visualization
 
-            if target_running_mean < threshold:
+            if max(target_running_mean, logs[target_key]) < threshold:
                 logs['is_loss_nan'] = False
                 return True
         return False

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -963,8 +963,8 @@ def train(env_name, args=None, vecenv=None, policy=None, logger=None, early_stop
             if early_stop_fn is not None:
                 should_stop_early = early_stop_fn(logs)
                 # This is hacky, but need to see if threshold looks reasonable
-                if 'early_stop_treshold' in logs:
-                    pufferl.logger.log({'environment/early_stop_treshold': logs['early_stop_treshold']}, logs['agent_steps'])
+                if 'early_stop_threshold' in logs:
+                    pufferl.logger.log({'environment/early_stop_threshold': logs['early_stop_threshold']}, logs['agent_steps'])
 
             if pufferl.global_step > logging_threshold:
                 all_logs.append(logs)
@@ -1082,7 +1082,7 @@ def sweep(args=None, env_name=None):
             
             # If metric distribution is percentile, threshold is also logit transformed
             threshold = sweep.get_early_stop_threshold(cost)
-            logs['early_stop_treshold'] = max(threshold, -5)  # clipping for visualization
+            logs['early_stop_threshold'] = max(threshold, -5)  # clipping for visualization
 
             if sweep.should_stop(max(target_running_mean, metric_val), cost):
                 logs['is_loss_nan'] = False

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -748,8 +748,11 @@ class Protein:
         pareto_observations = pruned_front if self.prune_pareto else pareto_front
 
         # Use the max cost from the pruned pareto to avoid inefficiently long runs
-        if self.upper_cost_threshold < pareto_front[-1]['cost']:
+        if self.upper_cost_threshold < 0:
             self.upper_cost_threshold = pareto_front[-1]['cost']
+        # Try to change the threshold slowly
+        elif self.upper_cost_threshold < pareto_front[-1]['cost']:
+            self.upper_cost_threshold *= 1.01
         self.stop_threshold_model.fit(self.success_observations, self.upper_cost_threshold)
 
         ### Sample suggestions

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -506,7 +506,7 @@ class Protein:
             num_random_samples = 10,
             num_keep_top_obs = 10,
             global_search_scale = 1,
-            suggestions_per_pareto = 128,
+            suggestions_per_pareto = 256,
             expansion_rate = 0.25,
             gp_training_iter = 50,
             gp_learning_rate = 0.001,
@@ -690,7 +690,7 @@ class Protein:
         if self.cost_param_idx is None:
             return params
 
-        # Add the same params with less cost to the search center
+        # Add the same params with less cost to the search center, and not the original
         original_costs_norm = params[:, self.cost_param_idx]
 
         params_1 = np.copy(params)
@@ -700,7 +700,7 @@ class Protein:
         cost_norm_2 = original_costs_norm - (original_costs_norm - (-1)) / 3
         params_2[:, self.cost_param_idx] = cost_norm_2
 
-        return np.vstack([params, params_1, params_2])
+        return np.vstack([params_1, params_2])
 
     def suggest(self, fill):
         info = {}

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -506,7 +506,7 @@ class Protein:
             num_keep_top_obs = 5,
             global_search_scale = 1,
             suggestions_per_pareto = 256,
-            expansion_rate = 0.25,
+            expansion_rate = 0.1,
             gp_training_iter = 50,
             gp_learning_rate = 0.001,
             gp_max_obs = 750,  # gp train time jumps after 800
@@ -622,7 +622,8 @@ class Protein:
 
         c = np.array([e['cost'] for e in observations])
         log_c = np.log(np.maximum(c, EPSILON))
-        self.log_c_min, self.log_c_max = log_c.min(), log_c.max()
+        self.log_c_min = log_c.min()
+        self.log_c_max = np.quantile(log_c, 0.97)  # Make it less sensitive to outlier points
 
         # When the data is scare, also use failed observations
         if len(observations) < 100 and self.failure_observations:

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -437,6 +437,7 @@ class ParetoLogCostModel:
     def __init__(self, min_allowed_cost=600):
         self.min_allowed_cost = min(min_allowed_cost, EPSILON)
         self.min_log_cost = np.log(min_allowed_cost)
+        self.max_threshold_fraction = 0.8
         self.is_fitted = False
         self.A = None
         self.B = None
@@ -470,10 +471,10 @@ class ParetoLogCostModel:
         cost_range = self.max_log_cost - self.min_log_cost
         if cost_range <= EPSILON:
             # Somehow sweep found an excellent hyperparam that solves within min cost
-            threshold_fraction = 0.8
+            threshold_fraction = self.max_threshold_fraction
         else:
             threshold_fraction = (log_c - self.min_log_cost) / cost_range
-            threshold_fraction = np.clip(threshold_fraction, 0, 1)
+            threshold_fraction = np.clip(threshold_fraction, 0, self.max_threshold_fraction)
 
         return threshold_fraction * predicted_pareto_score
 

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -855,7 +855,8 @@ class Protein:
 
     def logit_transform(self, value, epsilon=1e-9):
         value = np.clip(value, epsilon, 1 - epsilon)
-        return math.log(value / (1 - value))
+        logit = math.log(value / (1 - value))
+        return np.clip(logit, -5, 100)
 
     def observe(self, hypers, score, cost, is_failure=False):
         params = self.hyperparameters.from_dict(hypers)

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -504,7 +504,7 @@ class Protein:
             max_suggestion_cost = 3600,
             resample_frequency = 0,
             num_random_samples = 10,
-            num_keep_top_obs = 10,
+            num_keep_top_obs = 5,
             global_search_scale = 1,
             suggestions_per_pareto = 256,
             expansion_rate = 0.25,

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -489,12 +489,11 @@ class RobustLogCostModel:
         if not self.is_fitted or cost < self.min_allowed_cost:
             return -np.inf
 
-        # Let the training continue, if it can beat the current max more than 5%
+        # Stop long long train runs that don't do very well enough
         if cost > 1.2 * self.upper_cost_threshold:
-            return 1.05 * self.max_score
+            return 0.9 * self.max_score
 
-        log_c = np.log(np.maximum(cost, EPSILON))
-        return self.A + self.B * log_c
+        return self.A + self.B * np.log(cost)
 
 
 # TODO: Eval defaults

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -749,9 +749,9 @@ class Protein:
 
         # Use the max cost from the pruned pareto to avoid inefficiently long runs
         if self.upper_cost_threshold < 0:
-            self.upper_cost_threshold = pareto_front[-1]['cost']
+            self.upper_cost_threshold = pruned_front[-1]['cost']
         # Try to change the threshold slowly
-        elif self.upper_cost_threshold < pareto_front[-1]['cost']:
+        elif self.upper_cost_threshold < pruned_front[-1]['cost']:
             self.upper_cost_threshold *= 1.01
         self.stop_threshold_model.fit(self.success_observations, self.upper_cost_threshold)
 

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -279,8 +279,8 @@ def prune_pareto_front(pareto, efficiency_threshold=0.5, pruning_stop_score_frac
 
     max_pareto_score = scores[-1] if scores.size > 0 else -np.inf
 
-    for i in range(len(sorted_pareto) - 1, 0, -1):
-        if scores[i] < pruning_stop_score_fraction * max_pareto_score:
+    for i in range(len(sorted_pareto) - 1, 1, -1):
+        if scores[i-1] < pruning_stop_score_fraction * max_pareto_score:
             break
 
         norm_score_gain = (scores[i] - scores[i-1]) / score_range
@@ -550,7 +550,7 @@ class Protein:
         self.cost_param_idx = self.hyperparameters.get_flat_idx(cost_param)
         self.cost_random_suggestion = None
         if self.cost_param_idx is not None:
-            self.cost_random_suggestion = self.hyperparameters.search_centers[self.cost_param_idx]
+            self.cost_random_suggestion = -0.8  # In norm cost space. Make arg if necessary
 
         self.gp_max_obs = gp_max_obs  # train time bumps after 800?
         self.infer_batch_size = infer_batch_size

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -435,7 +435,7 @@ class RobustLogCostModel:
     Fits Score ~ A + B * log(Cost) using Quantile Regression (Median)
     and provides a cost-only threshold for early stopping.
     """
-    def __init__(self, min_num_samples=50, min_allowed_cost=600, quantile=0.3):
+    def __init__(self, min_num_samples=30, min_allowed_cost=600, quantile=0.3):
         self.min_num_samples = min_num_samples
         self.min_allowed_cost = min_allowed_cost
         self.quantile = quantile  # 0.5 = Median regression

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -486,12 +486,12 @@ class RobustLogCostModel:
         self.is_fitted = True
 
     def get_threshold(self, cost, upper_bound=1.5):
-        if not self.is_fitted or cost < self.min_allowed_cost:
-            return -np.inf
-
         # Do not run training longer than 1.5x pareto max
         if cost > upper_bound * self.max_cost:
             return upper_bound * self.max_score
+
+        if not self.is_fitted or cost < self.min_allowed_cost:
+            return -np.inf
 
         log_c = np.log(np.maximum(cost, EPSILON))
         return self.A + self.B * log_c

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -473,7 +473,8 @@ class RobustLogCostModel:
             self._quantile_loss, 
             x0=[a_init, b_init], 
             args=(x_log_c, y, self.quantile),
-            method='Nelder-Mead' # Robust solver for non-differentiable functions
+            method='Nelder-Mead', # Robust solver for non-differentiable functions
+            bounds=[(None, None), (0, None)] # B should be positive
         )
         
         self.A, self.B = res.x


### PR DESCRIPTION
The early-stop thresholding is done in 3 phases
* Safe zone: no thresholding during `early_stop_min_cost`
* Quantile-based thresholding: after `early_stop_min_cost`, the runs that are below `early_stop_quantile` (30%) are stopped. The threshold increases as cost increases.
* Hard zone: The above the upper bound should exceed the max score so far, or it gets stopped.

This will stop the training runs that are frustrating to watch and save some compute for sweep.

Breakout 500 runs:
<img width="514" height="665" alt="image" src="https://github.com/user-attachments/assets/f439384e-3bef-4496-be82-83a3e2e7ea04" />

Tetris:
<img width="417" height="657" alt="image" src="https://github.com/user-attachments/assets/d595d705-18f1-4c38-a3ca-7f762e186d5b" />
