### PR TITLE
Fused scan kernel optimization

### DIFF
--- a/profile_kernels.cu
+++ b/profile_kernels.cu
@@ -14,13 +14,17 @@
 #include <string.h>
 #include <dlfcn.h>
 
-#include "pufferlib/extensions/vecenv.h"
 
 #ifdef USE_TORCH
 #include "pufferlib/extensions/pufferlib.cpp"
-#include "pufferlib/extensions/cuda/modules.cu"
+#include "pufferlib/extensions/cuda/kernels.cu"
+// #include "pufferlib/extensions/modules.cpp"
 using namespace pufferlib;
-#else
+#endif
+
+#include "pufferlib/extensions/vecenv.h"
+
+#ifndef USE_TORCH
 #include "pufferlib/extensions/cuda/kernels.cu"
 #endif
 
@@ -697,6 +701,23 @@ void run_fusedscan_backward(FusedScanArgs* args) {
         args->T, args->H, args->B, 0);
 }
 
+void run_fusedscan_forward_checkpointed(FusedScanArgs* args) {
+    launch_fused_scan_forward_checkpointed<float>(
+        args->out, args->next_state,
+        args->a_star, args->s_vals, args->log_values_buf,
+        args->combined, args->state,
+        args->T, args->H, args->B, 0);
+}
+
+void run_fusedscan_backward_checkpointed(FusedScanArgs* args) {
+    launch_fused_scan_backward_checkpointed<float>(
+        args->grad_combined, args->grad_state,
+        args->grad_out, args->grad_next_state,
+        args->combined, args->state,
+        args->a_star, args->s_vals, args->log_values_buf,
+        args->T, args->H, args->B, 0);
+}
+
 #ifdef USE_TORCH
 
 typedef struct {
@@ -745,6 +766,82 @@ void run_fusedscan_forward_cpp(FusedScanArgsTorch* args) {
     fused_scan_cpp(args->combined, args->state);
 }
 
+void test_fusedscan_checkpointed_correct(FusedScanArgsTorch* args) {
+    // Run reference (non-checkpointed) kernel forward
+    auto combined_ref = args->combined.clone().requires_grad_(true);
+    auto state_ref = args->state.clone().requires_grad_(true);
+    combined_ref.retain_grad();
+    state_ref.retain_grad();
+    auto ref_outputs = fused_scan(combined_ref, state_ref);
+    auto ref_out = ref_outputs[0];
+    auto ref_next_state = ref_outputs[1];
+
+    // Run checkpointed forward kernel via raw launch
+    auto opts = torch::TensorOptions().dtype(args->combined.dtype()).device(torch::kCUDA);
+    auto opts_float = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+    
+    auto out_ckpt = torch::empty({args->B, args->T, args->H}, opts);
+    auto next_state_ckpt = torch::empty({args->B, 1, args->H}, opts);
+    auto a_star = torch::empty({args->B, args->T + 1, args->H}, opts_float);
+    auto s_vals = torch::empty({args->B, args->T + 1, args->H}, opts_float);
+    auto log_values_buf = torch::empty({args->B, args->T + 1, args->H}, opts_float);
+    
+    launch_fused_scan_forward_checkpointed<float>(
+        out_ckpt.data_ptr<float>(),
+        next_state_ckpt.data_ptr<float>(),
+        a_star.data_ptr<float>(),
+        s_vals.data_ptr<float>(),
+        log_values_buf.data_ptr<float>(),
+        args->combined.data_ptr<float>(),
+        args->state.data_ptr<float>(),
+        args->T, args->H, args->B,
+        at::cuda::getCurrentCUDAStream());
+    cudaDeviceSynchronize();
+
+    // Numerical comparison - use same tolerances as other tests
+    float rtol = 1e-3f, atol = 1e-4f;
+    bool out_match = torch::allclose(out_ckpt, ref_out, rtol, atol);
+    float out_max_diff = (out_ckpt - ref_out).abs().max().item<float>();
+    bool next_state_match = torch::allclose(next_state_ckpt, ref_next_state, rtol, atol);
+    float next_state_max_diff = (next_state_ckpt - ref_next_state).abs().max().item<float>();
+
+    printf("  checkpointed forward correctness: out=%s(%.2e) next_state=%s(%.2e)\n",
+           out_match ? "\033[32mok\033[0m" : "\033[31mFAIL\033[0m", out_max_diff,
+           next_state_match ? "\033[32mok\033[0m" : "\033[31mFAIL\033[0m", next_state_max_diff);
+
+    // Test backward pass - run reference backward
+    torch::autograd::backward({ref_out, ref_next_state}, {args->grad_out, args->grad_next_state});
+    auto grad_combined_ref = combined_ref.grad().clone();
+    auto grad_state_ref = state_ref.grad().clone();
+
+    // Run checkpointed backward
+    auto grad_combined_ckpt = torch::empty_like(args->combined);
+    auto grad_state_ckpt = torch::empty_like(args->state);
+
+    launch_fused_scan_backward_checkpointed<float>(
+        grad_combined_ckpt.data_ptr<float>(),
+        grad_state_ckpt.data_ptr<float>(),
+        args->grad_out.data_ptr<float>(),
+        args->grad_next_state.data_ptr<float>(),
+        args->combined.data_ptr<float>(),
+        args->state.data_ptr<float>(),
+        a_star.data_ptr<float>(),
+        s_vals.data_ptr<float>(),
+        log_values_buf.data_ptr<float>(),
+        args->T, args->H, args->B,
+        at::cuda::getCurrentCUDAStream());
+    cudaDeviceSynchronize();
+
+    bool grad_combined_match = torch::allclose(grad_combined_ckpt, grad_combined_ref, rtol, atol);
+    float grad_combined_max_diff = (grad_combined_ckpt - grad_combined_ref).abs().max().item<float>();
+    bool grad_state_match = torch::allclose(grad_state_ckpt, grad_state_ref, rtol, atol);
+    float grad_state_max_diff = (grad_state_ckpt - grad_state_ref).abs().max().item<float>();
+
+    printf("  checkpointed backward correctness: grad_combined=%s(%.2e) grad_state=%s(%.2e)\n",
+           grad_combined_match ? "\033[32mok\033[0m" : "\033[31mFAIL\033[0m", grad_combined_max_diff,
+           grad_state_match ? "\033[32mok\033[0m" : "\033[31mFAIL\033[0m", grad_state_max_diff);
+}
+
 #endif
 
 void profile_fusedscan(int batch, int seq, int hidden) {
@@ -759,8 +856,16 @@ void profile_fusedscan(int batch, int seq, int hidden) {
     float bwd_ms = profile_kernel((kernel_fn)run_fusedscan_backward, args);
     print_timing("\tbackward", bwd_ms, batch*seq);
 
+    float fwd_ckpt_ms = profile_kernel((kernel_fn)run_fusedscan_forward_checkpointed, args);
+    print_timing("\tforward (checkpointed)", fwd_ckpt_ms, batch*seq);
+
+    float bwd_ckpt_ms = profile_kernel((kernel_fn)run_fusedscan_backward_checkpointed, args);
+    print_timing("\tbackward (checkpointed)", bwd_ckpt_ms, batch*seq);
+
 #ifdef USE_TORCH
     FusedScanArgsTorch* args_torch = create_fusedscanargs_torch(args);
+
+    test_fusedscan_checkpointed_correct(args_torch);
 
     float fwd_torch_ms = profile_kernel((kernel_fn)run_fusedscan_forward_torch, args_torch);
     print_timing("\tforward (torch)", fwd_torch_ms, batch*seq);

--- a/pufferlib/extensions/cuda/kernels.cu
+++ b/pufferlib/extensions/cuda/kernels.cu
@@ -18,11 +18,16 @@
 
 #define SEQ_SIZE 256
 #define BLOCK_SIZE 256
+#define CHECKPOINT_INTERVAL 16  // Sparse checkpoint interval for optimized kernels
+#define OPT_BLOCK_SIZE 256     // Block size for optimized checkpointed kernels
 inline int grid_size(int N) {
     return (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
 }
 inline int seq_size(int N) {
     return (N + SEQ_SIZE - 1) / SEQ_SIZE;
+}
+inline int opt_grid_size(int N) {
+    return (N + OPT_BLOCK_SIZE - 1) / OPT_BLOCK_SIZE;
 }
 
 // If you can get this to work, go ahead. I tried.
@@ -512,6 +517,94 @@ __global__ void fused_scan_forward_kernel(
     next_state[state_idx] = T(scan_result);
 }
 
+
+// Optimized forward kernel with checkpointing
+// Writes checkpoints only every CHECKPOINT_INTERVAL timesteps (vs every time)
+// Uses fast math intrinsics for better performance
+template<typename T>
+__global__ void fused_scan_forward_kernel_checkpointed(
+    T* __restrict__ out,                 // (B, T, H) - sigmoid(proj) * scan_result
+    T* __restrict__ next_state,          // (B, 1, H) - raw scan_result at T (for recurrence)
+    float* __restrict__ a_star_buf,      // (B, T+1, H) - sparse checkpoints for backward
+    float* __restrict__ s_buf,           // (B, T+1, H) - sparse checkpoints for backward
+    float* __restrict__ log_values_buf,  // (B, T+1, H) - sparse checkpoints for backward
+    const T* __restrict__ combined,      // (B, T, 3*H) = [hidden(H), gate(H), proj(H)]
+    const T* __restrict__ state,         // (B, 1, H)
+    int T_seq,                           // sequence length (T)
+    int H,
+    int B
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= B * H) return;
+
+    int b = idx / H;
+    int h = idx % H;
+
+    int bH = b * H;
+    int H3 = 3 * H;
+    int H2 = 2 * H;
+    int bHT = bH * T_seq;
+    int out_base = bHT + h;
+    int cbase = 3 * bHT;
+
+    float a_star = 0.0f;
+    float log_value = 0.0f;
+
+    // Handle t=0 outside the loop: use log(state), coeff = 0
+    float s = __logf(float(state[bH + h]));
+    log_value = s;
+
+    int T_out = T_seq + 1;
+    int buf_base = b * T_out * H + h;
+    int buf_curr = buf_base;
+    a_star_buf[buf_curr] = a_star;
+    s_buf[buf_curr] = s;
+    log_values_buf[buf_curr] = log_value;
+
+    const T* combined_h_base = &combined[cbase + h];
+    const T* combined_g_base = &combined[cbase + H + h];
+    const T* combined_p_base = &combined[cbase + H2 + h];
+
+    // Loop t=1..T_seq with sparse checkpointing
+    float scan_result = 0.0f;
+    int out_curr = out_base;
+    int t_offset = 0;
+
+    for (int t = 1; t < T_seq + 1; t++) {
+        float hidden_val = float(combined_h_base[t_offset]);
+        float gate_val = float(combined_g_base[t_offset]);
+        float proj_val = float(combined_p_base[t_offset]);
+
+        float log_coeff_val;
+        log_coeffs_and_values_fwd(gate_val, hidden_val, &log_coeff_val, &log_value);
+
+        // a_star[t] = sum_{i=0}^t log_coeffs[i]
+        a_star += log_coeff_val;
+
+        float z = log_value - a_star;
+        float max_val = fmaxf(s, z);
+        s = max_val + log1pf(__expf(-fabsf(s - z)));
+
+        scan_result = __expf(a_star + s);
+        float proj_sigmoid = sigmoid(proj_val);
+
+        out[out_curr] = T(proj_sigmoid * scan_result);
+
+        buf_curr += H;
+        out_curr += H;
+        t_offset += H3;
+
+        if (t % CHECKPOINT_INTERVAL == 0) {
+            a_star_buf[buf_curr] = a_star;
+            s_buf[buf_curr] = s;
+            log_values_buf[buf_curr] = log_value;
+        }
+    }
+
+    // Write timestep T to next_state (raw scan_result, no proj, for recurrence)
+    next_state[bH + h] = T(scan_result);
+}
+
 // Fully fused backward: chains through sigmoid(proj)*out and log_coeffs_and_values
 // Takes combined (B, T, 3*H), outputs grad_combined (B, T, 3*H) = [grad_hidden, grad_gate, grad_proj]
 template<typename T>
@@ -629,6 +722,156 @@ __global__ void fused_scan_backward_kernel(
         }
     }
 }
+
+// Optimized backward kernel with sparse checkpoint loading
+// Reads sparse checkpoints from forward pass, recomputes intermediate values in chunks
+// Uses fast math intrinsics for better performance
+template<typename T>
+__global__ void fused_scan_backward_kernel_checkpointed(
+    T* __restrict__ grad_combined,         // (B, T, 3*H) = [grad_hidden, grad_gate, grad_proj]
+    T* __restrict__ grad_state,            // (B, 1, H)
+    const T* __restrict__ grad_out,        // (B, T, H) - gradient of sigmoid(proj)*scan_result
+    const T* __restrict__ grad_next_state, // (B, 1, H) - gradient of raw scan_result at T
+    const T* __restrict__ combined,        // (B, T, 3*H) = [hidden, gate, proj]
+    const T* __restrict__ state,           // (B, 1, H)
+    const float* __restrict__ a_star_buf,  // (B, T+1, H) sparse checkpoints from forward
+    const float* __restrict__ s_buf,       // (B, T+1, H) sparse checkpoints from forward
+    const float* __restrict__ log_values_buf, // (B, T+1, H) sparse checkpoints from forward
+    int T_seq,                             // sequence length (T)
+    int H,
+    int B
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= B * H) return;
+
+    int b = idx / H;
+    int h = idx % H;
+
+    int bHT = b * H * T_seq;
+    int cbase = 3 * bHT;
+    int H3 = 3 * H;
+    int H2 = 2 * H;
+    const int state_idx = b * H + h;
+    const int out_base = bHT + h;
+    
+    const T* combined_h_base = &combined[cbase + h];
+    const T* combined_g_base = &combined[cbase + H + h];
+    const T* combined_p_base = &combined[cbase + H2 + h];
+    
+    T* grad_combined_h_base = &grad_combined[cbase + h];
+    T* grad_combined_g_base = &grad_combined[cbase + H + h];
+    T* grad_combined_p_base = &grad_combined[cbase + H2 + h];
+    
+    int T_out = T_seq + 1;
+    int buf_base = b * T_out * H + h;
+
+    float acc = 0.0;
+    float s_val_next = 0.0;
+    float carry_grad_a = 0.0;
+    
+    for (int chunk_end = T_seq; chunk_end > 0; chunk_end -= CHECKPOINT_INTERVAL) {
+        int chunk_start = (chunk_end > CHECKPOINT_INTERVAL) ? (chunk_end - CHECKPOINT_INTERVAL) : 0;
+        int chunk_len = chunk_end - chunk_start;
+        
+        // Chunk storage in registers
+        float chunk_a_star[CHECKPOINT_INTERVAL];
+        float chunk_s[CHECKPOINT_INTERVAL];
+        float chunk_log_values[CHECKPOINT_INTERVAL];
+        float chunk_hidden[CHECKPOINT_INTERVAL];
+        float chunk_gate[CHECKPOINT_INTERVAL];
+        
+        // Load checkpoint from global memory
+        int ckpt_buf_idx = buf_base + chunk_start * H;
+        float recomp_a_star = a_star_buf[ckpt_buf_idx];
+        float recomp_s = s_buf[ckpt_buf_idx];
+        float recomp_log_value = log_values_buf[ckpt_buf_idx];
+        
+        // Recompute and store from chunk_start to chunk_end
+        for (int i = 0; i < chunk_len; ++i) {
+            int t = chunk_start + 1 + i;
+            int t_offset = (t - 1) * H3;
+            float hv = float(combined_h_base[t_offset]);
+            float gv = float(combined_g_base[t_offset]);
+            
+            float lc;
+            log_coeffs_and_values_fwd(gv, hv, &lc, &recomp_log_value);
+            recomp_a_star += lc;
+            
+            float z = recomp_log_value - recomp_a_star;
+            float mv = fmaxf(recomp_s, z);
+            recomp_s = mv + log1pf(__expf(-fabsf(recomp_s - z)));
+            
+            chunk_a_star[i] = recomp_a_star;
+            chunk_s[i] = recomp_s;
+            chunk_log_values[i] = recomp_log_value;
+            chunk_hidden[i] = hv;
+            chunk_gate[i] = gv;
+        }
+        
+        for (int i = chunk_len - 1; i >= 0; --i) {
+            int t = chunk_start + 1 + i;
+            int t_offset = (t - 1) * H3;
+            
+            float a_star_t = chunk_a_star[i];
+            float s_t = chunk_s[i];
+            float log_value_t = chunk_log_values[i];
+            float hidden_val = chunk_hidden[i];
+            float gate_val = chunk_gate[i];
+            
+            float proj_val = float(combined_p_base[t_offset]);
+            
+            float scan_result = __expf(a_star_t + s_t);
+            float z = log_value_t - a_star_t;
+            
+            float grad_out_val = float(grad_out[out_base + (t - 1) * H]);
+            
+            float grad_scan_from_next = (t == T_seq) ? float(grad_next_state[state_idx]) : 0.0f;
+            
+            float proj_sigmoid = sigmoid(proj_val);
+            float grad_scan_result = grad_scan_from_next + grad_out_val * proj_sigmoid;
+            float grad_proj = grad_out_val * scan_result * proj_sigmoid * (1.0f - proj_sigmoid);
+            
+            float grad_log_h = grad_scan_result * scan_result;
+            float grad_s = grad_log_h;
+            
+            if (t == T_seq) {
+                acc = grad_s;
+            } else {
+                acc = grad_s + acc * __expf(s_t - s_val_next);
+            }
+            float grad_z = acc * __expf(z - s_t);
+            s_val_next = s_t;
+            
+            float grad_a = grad_log_h + carry_grad_a - grad_z;
+            carry_grad_a = grad_a;
+            
+            float grad_g, grad_h;
+            log_coeffs_and_values_bwd(grad_a, grad_z, gate_val, hidden_val, &grad_g, &grad_h);
+            
+            grad_combined_h_base[t_offset] = T(grad_h);
+            grad_combined_g_base[t_offset] = T(grad_g);
+            grad_combined_p_base[t_offset] = T(grad_proj);
+        }
+    }
+    
+    int ckpt_0_idx = buf_base;
+    float a_star_0 = a_star_buf[ckpt_0_idx];
+    float s_0 = s_buf[ckpt_0_idx];
+    float log_value_0 = log_values_buf[ckpt_0_idx];
+    
+    float scan_result_0 = __expf(a_star_0 + s_0);
+    float z_0 = log_value_0 - a_star_0;
+    
+    float grad_scan_result_0 = 0.0f;
+    float grad_log_h_0 = grad_scan_result_0 * scan_result_0;
+    float grad_s_0 = grad_log_h_0;
+    
+    acc = grad_s_0 + acc * __expf(s_0 - s_val_next);
+    float grad_z_0 = acc * __expf(z_0 - s_0);
+    
+    grad_state[state_idx] = T(grad_z_0 / float(state[state_idx]));
+}
+
 
 /*
 template<typename T>
@@ -927,6 +1170,42 @@ void launch_fused_scan_forward(
     }
 }
 
+template<typename T>
+void launch_fused_scan_forward_checkpointed(
+    T* out,
+    T* next_state,
+    float* a_star,
+    float* s_vals,
+    float* log_values_buf,  // (B, T+1, H) - sparse checkpoints for backward
+    const T* combined,  // (B, T, 3*H) = [hidden, gate, proj]
+    const T* state,
+    int T_seq,
+    int H,
+    int B,
+    cudaStream_t stream
+) {
+    int total = B * H;
+    int grid = opt_grid_size(total);
+
+    fused_scan_forward_kernel_checkpointed<T><<<grid, OPT_BLOCK_SIZE, 0, stream>>>(
+        out,
+        next_state,
+        a_star,
+        s_vals,
+        log_values_buf,
+        combined,
+        state,
+        T_seq,
+        H,
+        B
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA kernel launch error in checkpointed forward: %s\n", cudaGetErrorString(err));
+    }
+}
+
 // Fully fused backward launch: outputs grad_combined (B, T, 3*H) = [grad_hidden, grad_gate, grad_proj]
 template<typename T>
 void launch_fused_scan_backward(
@@ -967,6 +1246,49 @@ void launch_fused_scan_backward(
         fprintf(stderr, "CUDA kernel launch error in backward: %s\n", cudaGetErrorString(err));
     }
 }
+
+// Optimized backward launch with sparse checkpoint loading
+// Reads sparse checkpoints from forward pass, recomputes intermediate values in chunks
+template<typename T>
+void launch_fused_scan_backward_checkpointed(
+    T* grad_combined,   // (B, T, 3*H) = [grad_hidden, grad_gate, grad_proj]
+    T* grad_state,
+    const T* grad_out,
+    const T* grad_next_state,
+    const T* combined,  // (B, T, 3*H) = [hidden, gate, proj]
+    const T* state,
+    const float* a_star_buf,  // (B, T+1, H) - sparse checkpoints from forward
+    const float* s_buf,       // (B, T+1, H) - sparse checkpoints from forward
+    const float* log_values_buf,  // (B, T+1, H) - sparse checkpoints from forward
+    int T_seq,
+    int H,
+    int B,
+    cudaStream_t stream
+) {
+    int total = B * H;
+    int grid = opt_grid_size(total);
+
+    fused_scan_backward_kernel_checkpointed<T><<<grid, OPT_BLOCK_SIZE, 0, stream>>>(
+        grad_combined,
+        grad_state,
+        grad_out,
+        grad_next_state,
+        combined,
+        state,
+        a_star_buf,
+        s_buf,
+        log_values_buf,
+        T_seq,
+        H,
+        B
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA kernel launch error in checkpointed backward: %s\n", cudaGetErrorString(err));
+    }
+}
+
 
 /*
 __device__ __forceinline__ float log_add_exp(const float a, const float b) {
@@ -1713,6 +2035,20 @@ void launch_fused_scan_forward_bf16(at::BFloat16* out, at::BFloat16* next_state,
 }
 void launch_fused_scan_backward_bf16(at::BFloat16* grad_combined, at::BFloat16* grad_state, const at::BFloat16* grad_out, const at::BFloat16* grad_next_state, const at::BFloat16* combined, const at::BFloat16* state, const float* a_star_buf, const float* s_buf, const float* log_values_buf, int T_seq, int H, int B, cudaStream_t stream) {
     launch_fused_scan_backward<at::BFloat16>(grad_combined, grad_state, grad_out, grad_next_state, combined, state, a_star_buf, s_buf, log_values_buf, T_seq, H, B, stream);
+}
+// Non-templated wrappers for checkpointed fused scan - Float
+void launch_fused_scan_forward_checkpointed_float(float* out, float* next_state, float* a_star, float* s_vals, float* log_values_buf, const float* combined, const float* state, int T_seq, int H, int B, cudaStream_t stream) {
+    launch_fused_scan_forward_checkpointed<float>(out, next_state, a_star, s_vals, log_values_buf, combined, state, T_seq, H, B, stream);
+}
+void launch_fused_scan_backward_checkpointed_float(float* grad_combined, float* grad_state, const float* grad_out, const float* grad_next_state, const float* combined, const float* state, const float* a_star_buf, const float* s_buf, const float* log_values_buf, int T_seq, int H, int B, cudaStream_t stream) {
+    launch_fused_scan_backward_checkpointed<float>(grad_combined, grad_state, grad_out, grad_next_state, combined, state, a_star_buf, s_buf, log_values_buf, T_seq, H, B, stream);
+}
+// Non-templated wrappers for checkpointed fused scan - BFloat16
+void launch_fused_scan_forward_checkpointed_bf16(at::BFloat16* out, at::BFloat16* next_state, float* a_star, float* s_vals, float* log_values_buf, const at::BFloat16* combined, const at::BFloat16* state, int T_seq, int H, int B, cudaStream_t stream) {
+    launch_fused_scan_forward_checkpointed<at::BFloat16>(out, next_state, a_star, s_vals, log_values_buf, combined, state, T_seq, H, B, stream);
+}
+void launch_fused_scan_backward_checkpointed_bf16(at::BFloat16* grad_combined, at::BFloat16* grad_state, const at::BFloat16* grad_out, const at::BFloat16* grad_next_state, const at::BFloat16* combined, const at::BFloat16* state, const float* a_star_buf, const float* s_buf, const float* log_values_buf, int T_seq, int H, int B, cudaStream_t stream) {
+    launch_fused_scan_backward_checkpointed<at::BFloat16>(grad_combined, grad_state, grad_out, grad_next_state, combined, state, a_star_buf, s_buf, log_values_buf, T_seq, H, B, stream);
 }
 void launch_logcumsumexp_forward_bf16(at::BFloat16* out, double* s_buf, const at::BFloat16* x, int T_total, int H, int B, cudaStream_t stream) {
     launch_logcumsumexp_forward<at::BFloat16>(out, s_buf, x, T_total, H, B, stream);

--- a/pufferlib/extensions/cuda/kernels.cu
+++ b/pufferlib/extensions/cuda/kernels.cu
@@ -519,14 +519,14 @@ __global__ void fused_scan_forward_kernel(
 // Uses fast math intrinsics for better performance
 template<typename T>
 __global__ void fused_scan_forward_kernel_checkpointed(
-    T* __restrict__ out,                 // (B, T, H) - sigmoid(proj) * scan_result
-    T* __restrict__ next_state,          // (B, 1, H) - raw scan_result at T (for recurrence)
-    float* __restrict__ a_star_buf,      // (B, T+1, H) - sparse checkpoints for backward
-    float* __restrict__ s_buf,           // (B, T+1, H) - sparse checkpoints for backward
-    float* __restrict__ log_values_buf,  // (B, T+1, H) - sparse checkpoints for backward
-    const T* __restrict__ combined,      // (B, T, 3*H) = [hidden(H), gate(H), proj(H)]
+    T* __restrict__ out,                 // (B, T, H)
+    T* __restrict__ next_state,          // (B, 1, H)
+    float* __restrict__ a_star_buf,      // (B, T+1, H)
+    float* __restrict__ s_buf,           // (B, T+1, H)
+    float* __restrict__ log_values_buf,  // (B, T+1, H)
+    const T* __restrict__ combined,      // (B, T, 3*H)
     const T* __restrict__ state,         // (B, 1, H)
-    int T_seq,                           // sequence length (T)
+    int T_seq,
     int H,
     int B
 ) {
@@ -724,16 +724,16 @@ __global__ void fused_scan_backward_kernel(
 // Uses fast math intrinsics for better performance
 template<typename T>
 __global__ void fused_scan_backward_kernel_checkpointed(
-    T* __restrict__ grad_combined,         // (B, T, 3*H) = [grad_hidden, grad_gate, grad_proj]
+    T* __restrict__ grad_combined,         // (B, T, 3*H)
     T* __restrict__ grad_state,            // (B, 1, H)
-    const T* __restrict__ grad_out,        // (B, T, H) - gradient of sigmoid(proj)*scan_result
-    const T* __restrict__ grad_next_state, // (B, 1, H) - gradient of raw scan_result at T
-    const T* __restrict__ combined,        // (B, T, 3*H) = [hidden, gate, proj]
+    const T* __restrict__ grad_out,        // (B, T, H)
+    const T* __restrict__ grad_next_state, // (B, 1, H)
+    const T* __restrict__ combined,        // (B, T, 3*H)
     const T* __restrict__ state,           // (B, 1, H)
-    const float* __restrict__ a_star_buf,  // (B, T+1, H) sparse checkpoints from forward
-    const float* __restrict__ s_buf,       // (B, T+1, H) sparse checkpoints from forward
-    const float* __restrict__ log_values_buf, // (B, T+1, H) sparse checkpoints from forward
-    int T_seq,                             // sequence length (T)
+    const float* __restrict__ a_star_buf,  // (B, T+1, H)
+    const float* __restrict__ s_buf,       // (B, T+1, H)
+    const float* __restrict__ log_values_buf, // (B, T+1, H)
+    int T_seq,                             // (T)
     int H,
     int B
 ) {
@@ -1172,8 +1172,8 @@ void launch_fused_scan_forward_checkpointed(
     T* next_state,
     float* a_star,
     float* s_vals,
-    float* log_values_buf,  // (B, T+1, H) - sparse checkpoints for backward
-    const T* combined,  // (B, T, 3*H) = [hidden, gate, proj]
+    float* log_values_buf,  // (B, T+1, H)
+    const T* combined,  // (B, T, 3*H)
     const T* state,
     int T_seq,
     int H,
@@ -1247,15 +1247,15 @@ void launch_fused_scan_backward(
 // Reads sparse checkpoints from forward pass, recomputes intermediate values in chunks
 template<typename T>
 void launch_fused_scan_backward_checkpointed(
-    T* grad_combined,   // (B, T, 3*H) = [grad_hidden, grad_gate, grad_proj]
+    T* grad_combined,   // (B, T, 3*H)
     T* grad_state,
     const T* grad_out,
     const T* grad_next_state,
-    const T* combined,  // (B, T, 3*H) = [hidden, gate, proj]
+    const T* combined,  // (B, T, 3*H)
     const T* state,
-    const float* a_star_buf,  // (B, T+1, H) - sparse checkpoints from forward
-    const float* s_buf,       // (B, T+1, H) - sparse checkpoints from forward
-    const float* log_values_buf,  // (B, T+1, H) - sparse checkpoints from forward
+    const float* a_star_buf,  // (B, T+1, H)
+    const float* s_buf,       // (B, T+1, H)
+    const float* log_values_buf,  // (B, T+1, H)
     int T_seq,
     int H,
     int B,

--- a/pufferlib/extensions/cuda/kernels.cu
+++ b/pufferlib/extensions/cuda/kernels.cu
@@ -18,16 +18,12 @@
 
 #define SEQ_SIZE 256
 #define BLOCK_SIZE 256
-#define CHECKPOINT_INTERVAL 16  // Sparse checkpoint interval for optimized kernels
-#define OPT_BLOCK_SIZE 256     // Block size for optimized checkpointed kernels
+#define CHECKPOINT_INTERVAL 4  // Sparse checkpoint interval for optimized kernels
 inline int grid_size(int N) {
     return (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
 }
 inline int seq_size(int N) {
     return (N + SEQ_SIZE - 1) / SEQ_SIZE;
-}
-inline int opt_grid_size(int N) {
-    return (N + OPT_BLOCK_SIZE - 1) / OPT_BLOCK_SIZE;
 }
 
 // If you can get this to work, go ahead. I tried.
@@ -1185,9 +1181,9 @@ void launch_fused_scan_forward_checkpointed(
     cudaStream_t stream
 ) {
     int total = B * H;
-    int grid = opt_grid_size(total);
+    int grid = grid_size(total);
 
-    fused_scan_forward_kernel_checkpointed<T><<<grid, OPT_BLOCK_SIZE, 0, stream>>>(
+    fused_scan_forward_kernel_checkpointed<T><<<grid, BLOCK_SIZE, 0, stream>>>(
         out,
         next_state,
         a_star,
@@ -1266,9 +1262,9 @@ void launch_fused_scan_backward_checkpointed(
     cudaStream_t stream
 ) {
     int total = B * H;
-    int grid = opt_grid_size(total);
+    int grid = grid_size(total);
 
-    fused_scan_backward_kernel_checkpointed<T><<<grid, OPT_BLOCK_SIZE, 0, stream>>>(
+    fused_scan_backward_kernel_checkpointed<T><<<grid, BLOCK_SIZE, 0, stream>>>(
         grad_combined,
         grad_state,
         grad_out,

--- a/pufferlib/extensions/vecenv.h
+++ b/pufferlib/extensions/vecenv.h
@@ -5,7 +5,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>
+#ifndef __cplusplus
 #include <stdatomic.h>
+#endif
 #include <cuda_runtime.h>
 
 #define FLOAT 1
@@ -92,6 +94,10 @@ void dict_set_ptr(Dict* dict, const char* key, void* ptr) {
     dict->items[dict->size].key = key;
     dict->items[dict->size].ptr = ptr;
     dict->size++;
+}
+
+void dict_set_int(Dict* dict, const char* key, int value) {
+    dict_set(dict, key, (double)value);
 }
 
 void* my_shared(Env* env, Dict* kwargs);


### PR DESCRIPTION
We optimize this kernel with a sort of checkpointing (see CHECKPOINT_INTERVAL in the code). It reduces intermediate buffer writes/reads by 4x. The backward recomputes values between checkpoints instead of reading them. The forward only writes every CHECKPOINT_INTERVAL amount of times. Also use fast math intrinsics where we can. End up with 2.3x forward and 1.03x backward speedups (about ~1.3x overall).

Had to fix some build issues i had as well.

Tested on 5090

```
fused_scan (N=4194304, 512x64x128, combined=512x64x384)
  	forward             74.0 us  442.54 M elem/s
  	backward           106.1 us  308.80 M elem/s
  	forward (checkpointed)   31.6 us  1038.33 M elem/s
  	backward (checkpointed)  103.4 us  316.86 M elem/s
  checkpointed forward correctness: out=ok(3.29e-05) next_state=ok(3.58e-05)
  checkpointed backward correctness: grad_combined=ok(5.43e-05) grad_state=ok(4.77e-07)
  ```