### PR TITLE
Remove dead code across codebase

### DIFF
--- a/pufferlib/emulation.py
+++ b/pufferlib/emulation.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import numpy as np
 import warnings

--- a/pufferlib/environments/__init__.py
+++ b/pufferlib/environments/__init__.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import pufferlib
 
 def try_import(module_path, package_name=None):

--- a/pufferlib/environments/atari/environment.py
+++ b/pufferlib/environments/atari/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 import functools
 

--- a/pufferlib/environments/box2d/environment.py
+++ b/pufferlib/environments/box2d/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import gymnasium
 import functools

--- a/pufferlib/environments/bsuite/environment.py
+++ b/pufferlib/environments/bsuite/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import gym
 import functools
 

--- a/pufferlib/environments/butterfly/environment.py
+++ b/pufferlib/environments/butterfly/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 from pettingzoo.utils.conversions import aec_to_parallel_wrapper
 import functools
 

--- a/pufferlib/environments/crafter/environment.py
+++ b/pufferlib/environments/crafter/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import gym
 import gymnasium

--- a/pufferlib/environments/dm_control/environment.py
+++ b/pufferlib/environments/dm_control/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import gym
 import shimmy

--- a/pufferlib/environments/dm_lab/environment.py
+++ b/pufferlib/environments/dm_lab/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import gym
 import shimmy

--- a/pufferlib/environments/griddly/environment.py
+++ b/pufferlib/environments/griddly/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import gym
 import shimmy

--- a/pufferlib/environments/gvgai/environment.py
+++ b/pufferlib/environments/gvgai/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 import functools
 

--- a/pufferlib/environments/links_awaken/environment.py
+++ b/pufferlib/environments/links_awaken/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import gymnasium
 

--- a/pufferlib/environments/magent/environment.py
+++ b/pufferlib/environments/magent/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 from pettingzoo.utils.conversions import aec_to_parallel_wrapper
 import functools
 

--- a/pufferlib/environments/microrts/environment.py
+++ b/pufferlib/environments/microrts/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 
 import warnings

--- a/pufferlib/environments/minerl/environment.py
+++ b/pufferlib/environments/minerl/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import gym
 import shimmy

--- a/pufferlib/environments/minigrid/environment.py
+++ b/pufferlib/environments/minigrid/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import gymnasium
 import functools

--- a/pufferlib/environments/minihack/environment.py
+++ b/pufferlib/environments/minihack/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import gym
 import shimmy

--- a/pufferlib/environments/minihack/torch.py
+++ b/pufferlib/environments/minihack/torch.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import pufferlib.pytorch
 from pufferlib.environments.nethack import Policy

--- a/pufferlib/environments/mujoco/environment.py
+++ b/pufferlib/environments/mujoco/environment.py
@@ -1,5 +1,4 @@
 
-from pdb import set_trace as T
 
 import functools
 

--- a/pufferlib/environments/nethack/environment.py
+++ b/pufferlib/environments/nethack/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import shimmy
 import gym

--- a/pufferlib/environments/nethack/torch.py
+++ b/pufferlib/environments/nethack/torch.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import torch
 import torch.nn as nn

--- a/pufferlib/environments/nmmo/environment.py
+++ b/pufferlib/environments/nmmo/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 import functools
 

--- a/pufferlib/environments/nmmo/torch.py
+++ b/pufferlib/environments/nmmo/torch.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import torch
 import torch.nn.functional as F

--- a/pufferlib/environments/open_spiel/environment.py
+++ b/pufferlib/environments/open_spiel/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 import functools
 

--- a/pufferlib/environments/open_spiel/gymnasium_environment.py
+++ b/pufferlib/environments/open_spiel/gymnasium_environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 
 from open_spiel.python.algorithms import mcts

--- a/pufferlib/environments/open_spiel/pettingzoo_environment.py
+++ b/pufferlib/environments/open_spiel/pettingzoo_environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 
 import pufferlib

--- a/pufferlib/environments/open_spiel/torch.py
+++ b/pufferlib/environments/open_spiel/torch.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 
 import torch

--- a/pufferlib/environments/open_spiel/utils.py
+++ b/pufferlib/environments/open_spiel/utils.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 
 import gymnasium

--- a/pufferlib/environments/pokemon_red/environment.py
+++ b/pufferlib/environments/pokemon_red/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 
 import gymnasium
 import functools

--- a/pufferlib/environments/procgen/environment.py
+++ b/pufferlib/environments/procgen/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 
 import gym

--- a/pufferlib/environments/procgen/torch.py
+++ b/pufferlib/environments/procgen/torch.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 from torch import nn
 import pufferlib.models
 

--- a/pufferlib/environments/slimevolley/environment.py
+++ b/pufferlib/environments/slimevolley/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 import functools
 

--- a/pufferlib/environments/stable_retro/environment.py
+++ b/pufferlib/environments/stable_retro/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 
 import gymnasium as gym

--- a/pufferlib/environments/test/environment.py
+++ b/pufferlib/environments/test/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 
 import time

