### PR TITLE
Fix a nan loss handling edge case when downsample is set to zero

### DIFF
--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1113,7 +1113,8 @@ def sweep(args=None, env_name=None):
         timesteps = downsample([log['agent_steps'] for log in all_logs], points_per_run)
 
         is_final_loss_nan = all_logs[-1].get('is_loss_nan', False)
-        if is_final_loss_nan:
+        # scores, costs and timesteps can be empty if downsample set to 0 in the env's config
+        if scores and is_final_loss_nan:
             s = scores.pop()
             c = costs.pop()
             args['train']['total_timesteps'] = timesteps.pop()


### PR DESCRIPTION
subj

I've stumbled on an error while running a sweep for puffer_grid.
puffer_grid has downsample=0 in its config, so downsample function returns an empty list.
One of the runs ended with nan losses, and given that downsample function returned empty lists (scores, costs, timesteps), scores.pop() resulted in an IndexError.