### PR TITLE
Fix env_init error message arg count

### DIFF
--- a/pufferlib/ocean/env_binding.h
+++ b/pufferlib/ocean/env_binding.h
@@ -49,7 +49,7 @@ static Env* unpack_env(PyObject* args) {
 // Python function to initialize the environment
 static PyObject* env_init(PyObject* self, PyObject* args, PyObject* kwargs) {
     if (PyTuple_Size(args) != 6) {
-        PyErr_SetString(PyExc_TypeError, "Environment requires 5 arguments");
+        PyErr_SetString(PyExc_TypeError, "Environment requires 6 arguments");
         return NULL;
     }
 


### PR DESCRIPTION
Fixes #373

Error message says 5 args but function actually needs 6. Fixed the string to match what the code does.