--- a/pufferlib/environments/test/mock_environments.py
+++ b/pufferlib/environments/test/mock_environments.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 
 import time

--- a/pufferlib/environments/vizdoom/environment.py
+++ b/pufferlib/environments/vizdoom/environment.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 import functools
 

--- a/pufferlib/models.py
+++ b/pufferlib/models.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 
 import torch

--- a/pufferlib/ocean/environment.py
+++ b/pufferlib/ocean/environment.py
@@ -1,14 +1,6 @@
 import importlib
 import pufferlib.emulation
 
-def lazy_import(module_path, attr):
-    """
-    Returns a callable that, when called with any arguments, will
-    import the module, retrieve the attribute (usually a class or factory)
-    and then call it with the given arguments.
-    """
-    return lambda *args, **kwargs: getattr(__import__(module_path, fromlist=[attr]), attr)(*args, **kwargs)
-
 def make_foraging(width=1080, height=720, num_agents=4096, horizon=512,
         discretize=True, food_reward=0.1, render_mode='rgb_array'):
     from .grid import grid

--- a/pufferlib/ocean/moba/moba.py
+++ b/pufferlib/ocean/moba/moba.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 import os
 

--- a/pufferlib/ocean/nmmo3/nmmo3.py
+++ b/pufferlib/ocean/nmmo3/nmmo3.py
@@ -1,4 +1,3 @@
-from pdb import set_trace as T
 import numpy as np
 from types import SimpleNamespace
 import gymnasium

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -713,12 +713,6 @@ def dist_sum(value, device):
     torch.distributed.all_reduce(tensor, op=torch.distributed.ReduceOp.SUM)
     return tensor.item()
 
-def dist_mean(value, device):
-    if not torch.distributed.is_initialized():
-        return value
-
-    return dist_sum(value, device) / torch.distributed.get_world_size()
-
 class Profile:
     def __init__(self, frequency=5):
         self.profiles = defaultdict(lambda: defaultdict(float))

--- a/pufferlib/pytorch.py
+++ b/pufferlib/pytorch.py
@@ -1,11 +1,9 @@
 import sys
-from pdb import set_trace as T
 from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import torch
 from torch import nn
-from torch.distributions import Categorical
 from torch.distributions.utils import logits_to_probs
 
 import pufferlib
@@ -103,23 +101,6 @@ def nativize_tensor(observation: torch.Tensor, native_dtype: NativeDType):
     return _nativize_tensor(observation, native_dtype)
 
 
-# torch.view(dtype) does not compile
-# This is a workaround hack
-# @thatguy - can you figure out a more robust way to handle cast?
-# I think it may screw up for non-uint data... so I put a hard .view
-# fallback that breaks compile
-def compilable_cast(u8, dtype):
-    if dtype in (torch.uint8, torch.uint16, torch.uint32, torch.uint64):
-        n = dtype.itemsize
-        bytes = [u8[..., i::n].to(dtype) for i in range(n)]
-        if not LITTLE_BYTE_ORDER:
-            bytes = bytes[::-1]
-
-        bytes = sum(bytes[i] << (i * 8) for i in range(n))
-        return bytes.view(dtype)
-    return u8.view(dtype)  # breaking cast
-
-
 def _nativize_tensor(observation: torch.Tensor, native_dtype: NativeDType):
     if isinstance(native_dtype, tuple):
         dtype, shape, offset, delta = native_dtype
@@ -140,15 +121,6 @@ def _nativize_tensor(observation: torch.Tensor, native_dtype: NativeDType):
             subviews[name] = _nativize_tensor(observation, dtype)
         return subviews
 
-
-def nativize_observation(observation, emulated):
-    # TODO: Any way to check that user has not accidentally cast data to float?
-    # float is natively supported, but only if that is the actual correct type
-    return nativize_tensor(
-        observation,
-        emulated['observation_dtype'],
-        emulated['emulated_observation_dtype'],
-    )
 
 def flattened_tensor_size(native_dtype):
     return _flattened_tensor_size(native_dtype)
@@ -180,10 +152,6 @@ def entropy(logits):
     min_real = torch.finfo(logits.dtype).min
     logits = torch.clamp(logits, min=min_real)
     p_log_p = logits * logits_to_probs(logits)
-    return -p_log_p.sum(-1)
-
-def entropy_probs(logits, probs):
-    p_log_p = logits * probs
     return -p_log_p.sum(-1)
 
 def sample_logits(logits, action=None):

--- a/pufferlib/vector.py
+++ b/pufferlib/vector.py
@@ -1,6 +1,5 @@
 # TODO: Check actions passed to envs are right shape? On first call at least
 
-from pdb import set_trace as T
 
 import numpy as np
 import time


### PR DESCRIPTION
Remove unused lazy_import function (fixes #374), 40 unused pdb debug imports, and dead functions (compilable_cast, entropy_probs, nativize_observation, dist_mean) from pytorch.py and pufferl.py. All imports verified working.