### PR TITLE
Add torch>=2.3.0 version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,7 +251,7 @@ puffer = "pufferlib.pufferl:main"
 Homepage = "https://puffer.ai"
 
 [build-system]
-requires = ["setuptools", "wheel", "Cython", "numpy<2.0", "torch"]
+requires = ["setuptools", "wheel", "Cython", "numpy<2.0", "torch>=2.3.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.uv]

--- a/setup.py
+++ b/setup.py
@@ -281,7 +281,7 @@ install_requires = [
 
 if not NO_TRAIN:
     install_requires += [
-        'torch',
+        'torch>=2.3.0',
         'psutil',
         'nvidia-ml-py',
         'rich',


### PR DESCRIPTION
PufferLib uses torch.uint64/uint32/uint16 dtypes in pytorch.py which require PyTorch 2.3+. Fixes #123