### PR TITLE
Fix cartpole dynamics equations

### DIFF
--- a/pufferlib/ocean/cartpole/cartpole.h
+++ b/pufferlib/ocean/cartpole/cartpole.h
@@ -182,10 +182,10 @@ void c_step(Cartpole* env) {
     float sintheta = sinf(env->theta);
 
     float total_mass = env->cart_mass + env->pole_mass;
-    float polemass_length = total_mass + env->pole_mass;
+    float polemass_length = env->pole_mass * env->pole_length;
     float temp = (force + polemass_length * env->theta_dot * env->theta_dot * sintheta) / total_mass;
-    float thetaacc = (env->gravity * sintheta - costheta * temp) / 
-                     (env->pole_length * (4.0f / 3.0f - total_mass * costheta * costheta / total_mass));
+    float thetaacc = (env->gravity * sintheta - costheta * temp) /
+                     (env->pole_length * (4.0f / 3.0f - env->pole_mass * costheta * costheta / total_mass));
     float xacc = temp - polemass_length * thetaacc * costheta / total_mass;
 
     env->x += env->tau * env->x_dot;


### PR DESCRIPTION
## Summary
- Fix two algebraic errors in cartpole physics (issue #447)
- `polemass_length` was `total_mass + pole_mass`, should be `pole_mass * pole_length`
- `thetaacc` denominator used `total_mass` where it should use `pole_mass`

## Reference
Florian's cart-pole dynamics paper (equations 23 and 24)

## Test plan
- [x] Verified fixed equations match Gymnasium's CartPole implementation
- [x] Simulated 100 steps with identical parameters: 0.00 difference in pole angle