### PR TITLE
Fix CoGames training crashes when a render mode is supplied

### DIFF
--- a/pufferlib/environments/cogames/environment.py
+++ b/pufferlib/environments/cogames/environment.py
@@ -20,10 +20,13 @@ def make(name="cogames.cogs_v_clips.machina_1.open_world", variants=None, cogs=N
     render = "none" if render_mode == "auto" else "unicode" if render_mode in {"human", "ansi"} else render_mode
     simulator = Simulator()
     simulator.add_event_handler(StatsTracker(NoopStatsWriter()))
-    env = PufferMettaGridEnv(simulator=simulator, cfg=env_cfg, buf=buf, seed=seed or 0)
-    render_prop = getattr(type(env), "render_mode", None)
-    if isinstance(render_prop, property) and render_prop.fset:
-        env.render_mode = render
+    env = PufferMettaGridEnv(
+        simulator=simulator,
+        cfg=env_cfg,
+        buf=buf,
+        seed=seed or 0,
+        render_mode=render,
+    )
     if seed:
         env.reset(seed)
     return env

--- a/pufferlib/environments/cogames/environment.py
+++ b/pufferlib/environments/cogames/environment.py
@@ -17,16 +17,10 @@ def make(name="cogames.cogs_v_clips.machina_1.open_world", variants=None, cogs=N
     variants = variants.split() if isinstance(variants, str) else variants
     _, env_cfg, _ = get_mission(mission_name, variants_arg=variants, cogs=cogs)
 
-    render = "none" if render_mode == "auto" else "unicode" if render_mode in {"human", "ansi"} else render_mode
     simulator = Simulator()
     simulator.add_event_handler(StatsTracker(NoopStatsWriter()))
-    env = PufferMettaGridEnv(
-        simulator=simulator,
-        cfg=env_cfg,
-        buf=buf,
-        seed=seed or 0,
-        render_mode=render,
-    )
+    # render_mode is accepted for API compatibility but not used by MettaGridPufferEnv.
+    env = PufferMettaGridEnv(simulator=simulator, cfg=env_cfg, buf=buf, seed=seed or 0)
     if seed:
         env.reset(seed)
     return env

--- a/pufferlib/environments/cogames/environment.py
+++ b/pufferlib/environments/cogames/environment.py
@@ -12,14 +12,15 @@ def env_creator(name="cogames.cogs_v_clips.machina_1.open_world"):
     return functools.partial(make, name=name)
 
 
-def make(name="cogames.cogs_v_clips.machina_1.open_world", variants=None, cogs=None, render_mode="auto", seed=None, buf=None):
+def make(
+    name="cogames.cogs_v_clips.machina_1.open_world", variants=None, cogs=None, render_mode="auto", seed=None, buf=None
+):
     mission_name = name.removeprefix("cogames.cogs_v_clips.") if name.startswith("cogames.cogs_v_clips.") else name
     variants = variants.split() if isinstance(variants, str) else variants
     _, env_cfg, _ = get_mission(mission_name, variants_arg=variants, cogs=cogs)
 
     simulator = Simulator()
     simulator.add_event_handler(StatsTracker(NoopStatsWriter()))
-    # render_mode is accepted for API compatibility but not used by MettaGridPufferEnv.
     env = PufferMettaGridEnv(simulator=simulator, cfg=env_cfg, buf=buf, seed=seed or 0)
     if seed:
         env.reset(seed)

--- a/pufferlib/environments/cogames/environment.py
+++ b/pufferlib/environments/cogames/environment.py
@@ -21,7 +21,9 @@ def make(name="cogames.cogs_v_clips.machina_1.open_world", variants=None, cogs=N
     simulator = Simulator()
     simulator.add_event_handler(StatsTracker(NoopStatsWriter()))
     env = PufferMettaGridEnv(simulator=simulator, cfg=env_cfg, buf=buf, seed=seed or 0)
-    env.render_mode = render
+    render_prop = getattr(type(env), "render_mode", None)
+    if isinstance(render_prop, property) and render_prop.fset:
+        env.render_mode = render
     if seed:
         env.reset(seed)
     return env

--- a/pufferlib/environments/cogames/environment.py
+++ b/pufferlib/environments/cogames/environment.py
@@ -12,9 +12,7 @@ def env_creator(name="cogames.cogs_v_clips.machina_1.open_world"):
     return functools.partial(make, name=name)
 
 
-def make(
-    name="cogames.cogs_v_clips.machina_1.open_world", variants=None, cogs=None, render_mode="auto", seed=None, buf=None
-):
+def make(name="cogames.cogs_v_clips.machina_1.open_world", variants=None, cogs=None, render_mode="auto", seed=None, buf=None):
     mission_name = name.removeprefix("cogames.cogs_v_clips.") if name.startswith("cogames.cogs_v_clips.") else name
     variants = variants.split() if isinstance(variants, str) else variants
     _, env_cfg, _ = get_mission(mission_name, variants_arg=variants, cogs=cogs)


### PR DESCRIPTION
## Summary

Stop the CoGames wrapper from assigning to MettaGrid’s read-only render mode. Callers can still pass the option, but it is ignored instead of causing a crash.

## Details

CoGames MettaGrid exposes `render_mode` as a read-only value that always reports `ansi`. The PufferLib wrapper accepted a `render_mode` argument and then tried to assign it, which raises an `AttributeError`.

This PR keeps the `render_mode` argument for API compatibility but stops assigning it inside the CoGames env wrapper. Training behavior stays unchanged, and CoGames runs can pass `--env.render-mode none` without crashing.

## Verification

- `python -m pufferlib.pufferl train cogames.cogs_v_clips.training_facility.harvest --train.total-timesteps 2000 --vec.num-envs 1 --vec.num-workers 1 --train.batch-size 64 --train.minibatch-size 64 --train.device cpu --env.render-mode none`

[Codex, acting on behalf of relh]
