### PR TITLE
PPO kernel optimization

### DIFF
--- a/profile_kernels.cu
+++ b/profile_kernels.cu
@@ -14,13 +14,17 @@
 #include <string.h>
 #include <dlfcn.h>
 
-#include "pufferlib/extensions/vecenv.h"
 
 #ifdef USE_TORCH
 #include "pufferlib/extensions/pufferlib.cpp"
-#include "pufferlib/extensions/cuda/modules.cu"
+#include "pufferlib/extensions/cuda/kernels.cu"
+// #include "pufferlib/extensions/modules.cpp"
 using namespace pufferlib;
-#else
+#endif
+
+#include "pufferlib/extensions/vecenv.h"
+
+#ifndef USE_TORCH
 #include "pufferlib/extensions/cuda/kernels.cu"
 #endif
 
@@ -697,6 +701,23 @@ void run_fusedscan_backward(FusedScanArgs* args) {
         args->T, args->H, args->B, 0);
 }
 
+void run_fusedscan_forward_checkpointed(FusedScanArgs* args) {
+    launch_fused_scan_forward_checkpointed<float>(
+        args->out, args->next_state,
+        args->a_star, args->s_vals, args->log_values_buf,
+        args->combined, args->state,
+        args->T, args->H, args->B, 0);
+}
+
+void run_fusedscan_backward_checkpointed(FusedScanArgs* args) {
+    launch_fused_scan_backward_checkpointed<float>(
+        args->grad_combined, args->grad_state,
+        args->grad_out, args->grad_next_state,
+        args->combined, args->state,
+        args->a_star, args->s_vals, args->log_values_buf,
+        args->T, args->H, args->B, 0);
+}
+
 #ifdef USE_TORCH
 
 typedef struct {
@@ -745,6 +766,82 @@ void run_fusedscan_forward_cpp(FusedScanArgsTorch* args) {
     fused_scan_cpp(args->combined, args->state);
 }
 
+void test_fusedscan_checkpointed_correct(FusedScanArgsTorch* args) {
+    // Run reference (non-checkpointed) kernel forward
+    auto combined_ref = args->combined.clone().requires_grad_(true);
+    auto state_ref = args->state.clone().requires_grad_(true);
+    combined_ref.retain_grad();
+    state_ref.retain_grad();
+    auto ref_outputs = fused_scan(combined_ref, state_ref);
+    auto ref_out = ref_outputs[0];
+    auto ref_next_state = ref_outputs[1];
+
+    // Run checkpointed forward kernel via raw launch
+    auto opts = torch::TensorOptions().dtype(args->combined.dtype()).device(torch::kCUDA);
+    auto opts_float = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+    
+    auto out_ckpt = torch::empty({args->B, args->T, args->H}, opts);
+    auto next_state_ckpt = torch::empty({args->B, 1, args->H}, opts);
+    auto a_star = torch::empty({args->B, args->T + 1, args->H}, opts_float);
+    auto s_vals = torch::empty({args->B, args->T + 1, args->H}, opts_float);
+    auto log_values_buf = torch::empty({args->B, args->T + 1, args->H}, opts_float);
+    
+    launch_fused_scan_forward_checkpointed<float>(
+        out_ckpt.data_ptr<float>(),
+        next_state_ckpt.data_ptr<float>(),
+        a_star.data_ptr<float>(),
+        s_vals.data_ptr<float>(),
+        log_values_buf.data_ptr<float>(),
+        args->combined.data_ptr<float>(),
+        args->state.data_ptr<float>(),
+        args->T, args->H, args->B,
+        at::cuda::getCurrentCUDAStream());
+    cudaDeviceSynchronize();
+
+    // Numerical comparison - use same tolerances as other tests
+    float rtol = 1e-3f, atol = 1e-4f;
+    bool out_match = torch::allclose(out_ckpt, ref_out, rtol, atol);
+    float out_max_diff = (out_ckpt - ref_out).abs().max().item<float>();
+    bool next_state_match = torch::allclose(next_state_ckpt, ref_next_state, rtol, atol);
+    float next_state_max_diff = (next_state_ckpt - ref_next_state).abs().max().item<float>();
+
+    printf("  checkpointed forward correctness: out=%s(%.2e) next_state=%s(%.2e)\n",
+           out_match ? "\033[32mok\033[0m" : "\033[31mFAIL\033[0m", out_max_diff,
+           next_state_match ? "\033[32mok\033[0m" : "\033[31mFAIL\033[0m", next_state_max_diff);
+
+    // Test backward pass - run reference backward
+    torch::autograd::backward({ref_out, ref_next_state}, {args->grad_out, args->grad_next_state});
+    auto grad_combined_ref = combined_ref.grad().clone();
+    auto grad_state_ref = state_ref.grad().clone();
+
+    // Run checkpointed backward
+    auto grad_combined_ckpt = torch::empty_like(args->combined);
+    auto grad_state_ckpt = torch::empty_like(args->state);
+
+    launch_fused_scan_backward_checkpointed<float>(
+        grad_combined_ckpt.data_ptr<float>(),
+        grad_state_ckpt.data_ptr<float>(),
+        args->grad_out.data_ptr<float>(),
+        args->grad_next_state.data_ptr<float>(),
+        args->combined.data_ptr<float>(),
+        args->state.data_ptr<float>(),
+        a_star.data_ptr<float>(),
+        s_vals.data_ptr<float>(),
+        log_values_buf.data_ptr<float>(),
+        args->T, args->H, args->B,
+        at::cuda::getCurrentCUDAStream());
+    cudaDeviceSynchronize();
+
+    bool grad_combined_match = torch::allclose(grad_combined_ckpt, grad_combined_ref, rtol, atol);
+    float grad_combined_max_diff = (grad_combined_ckpt - grad_combined_ref).abs().max().item<float>();
+    bool grad_state_match = torch::allclose(grad_state_ckpt, grad_state_ref, rtol, atol);
+    float grad_state_max_diff = (grad_state_ckpt - grad_state_ref).abs().max().item<float>();
+
+    printf("  checkpointed backward correctness: grad_combined=%s(%.2e) grad_state=%s(%.2e)\n",
+           grad_combined_match ? "\033[32mok\033[0m" : "\033[31mFAIL\033[0m", grad_combined_max_diff,
+           grad_state_match ? "\033[32mok\033[0m" : "\033[31mFAIL\033[0m", grad_state_max_diff);
+}
+
 #endif
 
 void profile_fusedscan(int batch, int seq, int hidden) {
@@ -759,8 +856,16 @@ void profile_fusedscan(int batch, int seq, int hidden) {
     float bwd_ms = profile_kernel((kernel_fn)run_fusedscan_backward, args);
     print_timing("\tbackward", bwd_ms, batch*seq);
 
+    float fwd_ckpt_ms = profile_kernel((kernel_fn)run_fusedscan_forward_checkpointed, args);
+    print_timing("\tforward (checkpointed)", fwd_ckpt_ms, batch*seq);
+
+    float bwd_ckpt_ms = profile_kernel((kernel_fn)run_fusedscan_backward_checkpointed, args);
+    print_timing("\tbackward (checkpointed)", bwd_ckpt_ms, batch*seq);
+
 #ifdef USE_TORCH
     FusedScanArgsTorch* args_torch = create_fusedscanargs_torch(args);
+
+    test_fusedscan_checkpointed_correct(args_torch);
 
     float fwd_torch_ms = profile_kernel((kernel_fn)run_fusedscan_forward_torch, args_torch);
     print_timing("\tforward (torch)", fwd_torch_ms, batch*seq);

--- a/profile_kernels.cu
+++ b/profile_kernels.cu
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <dlfcn.h>
+#include <cmath>
 
 
 #ifdef USE_TORCH
@@ -1044,6 +1045,26 @@ void run_ppoloss_backward(PPOLossArgs* args) {
         args->T, args->A, args->N, 0);
 }
 
+void run_ppoloss_forward_opt(PPOLossArgs* args) {
+    launch_ppo_loss_forward_optimized<float>(
+        args->loss, args->saved_for_backward,
+        args->logits, args->values_pred, args->actions,
+        args->old_logprobs, args->advantages, args->prio,
+        args->values, args->returns, args->adv_mean, args->adv_std,
+        args->clip_coef, args->vf_clip_coef, args->vf_coef, args->ent_coef,
+        args->T, args->A, args->N, 0);
+}
+
+void run_ppoloss_backward_opt(PPOLossArgs* args) {
+    launch_ppo_loss_backward_optimized<float>(
+        args->grad_logits, args->grad_values_pred, args->grad_loss,
+        args->logits, args->values_pred, args->actions,
+        args->old_logprobs, args->advantages, args->prio,
+        args->values, args->returns, args->adv_mean, args->adv_std,
+        args->clip_coef, args->vf_clip_coef, args->vf_coef, args->ent_coef,
+        args->T, args->A, args->N, 0);
+}
+
 #ifdef USE_TORCH
 
 typedef struct {
@@ -1124,13 +1145,20 @@ void profile_ppoloss(int batch, int seq, int actions) {
     PPOLossArgs* args = create_ppolossargs(batch, seq, actions);
 
     int NT = batch*seq;
+    int NTA = batch*seq*actions;
     printf("ppo_loss (NT=%d, %dx%d, A=%d)\n", NT, batch, seq, actions);
 
     float fwd_ms = profile_kernel((kernel_fn)run_ppoloss_forward, args);
-    print_timing("\tforward", fwd_ms, NT);
+    print_timing("\tforward (original)", fwd_ms, NT);
 
     float bwd_ms = profile_kernel((kernel_fn)run_ppoloss_backward, args);
-    print_timing("\tbackward", bwd_ms, NT);
+    print_timing("\tbackward (original)", bwd_ms, NT);
+
+    float fwd_opt_ms = profile_kernel((kernel_fn)run_ppoloss_forward_opt, args);
+    print_timing("\tforward (optimized)", fwd_opt_ms, NT);
+
+    float bwd_opt_ms = profile_kernel((kernel_fn)run_ppoloss_backward_opt, args);
+    print_timing("\tbackward (optimized)", bwd_opt_ms, NT);
 
 #ifdef USE_TORCH
     PPOLossArgsTorch* args_torch = create_ppolossargs_torch(args);
@@ -1161,6 +1189,240 @@ void profile_ppoloss(int batch, int seq, int actions) {
 
     float fwd_graph_ms = profile_graph((kernel_fn)run_ppoloss_forward_cpp, args_torch);
     print_timing("\tforward (graph)", fwd_graph_ms, NT);
+
+    // ========================================================================
+    // Numerical Stability Comparison: Torch vs Original vs Optimized
+    // ========================================================================
+    printf("\n\tNumerical Stability Comparison:\n");
+
+    // Allocate separate output buffers for each implementation
+    float* loss_orig = nullptr;
+    float* loss_opt = nullptr;
+    double* saved_orig = nullptr;
+    double* saved_opt = nullptr;
+    float* grad_logits_orig = nullptr;
+    float* grad_logits_opt = nullptr;
+    float* grad_values_orig = nullptr;
+    float* grad_values_opt = nullptr;
+
+    cudaMalloc(&loss_orig, sizeof(float));
+    cudaMalloc(&loss_opt, sizeof(float));
+    cudaMalloc(&saved_orig, NT * 5 * sizeof(double));
+    cudaMalloc(&saved_opt, NT * 5 * sizeof(double));
+    cudaMalloc(&grad_logits_orig, NTA * sizeof(float));
+    cudaMalloc(&grad_logits_opt, NTA * sizeof(float));
+    cudaMalloc(&grad_values_orig, NT * sizeof(float));
+    cudaMalloc(&grad_values_opt, NT * sizeof(float));
+
+    // Zero loss buffers before kernel calls (they use atomicAdd)
+    cudaMemset(loss_orig, 0, sizeof(float));
+    cudaMemset(loss_opt, 0, sizeof(float));
+
+    // Run original forward
+    launch_ppo_loss_forward<float>(
+        loss_orig, saved_orig,
+        args->logits, args->values_pred, args->actions,
+        args->old_logprobs, args->advantages, args->prio,
+        args->values, args->returns, args->adv_mean, args->adv_std,
+        args->clip_coef, args->vf_clip_coef, args->vf_coef, args->ent_coef,
+        args->T, args->A, args->N, 0);
+
+    // Run optimized forward
+    launch_ppo_loss_forward_optimized<float>(
+        loss_opt, saved_opt,
+        args->logits, args->values_pred, args->actions,
+        args->old_logprobs, args->advantages, args->prio,
+        args->values, args->returns, args->adv_mean, args->adv_std,
+        args->clip_coef, args->vf_clip_coef, args->vf_coef, args->ent_coef,
+        args->T, args->A, args->N, 0);
+
+    // Run pure PyTorch reference (ground truth) - fused_ppo_loss_cpp is the correct implementation
+    torch::Tensor torch_loss = fused_ppo_loss_cpp(
+        args_torch->logits, args_torch->values_pred, args_torch->actions,
+        args_torch->old_logprobs, args_torch->advantages, args_torch->prio,
+        args_torch->values, args_torch->returns, args_torch->adv_mean, args_torch->adv_std,
+        args_torch->clip_coef, args_torch->vf_clip_coef, args_torch->vf_coef, args_torch->ent_coef);
+
+    cudaDeviceSynchronize();
+
+    // Copy results to host
+    float h_loss_orig, h_loss_opt;
+    cudaMemcpy(&h_loss_orig, loss_orig, sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(&h_loss_opt, loss_opt, sizeof(float), cudaMemcpyDeviceToHost);
+    float h_loss_torch = torch_loss.item<float>();
+
+    // Check for NaN/Inf
+    bool orig_nan = std::isnan(h_loss_orig) || std::isinf(h_loss_orig);
+    bool opt_nan = std::isnan(h_loss_opt) || std::isinf(h_loss_opt);
+    bool torch_nan = std::isnan(h_loss_torch) || std::isinf(h_loss_torch);
+
+    printf("\t  Forward Loss Values:\n");
+    printf("\t    PyTorch:   %.8f %s\n", h_loss_torch, torch_nan ? "(NaN/Inf!)" : "");
+    printf("\t    Original:  %.8f %s\n", h_loss_orig, orig_nan ? "(NaN/Inf!)" : "");
+    printf("\t    Optimized: %.8f %s\n", h_loss_opt, opt_nan ? "(NaN/Inf!)" : "");
+
+    // Compute relative differences
+    float diff_orig_torch = fabsf(h_loss_orig - h_loss_torch) / (fabsf(h_loss_torch) + 1e-8f);
+    float diff_opt_torch = fabsf(h_loss_opt - h_loss_torch) / (fabsf(h_loss_torch) + 1e-8f);
+    float diff_orig_opt = fabsf(h_loss_orig - h_loss_opt) / (fabsf(h_loss_orig) + 1e-8f);
+
+    printf("\t  Relative Differences:\n");
+    printf("\t    Original vs PyTorch:   %.2e %s\n", diff_orig_torch, diff_orig_torch > 0.01f ? "(>1%% MISMATCH)" : "(OK)");
+    printf("\t    Optimized vs PyTorch:  %.2e %s\n", diff_opt_torch, diff_opt_torch > 0.01f ? "(>1%% MISMATCH)" : "(OK)");
+    printf("\t    Original vs Optimized: %.2e %s\n", diff_orig_opt, diff_orig_opt > 1e-5f ? "(DIFF)" : "(OK)");
+    fflush(stdout);
+
+    // Run backward passes
+    float grad_loss_val = 1.0f;
+    cudaMemcpy(args->grad_loss, &grad_loss_val, sizeof(float), cudaMemcpyHostToDevice);
+
+    launch_ppo_loss_backward<float>(
+        grad_logits_orig, grad_values_orig, args->grad_loss,
+        args->logits, args->actions, args->old_logprobs,
+        args->advantages, args->prio, args->values, args->returns,
+        saved_orig, args->adv_mean, args->adv_std,
+        args->clip_coef, args->vf_clip_coef, args->vf_coef, args->ent_coef,
+        args->T, args->A, args->N, 0);
+
+    launch_ppo_loss_backward_optimized<float>(
+        grad_logits_opt, grad_values_opt, args->grad_loss,
+        args->logits, args->values_pred, args->actions,
+        args->old_logprobs, args->advantages, args->prio,
+        args->values, args->returns, args->adv_mean, args->adv_std,
+        args->clip_coef, args->vf_clip_coef, args->vf_coef, args->ent_coef,
+        args->T, args->A, args->N, 0);
+
+    // Run torch backward using fused_ppo_loss_cpp (pure PyTorch, has proper autograd)
+    bool torch_backward_ok = false;
+    try {
+        args_torch->logits.mutable_grad() = torch::Tensor();
+        args_torch->values_pred.mutable_grad() = torch::Tensor();
+        torch_loss.backward();
+        torch_backward_ok = args_torch->logits.grad().defined() && args_torch->values_pred.grad().defined();
+    } catch (...) {
+        torch_backward_ok = false;
+    }
+
+    cudaDeviceSynchronize();
+
+    // Copy gradients to host for comparison
+    float* h_grad_logits_orig = (float*)malloc(NTA * sizeof(float));
+    float* h_grad_logits_opt = (float*)malloc(NTA * sizeof(float));
+    float* h_grad_values_orig = (float*)malloc(NT * sizeof(float));
+    float* h_grad_values_opt = (float*)malloc(NT * sizeof(float));
+
+    cudaMemcpy(h_grad_logits_orig, grad_logits_orig, NTA * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_grad_logits_opt, grad_logits_opt, NTA * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_grad_values_orig, grad_values_orig, NT * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_grad_values_opt, grad_values_opt, NT * sizeof(float), cudaMemcpyDeviceToHost);
+
+    // Get torch gradients - check if backward succeeded
+    float* h_grad_logits_torch = nullptr;
+    float* h_grad_values_torch = nullptr;
+    bool has_torch_grads = torch_backward_ok;
+    
+    torch::Tensor torch_grad_logits, torch_grad_values;
+    if (has_torch_grads) {
+        torch_grad_logits = args_torch->logits.grad().contiguous().cpu();
+        torch_grad_values = args_torch->values_pred.grad().contiguous().cpu();
+        h_grad_logits_torch = torch_grad_logits.data_ptr<float>();
+        h_grad_values_torch = torch_grad_values.data_ptr<float>();
+    }
+    
+    // Debug: check torch gradient sizes
+    if (has_torch_grads) {
+        // Safety check - if sizes don't match, skip torch comparison
+        if (torch_grad_logits.numel() != NTA || torch_grad_values.numel() != NT) {
+            has_torch_grads = false;
+        }
+    }
+
+    // Compute gradient statistics
+    double grad_logits_orig_torch_diff = 0.0, grad_logits_opt_torch_diff = 0.0, grad_logits_orig_opt_diff = 0.0;
+    double grad_logits_orig_torch_max = 0.0, grad_logits_opt_torch_max = 0.0, grad_logits_orig_opt_max = 0.0;
+    int grad_logits_nan_orig = 0, grad_logits_nan_opt = 0, grad_logits_nan_torch = 0;
+
+    for (int i = 0; i < NTA; ++i) {
+        if (std::isnan(h_grad_logits_orig[i]) || std::isinf(h_grad_logits_orig[i])) grad_logits_nan_orig++;
+        if (std::isnan(h_grad_logits_opt[i]) || std::isinf(h_grad_logits_opt[i])) grad_logits_nan_opt++;
+
+        double d3 = fabs((double)h_grad_logits_orig[i] - (double)h_grad_logits_opt[i]);
+        grad_logits_orig_opt_diff += d3;
+        grad_logits_orig_opt_max = fmax(grad_logits_orig_opt_max, d3);
+
+        if (has_torch_grads) {
+            if (std::isnan(h_grad_logits_torch[i]) || std::isinf(h_grad_logits_torch[i])) grad_logits_nan_torch++;
+            double d1 = fabs((double)h_grad_logits_orig[i] - (double)h_grad_logits_torch[i]);
+            double d2 = fabs((double)h_grad_logits_opt[i] - (double)h_grad_logits_torch[i]);
+            grad_logits_orig_torch_diff += d1;
+            grad_logits_opt_torch_diff += d2;
+            grad_logits_orig_torch_max = fmax(grad_logits_orig_torch_max, d1);
+            grad_logits_opt_torch_max = fmax(grad_logits_opt_torch_max, d2);
+        }
+    }
+
+    double grad_values_orig_torch_diff = 0.0, grad_values_opt_torch_diff = 0.0, grad_values_orig_opt_diff = 0.0;
+    double grad_values_orig_torch_max = 0.0, grad_values_opt_torch_max = 0.0, grad_values_orig_opt_max = 0.0;
+    int grad_values_nan_orig = 0, grad_values_nan_opt = 0, grad_values_nan_torch = 0;
+
+    for (int i = 0; i < NT; ++i) {
+        if (std::isnan(h_grad_values_orig[i]) || std::isinf(h_grad_values_orig[i])) grad_values_nan_orig++;
+        if (std::isnan(h_grad_values_opt[i]) || std::isinf(h_grad_values_opt[i])) grad_values_nan_opt++;
+
+        double d3 = fabs((double)h_grad_values_orig[i] - (double)h_grad_values_opt[i]);
+        grad_values_orig_opt_diff += d3;
+        grad_values_orig_opt_max = fmax(grad_values_orig_opt_max, d3);
+
+        if (has_torch_grads) {
+            if (std::isnan(h_grad_values_torch[i]) || std::isinf(h_grad_values_torch[i])) grad_values_nan_torch++;
+            double d1 = fabs((double)h_grad_values_orig[i] - (double)h_grad_values_torch[i]);
+            double d2 = fabs((double)h_grad_values_opt[i] - (double)h_grad_values_torch[i]);
+            grad_values_orig_torch_diff += d1;
+            grad_values_opt_torch_diff += d2;
+            grad_values_orig_torch_max = fmax(grad_values_orig_torch_max, d1);
+            grad_values_opt_torch_max = fmax(grad_values_opt_torch_max, d2);
+        }
+    }
+
+    printf("\t  Backward grad_logits (NTA=%d):\n", NTA);
+    if (has_torch_grads) {
+        printf("\t    NaN/Inf counts: torch=%d, orig=%d, opt=%d\n", grad_logits_nan_torch, grad_logits_nan_orig, grad_logits_nan_opt);
+        printf("\t    Mean abs diff: orig-torch=%.2e, opt-torch=%.2e, orig-opt=%.2e\n",
+               grad_logits_orig_torch_diff/NTA, grad_logits_opt_torch_diff/NTA, grad_logits_orig_opt_diff/NTA);
+        printf("\t    Max abs diff:  orig-torch=%.2e, opt-torch=%.2e, orig-opt=%.2e\n",
+               grad_logits_orig_torch_max, grad_logits_opt_torch_max, grad_logits_orig_opt_max);
+    } else {
+        printf("\t    NaN/Inf counts: orig=%d, opt=%d (torch grads unavailable)\n", grad_logits_nan_orig, grad_logits_nan_opt);
+        printf("\t    Mean abs diff: orig-opt=%.2e\n", grad_logits_orig_opt_diff/NTA);
+        printf("\t    Max abs diff:  orig-opt=%.2e\n", grad_logits_orig_opt_max);
+    }
+
+    printf("\t  Backward grad_values (NT=%d):\n", NT);
+    if (has_torch_grads) {
+        printf("\t    NaN/Inf counts: torch=%d, orig=%d, opt=%d\n", grad_values_nan_torch, grad_values_nan_orig, grad_values_nan_opt);
+        printf("\t    Mean abs diff: orig-torch=%.2e, opt-torch=%.2e, orig-opt=%.2e\n",
+               grad_values_orig_torch_diff/NT, grad_values_opt_torch_diff/NT, grad_values_orig_opt_diff/NT);
+        printf("\t    Max abs diff:  orig-torch=%.2e, opt-torch=%.2e, orig-opt=%.2e\n",
+               grad_values_orig_torch_max, grad_values_opt_torch_max, grad_values_orig_opt_max);
+    } else {
+        printf("\t    NaN/Inf counts: orig=%d, opt=%d (torch grads unavailable)\n", grad_values_nan_orig, grad_values_nan_opt);
+        printf("\t    Mean abs diff: orig-opt=%.2e\n", grad_values_orig_opt_diff/NT);
+        printf("\t    Max abs diff:  orig-opt=%.2e\n", grad_values_orig_opt_max);
+    }
+
+    // Cleanup
+    free(h_grad_logits_orig);
+    free(h_grad_logits_opt);
+    free(h_grad_values_orig);
+    free(h_grad_values_opt);
+    cudaFree(loss_orig);
+    cudaFree(loss_opt);
+    cudaFree(saved_orig);
+    cudaFree(saved_opt);
+    cudaFree(grad_logits_orig);
+    cudaFree(grad_logits_opt);
+    cudaFree(grad_values_orig);
+    cudaFree(grad_values_opt);
 
     delete args_torch;
 #endif

--- a/pufferlib/extensions/cuda/kernels.cu
+++ b/pufferlib/extensions/cuda/kernels.cu
@@ -18,11 +18,16 @@
 
 #define SEQ_SIZE 256
 #define BLOCK_SIZE 256
+#define CHECKPOINT_INTERVAL 16  // Sparse checkpoint interval for optimized kernels
+#define OPT_BLOCK_SIZE 256     // Block size for optimized checkpointed kernels
 inline int grid_size(int N) {
     return (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
 }
 inline int seq_size(int N) {
     return (N + SEQ_SIZE - 1) / SEQ_SIZE;
+}
+inline int opt_grid_size(int N) {
+    return (N + OPT_BLOCK_SIZE - 1) / OPT_BLOCK_SIZE;
 }
 
 // If you can get this to work, go ahead. I tried.
@@ -512,6 +517,94 @@ __global__ void fused_scan_forward_kernel(
     next_state[state_idx] = T(scan_result);
 }
 
+
+// Optimized forward kernel with checkpointing
+// Writes checkpoints only every CHECKPOINT_INTERVAL timesteps (vs every time)
+// Uses fast math intrinsics for better performance
+template<typename T>
+__global__ void fused_scan_forward_kernel_checkpointed(
+    T* __restrict__ out,                 // (B, T, H) - sigmoid(proj) * scan_result
+    T* __restrict__ next_state,          // (B, 1, H) - raw scan_result at T (for recurrence)
+    float* __restrict__ a_star_buf,      // (B, T+1, H) - sparse checkpoints for backward
+    float* __restrict__ s_buf,           // (B, T+1, H) - sparse checkpoints for backward
+    float* __restrict__ log_values_buf,  // (B, T+1, H) - sparse checkpoints for backward
+    const T* __restrict__ combined,      // (B, T, 3*H) = [hidden(H), gate(H), proj(H)]
+    const T* __restrict__ state,         // (B, 1, H)
+    int T_seq,                           // sequence length (T)
+    int H,
+    int B
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= B * H) return;
+
+    int b = idx / H;
+    int h = idx % H;
+
+    int bH = b * H;
+    int H3 = 3 * H;
+    int H2 = 2 * H;
+    int bHT = bH * T_seq;
+    int out_base = bHT + h;
+    int cbase = 3 * bHT;
+
+    float a_star = 0.0f;
+    float log_value = 0.0f;
+
+    // Handle t=0 outside the loop: use log(state), coeff = 0
+    float s = __logf(float(state[bH + h]));
+    log_value = s;
+
+    int T_out = T_seq + 1;
+    int buf_base = b * T_out * H + h;
+    int buf_curr = buf_base;
+    a_star_buf[buf_curr] = a_star;
+    s_buf[buf_curr] = s;
+    log_values_buf[buf_curr] = log_value;
+
+    const T* combined_h_base = &combined[cbase + h];
+    const T* combined_g_base = &combined[cbase + H + h];
+    const T* combined_p_base = &combined[cbase + H2 + h];
+
+    // Loop t=1..T_seq with sparse checkpointing
+    float scan_result = 0.0f;
+    int out_curr = out_base;
+    int t_offset = 0;
+
+    for (int t = 1; t < T_seq + 1; t++) {
+        float hidden_val = float(combined_h_base[t_offset]);
+        float gate_val = float(combined_g_base[t_offset]);
+        float proj_val = float(combined_p_base[t_offset]);
+
+        float log_coeff_val;
+        log_coeffs_and_values_fwd(gate_val, hidden_val, &log_coeff_val, &log_value);
+
+        // a_star[t] = sum_{i=0}^t log_coeffs[i]
+        a_star += log_coeff_val;
+
+        float z = log_value - a_star;
+        float max_val = fmaxf(s, z);
+        s = max_val + log1pf(__expf(-fabsf(s - z)));
+
+        scan_result = __expf(a_star + s);
+        float proj_sigmoid = sigmoid(proj_val);
+
+        out[out_curr] = T(proj_sigmoid * scan_result);
+
+        buf_curr += H;
+        out_curr += H;
+        t_offset += H3;
+
+        if (t % CHECKPOINT_INTERVAL == 0) {
+            a_star_buf[buf_curr] = a_star;
+            s_buf[buf_curr] = s;
+            log_values_buf[buf_curr] = log_value;
+        }
+    }
+
+    // Write timestep T to next_state (raw scan_result, no proj, for recurrence)
+    next_state[bH + h] = T(scan_result);
+}
+
 // Fully fused backward: chains through sigmoid(proj)*out and log_coeffs_and_values
 // Takes combined (B, T, 3*H), outputs grad_combined (B, T, 3*H) = [grad_hidden, grad_gate, grad_proj]
 template<typename T>
@@ -629,6 +722,156 @@ __global__ void fused_scan_backward_kernel(
         }
     }
 }
+
+// Optimized backward kernel with sparse checkpoint loading
+// Reads sparse checkpoints from forward pass, recomputes intermediate values in chunks
+// Uses fast math intrinsics for better performance
+template<typename T>
+__global__ void fused_scan_backward_kernel_checkpointed(
+    T* __restrict__ grad_combined,         // (B, T, 3*H) = [grad_hidden, grad_gate, grad_proj]
+    T* __restrict__ grad_state,            // (B, 1, H)
+    const T* __restrict__ grad_out,        // (B, T, H) - gradient of sigmoid(proj)*scan_result
+    const T* __restrict__ grad_next_state, // (B, 1, H) - gradient of raw scan_result at T
+    const T* __restrict__ combined,        // (B, T, 3*H) = [hidden, gate, proj]
+    const T* __restrict__ state,           // (B, 1, H)
+    const float* __restrict__ a_star_buf,  // (B, T+1, H) sparse checkpoints from forward
+    const float* __restrict__ s_buf,       // (B, T+1, H) sparse checkpoints from forward
+    const float* __restrict__ log_values_buf, // (B, T+1, H) sparse checkpoints from forward
+    int T_seq,                             // sequence length (T)
+    int H,
+    int B
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= B * H) return;
+
+    int b = idx / H;
+    int h = idx % H;
+
+    int bHT = b * H * T_seq;
+    int cbase = 3 * bHT;
+    int H3 = 3 * H;
+    int H2 = 2 * H;
+    const int state_idx = b * H + h;
+    const int out_base = bHT + h;
+    
+    const T* combined_h_base = &combined[cbase + h];
+    const T* combined_g_base = &combined[cbase + H + h];
+    const T* combined_p_base = &combined[cbase + H2 + h];
+    
+    T* grad_combined_h_base = &grad_combined[cbase + h];
+    T* grad_combined_g_base = &grad_combined[cbase + H + h];
+    T* grad_combined_p_base = &grad_combined[cbase + H2 + h];
+    
+    int T_out = T_seq + 1;
+    int buf_base = b * T_out * H + h;
+
+    float acc = 0.0;
+    float s_val_next = 0.0;
+    float carry_grad_a = 0.0;
+    
+    for (int chunk_end = T_seq; chunk_end > 0; chunk_end -= CHECKPOINT_INTERVAL) {
+        int chunk_start = (chunk_end > CHECKPOINT_INTERVAL) ? (chunk_end - CHECKPOINT_INTERVAL) : 0;
+        int chunk_len = chunk_end - chunk_start;
+        
+        // Chunk storage in registers
+        float chunk_a_star[CHECKPOINT_INTERVAL];
+        float chunk_s[CHECKPOINT_INTERVAL];
+        float chunk_log_values[CHECKPOINT_INTERVAL];
+        float chunk_hidden[CHECKPOINT_INTERVAL];
+        float chunk_gate[CHECKPOINT_INTERVAL];
+        
+        // Load checkpoint from global memory
+        int ckpt_buf_idx = buf_base + chunk_start * H;
+        float recomp_a_star = a_star_buf[ckpt_buf_idx];
+        float recomp_s = s_buf[ckpt_buf_idx];
+        float recomp_log_value = log_values_buf[ckpt_buf_idx];
+        
+        // Recompute and store from chunk_start to chunk_end
+        for (int i = 0; i < chunk_len; ++i) {
+            int t = chunk_start + 1 + i;
+            int t_offset = (t - 1) * H3;
+            float hv = float(combined_h_base[t_offset]);
+            float gv = float(combined_g_base[t_offset]);
+            
+            float lc;
+            log_coeffs_and_values_fwd(gv, hv, &lc, &recomp_log_value);
+            recomp_a_star += lc;
+            
+            float z = recomp_log_value - recomp_a_star;
+            float mv = fmaxf(recomp_s, z);
+            recomp_s = mv + log1pf(__expf(-fabsf(recomp_s - z)));
+            
+            chunk_a_star[i] = recomp_a_star;
+            chunk_s[i] = recomp_s;
+            chunk_log_values[i] = recomp_log_value;
+            chunk_hidden[i] = hv;
+            chunk_gate[i] = gv;
+        }
+        
+        for (int i = chunk_len - 1; i >= 0; --i) {
+            int t = chunk_start + 1 + i;
+            int t_offset = (t - 1) * H3;
+            
+            float a_star_t = chunk_a_star[i];
+            float s_t = chunk_s[i];
+            float log_value_t = chunk_log_values[i];
+            float hidden_val = chunk_hidden[i];
+            float gate_val = chunk_gate[i];
+            
+            float proj_val = float(combined_p_base[t_offset]);
+            
+            float scan_result = __expf(a_star_t + s_t);
+            float z = log_value_t - a_star_t;
+            
+            float grad_out_val = float(grad_out[out_base + (t - 1) * H]);
+            
+            float grad_scan_from_next = (t == T_seq) ? float(grad_next_state[state_idx]) : 0.0f;
+            
+            float proj_sigmoid = sigmoid(proj_val);
+            float grad_scan_result = grad_scan_from_next + grad_out_val * proj_sigmoid;
+            float grad_proj = grad_out_val * scan_result * proj_sigmoid * (1.0f - proj_sigmoid);
+            
+            float grad_log_h = grad_scan_result * scan_result;
+            float grad_s = grad_log_h;
+            
+            if (t == T_seq) {
+                acc = grad_s;
+            } else {
+                acc = grad_s + acc * __expf(s_t - s_val_next);
+            }
+            float grad_z = acc * __expf(z - s_t);
+            s_val_next = s_t;
+            
+            float grad_a = grad_log_h + carry_grad_a - grad_z;
+            carry_grad_a = grad_a;
+            
+            float grad_g, grad_h;
+            log_coeffs_and_values_bwd(grad_a, grad_z, gate_val, hidden_val, &grad_g, &grad_h);
+            
+            grad_combined_h_base[t_offset] = T(grad_h);
+            grad_combined_g_base[t_offset] = T(grad_g);
+            grad_combined_p_base[t_offset] = T(grad_proj);
+        }
+    }
+    
+    int ckpt_0_idx = buf_base;
+    float a_star_0 = a_star_buf[ckpt_0_idx];
+    float s_0 = s_buf[ckpt_0_idx];
+    float log_value_0 = log_values_buf[ckpt_0_idx];
+    
+    float scan_result_0 = __expf(a_star_0 + s_0);
+    float z_0 = log_value_0 - a_star_0;
+    
+    float grad_scan_result_0 = 0.0f;
+    float grad_log_h_0 = grad_scan_result_0 * scan_result_0;
+    float grad_s_0 = grad_log_h_0;
+    
+    acc = grad_s_0 + acc * __expf(s_0 - s_val_next);
+    float grad_z_0 = acc * __expf(z_0 - s_0);
+    
+    grad_state[state_idx] = T(grad_z_0 / float(state[state_idx]));
+}
+
 
 /*
 template<typename T>
@@ -927,6 +1170,42 @@ void launch_fused_scan_forward(
     }
 }
 
+template<typename T>
+void launch_fused_scan_forward_checkpointed(
+    T* out,
+    T* next_state,
+    float* a_star,
+    float* s_vals,
+    float* log_values_buf,  // (B, T+1, H) - sparse checkpoints for backward
+    const T* combined,  // (B, T, 3*H) = [hidden, gate, proj]
+    const T* state,
+    int T_seq,
+    int H,
+    int B,
+    cudaStream_t stream
+) {
+    int total = B * H;
+    int grid = opt_grid_size(total);
+
+    fused_scan_forward_kernel_checkpointed<T><<<grid, OPT_BLOCK_SIZE, 0, stream>>>(
+        out,
+        next_state,
+        a_star,
+        s_vals,
+        log_values_buf,
+        combined,
+        state,
+        T_seq,
+        H,
+        B
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA kernel launch error in checkpointed forward: %s\n", cudaGetErrorString(err));
+    }
+}
+
 // Fully fused backward launch: outputs grad_combined (B, T, 3*H) = [grad_hidden, grad_gate, grad_proj]
 template<typename T>
 void launch_fused_scan_backward(
@@ -967,6 +1246,49 @@ void launch_fused_scan_backward(
         fprintf(stderr, "CUDA kernel launch error in backward: %s\n", cudaGetErrorString(err));
     }
 }
+
+// Optimized backward launch with sparse checkpoint loading
+// Reads sparse checkpoints from forward pass, recomputes intermediate values in chunks
+template<typename T>
+void launch_fused_scan_backward_checkpointed(
+    T* grad_combined,   // (B, T, 3*H) = [grad_hidden, grad_gate, grad_proj]
+    T* grad_state,
+    const T* grad_out,
+    const T* grad_next_state,
+    const T* combined,  // (B, T, 3*H) = [hidden, gate, proj]
+    const T* state,
+    const float* a_star_buf,  // (B, T+1, H) - sparse checkpoints from forward
+    const float* s_buf,       // (B, T+1, H) - sparse checkpoints from forward
+    const float* log_values_buf,  // (B, T+1, H) - sparse checkpoints from forward
+    int T_seq,
+    int H,
+    int B,
+    cudaStream_t stream
+) {
+    int total = B * H;
+    int grid = opt_grid_size(total);
+
+    fused_scan_backward_kernel_checkpointed<T><<<grid, OPT_BLOCK_SIZE, 0, stream>>>(
+        grad_combined,
+        grad_state,
+        grad_out,
+        grad_next_state,
+        combined,
+        state,
+        a_star_buf,
+        s_buf,
+        log_values_buf,
+        T_seq,
+        H,
+        B
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA kernel launch error in checkpointed backward: %s\n", cudaGetErrorString(err));
+    }
+}
+
 
 /*
 __device__ __forceinline__ float log_add_exp(const float a, const float b) {
@@ -1713,6 +2035,20 @@ void launch_fused_scan_forward_bf16(at::BFloat16* out, at::BFloat16* next_state,
 }
 void launch_fused_scan_backward_bf16(at::BFloat16* grad_combined, at::BFloat16* grad_state, const at::BFloat16* grad_out, const at::BFloat16* grad_next_state, const at::BFloat16* combined, const at::BFloat16* state, const float* a_star_buf, const float* s_buf, const float* log_values_buf, int T_seq, int H, int B, cudaStream_t stream) {
     launch_fused_scan_backward<at::BFloat16>(grad_combined, grad_state, grad_out, grad_next_state, combined, state, a_star_buf, s_buf, log_values_buf, T_seq, H, B, stream);
+}
+// Non-templated wrappers for checkpointed fused scan - Float
+void launch_fused_scan_forward_checkpointed_float(float* out, float* next_state, float* a_star, float* s_vals, float* log_values_buf, const float* combined, const float* state, int T_seq, int H, int B, cudaStream_t stream) {
+    launch_fused_scan_forward_checkpointed<float>(out, next_state, a_star, s_vals, log_values_buf, combined, state, T_seq, H, B, stream);
+}
+void launch_fused_scan_backward_checkpointed_float(float* grad_combined, float* grad_state, const float* grad_out, const float* grad_next_state, const float* combined, const float* state, const float* a_star_buf, const float* s_buf, const float* log_values_buf, int T_seq, int H, int B, cudaStream_t stream) {
+    launch_fused_scan_backward_checkpointed<float>(grad_combined, grad_state, grad_out, grad_next_state, combined, state, a_star_buf, s_buf, log_values_buf, T_seq, H, B, stream);
+}
+// Non-templated wrappers for checkpointed fused scan - BFloat16
+void launch_fused_scan_forward_checkpointed_bf16(at::BFloat16* out, at::BFloat16* next_state, float* a_star, float* s_vals, float* log_values_buf, const at::BFloat16* combined, const at::BFloat16* state, int T_seq, int H, int B, cudaStream_t stream) {
+    launch_fused_scan_forward_checkpointed<at::BFloat16>(out, next_state, a_star, s_vals, log_values_buf, combined, state, T_seq, H, B, stream);
+}
+void launch_fused_scan_backward_checkpointed_bf16(at::BFloat16* grad_combined, at::BFloat16* grad_state, const at::BFloat16* grad_out, const at::BFloat16* grad_next_state, const at::BFloat16* combined, const at::BFloat16* state, const float* a_star_buf, const float* s_buf, const float* log_values_buf, int T_seq, int H, int B, cudaStream_t stream) {
+    launch_fused_scan_backward_checkpointed<at::BFloat16>(grad_combined, grad_state, grad_out, grad_next_state, combined, state, a_star_buf, s_buf, log_values_buf, T_seq, H, B, stream);
 }
 void launch_logcumsumexp_forward_bf16(at::BFloat16* out, double* s_buf, const at::BFloat16* x, int T_total, int H, int B, cudaStream_t stream) {
     launch_logcumsumexp_forward<at::BFloat16>(out, s_buf, x, T_total, H, B, stream);

--- a/pufferlib/extensions/cuda/kernels.cu
+++ b/pufferlib/extensions/cuda/kernels.cu
@@ -519,14 +519,14 @@ __global__ void fused_scan_forward_kernel(
 // Uses fast math intrinsics for better performance
 template<typename T>
 __global__ void fused_scan_forward_kernel_checkpointed(
-    T* __restrict__ out,                 // (B, T, H) - sigmoid(proj) * scan_result
-    T* __restrict__ next_state,          // (B, 1, H) - raw scan_result at T (for recurrence)
-    float* __restrict__ a_star_buf,      // (B, T+1, H) - sparse checkpoints for backward
-    float* __restrict__ s_buf,           // (B, T+1, H) - sparse checkpoints for backward
-    float* __restrict__ log_values_buf,  // (B, T+1, H) - sparse checkpoints for backward
-    const T* __restrict__ combined,      // (B, T, 3*H) = [hidden(H), gate(H), proj(H)]
+    T* __restrict__ out,                 // (B, T, H)
+    T* __restrict__ next_state,          // (B, 1, H)
+    float* __restrict__ a_star_buf,      // (B, T+1, H)
+    float* __restrict__ s_buf,           // (B, T+1, H)
+    float* __restrict__ log_values_buf,  // (B, T+1, H)
+    const T* __restrict__ combined,      // (B, T, 3*H)
     const T* __restrict__ state,         // (B, 1, H)
-    int T_seq,                           // sequence length (T)
+    int T_seq,
     int H,
     int B
 ) {
@@ -724,16 +724,16 @@ __global__ void fused_scan_backward_kernel(
 // Uses fast math intrinsics for better performance
 template<typename T>
 __global__ void fused_scan_backward_kernel_checkpointed(
-    T* __restrict__ grad_combined,         // (B, T, 3*H) = [grad_hidden, grad_gate, grad_proj]
+    T* __restrict__ grad_combined,         // (B, T, 3*H)
     T* __restrict__ grad_state,            // (B, 1, H)
-    const T* __restrict__ grad_out,        // (B, T, H) - gradient of sigmoid(proj)*scan_result
-    const T* __restrict__ grad_next_state, // (B, 1, H) - gradient of raw scan_result at T
-    const T* __restrict__ combined,        // (B, T, 3*H) = [hidden, gate, proj]
+    const T* __restrict__ grad_out,        // (B, T, H)
+    const T* __restrict__ grad_next_state, // (B, 1, H)
+    const T* __restrict__ combined,        // (B, T, 3*H)
     const T* __restrict__ state,           // (B, 1, H)
-    const float* __restrict__ a_star_buf,  // (B, T+1, H) sparse checkpoints from forward
-    const float* __restrict__ s_buf,       // (B, T+1, H) sparse checkpoints from forward
-    const float* __restrict__ log_values_buf, // (B, T+1, H) sparse checkpoints from forward
-    int T_seq,                             // sequence length (T)
+    const float* __restrict__ a_star_buf,  // (B, T+1, H)
+    const float* __restrict__ s_buf,       // (B, T+1, H)
+    const float* __restrict__ log_values_buf, // (B, T+1, H)
+    int T_seq,                             // (T)
     int H,
     int B
 ) {
@@ -1172,8 +1172,8 @@ void launch_fused_scan_forward_checkpointed(
     T* next_state,
     float* a_star,
     float* s_vals,
-    float* log_values_buf,  // (B, T+1, H) - sparse checkpoints for backward
-    const T* combined,  // (B, T, 3*H) = [hidden, gate, proj]
+    float* log_values_buf,  // (B, T+1, H)
+    const T* combined,  // (B, T, 3*H)
     const T* state,
     int T_seq,
     int H,
@@ -1247,15 +1247,15 @@ void launch_fused_scan_backward(
 // Reads sparse checkpoints from forward pass, recomputes intermediate values in chunks
 template<typename T>
 void launch_fused_scan_backward_checkpointed(
-    T* grad_combined,   // (B, T, 3*H) = [grad_hidden, grad_gate, grad_proj]
+    T* grad_combined,   // (B, T, 3*H)
     T* grad_state,
     const T* grad_out,
     const T* grad_next_state,
-    const T* combined,  // (B, T, 3*H) = [hidden, gate, proj]
+    const T* combined,  // (B, T, 3*H)
     const T* state,
-    const float* a_star_buf,  // (B, T+1, H) - sparse checkpoints from forward
-    const float* s_buf,       // (B, T+1, H) - sparse checkpoints from forward
-    const float* log_values_buf,  // (B, T+1, H) - sparse checkpoints from forward
+    const float* a_star_buf,  // (B, T+1, H)
+    const float* s_buf,       // (B, T+1, H)
+    const float* log_values_buf,  // (B, T+1, H)
     int T_seq,
     int H,
     int B,

--- a/pufferlib/extensions/cuda/kernels.cu
+++ b/pufferlib/extensions/cuda/kernels.cu
@@ -16,6 +16,10 @@
 #include <cstdio>
 #include <cstdint>
 
+#define WARP_SIZE 32
+#define PPO_THREADS 256
+#define FULL_MASK 0xffffffff
+
 #define SEQ_SIZE 256
 #define BLOCK_SIZE 256
 #define CHECKPOINT_INTERVAL 4  // Sparse checkpoint interval for optimized kernels
@@ -1461,6 +1465,344 @@ void launch_logcumsumexp_backward(
 }
 
 template<typename T>
+__global__ void ppo_loss_forward_kernel_optimized(
+    float* __restrict__ loss,
+    double* __restrict__ saved_for_backward,
+    const T* __restrict__ logits,
+    const T* __restrict__ values_pred,
+    const int64_t* __restrict__ actions,
+    const T* __restrict__ old_logprobs,
+    const T* __restrict__ advantages,
+    const T* __restrict__ prio,
+    const T* __restrict__ values,
+    const T* __restrict__ returns,
+    const float* __restrict__ adv_mean,
+    const float* __restrict__ adv_std,
+    float clip_coef,
+    float vf_clip_coef,
+    float vf_coef,
+    float ent_coef,
+    int T_seq,
+    int A,
+    int N
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total_elements = N * T_seq;
+    if (idx >= total_elements) return;
+
+    __shared__ float block_loss[PPO_THREADS];
+
+    int n = idx / T_seq;
+    int t = idx % T_seq;
+    int nt = n * T_seq + t;
+    int logits_offset = n * T_seq * A + t * A;
+    int act = actions[nt];
+
+    float max_logit = -INFINITY;
+    float sum = 0.0f;
+    float act_logit = 0.0f;
+
+    for (int a = 0; a < A; a++) {
+        float l = float(logits[logits_offset + a]);
+
+        // cache the action's logit
+        if (a == act) {
+            act_logit = l;
+        }
+
+        // rescale
+        if (l > max_logit) {
+            sum *= __expf(max_logit - l);
+            max_logit = l;
+        }
+        sum += __expf(l - max_logit);
+    }
+
+    float logsumexp = max_logit + __logf(sum);
+
+    float entropy = 0.0f;
+    for (int a = 0; a < A; a++) {
+        float l = float(logits[logits_offset + a]);
+        float logp = l - logsumexp;
+        float p = __expf(logp);
+        entropy -= p * logp;
+    }
+
+    float new_logp = act_logit - logsumexp;
+    float old_logp = float(old_logprobs[nt]);
+    float adv = float(advantages[nt]);
+    float w = float(prio[n]);
+    float adv_normalized = (adv - adv_mean[0]) / (adv_std[0] + 1e-8f);
+
+    float logratio = new_logp - old_logp;
+    float ratio = __expf(logratio);
+
+    float ratio_clipped = fmaxf(1.0f - clip_coef, fminf(1.0f + clip_coef, ratio));
+    float wa = -w * adv_normalized;
+    float pg_loss1 = wa * ratio;
+    float pg_loss2 = wa * ratio_clipped;
+    float pg_loss = fmaxf(pg_loss1, pg_loss2);
+
+    float val = float(values[nt]);
+    float ret = float(returns[nt]);
+    float val_pred = float(values_pred[nt]);
+
+    float v_error = val_pred - val;
+    float v_clipped = val + fmaxf(-vf_clip_coef, fminf(vf_clip_coef, v_error));
+    float v_loss_unclipped = (val_pred - ret) * (val_pred - ret);
+    float v_loss_clipped = (v_clipped - ret) * (v_clipped - ret);
+    float v_loss = 0.5f * fmaxf(v_loss_unclipped, v_loss_clipped);
+
+    float thread_loss = (pg_loss + vf_coef * v_loss - ent_coef * entropy) / float(total_elements);
+
+    int tid = threadIdx.x;
+    block_loss[tid] = thread_loss;
+    __syncthreads();
+
+    for (int stride = PPO_THREADS / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            block_loss[tid] += block_loss[tid + stride];
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        atomicAdd(loss, block_loss[0]);
+    }
+}
+
+
+template<typename T>
+__global__ void ppo_loss_backward_kernel_optimized(
+    T* __restrict__ grad_logits,
+    T* __restrict__ grad_values_pred,
+    const float* __restrict__ grad_loss,
+    const T* __restrict__ logits,
+    const T* __restrict__ values_pred,
+    const int64_t* __restrict__ actions,
+    const T* __restrict__ old_logprobs,
+    const T* __restrict__ advantages,
+    const T* __restrict__ prio,
+    const T* __restrict__ values,
+    const T* __restrict__ returns,
+    const float* __restrict__ adv_mean,
+    const float* __restrict__ adv_std,
+    float clip_coef,
+    float vf_clip_coef,
+    float vf_coef,
+    float ent_coef,
+    int T_seq,
+    int A,
+    int N
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total_elements = N * T_seq;
+    if (idx >= total_elements) return;
+
+    float inv_NT = 1.0f / float(total_elements);
+    int n = idx / T_seq;
+    int t = idx % T_seq;
+    int nt = n * T_seq + t;
+    int logits_offset = n * T_seq * A + t * A;
+    int act = actions[nt];
+
+    float old_logp = float(old_logprobs[nt]);
+    float adv = float(advantages[nt]);
+    float w = float(prio[n]);
+    float val = float(values[nt]);
+    float ret = float(returns[nt]);
+    float val_pred = float(values_pred[nt]);
+
+    float max_logit = -INFINITY;
+    float sum = 0.0f;
+    float act_logit = 0.0f;
+
+    for (int a = 0; a < A; a++) {
+        float l = float(logits[logits_offset + a]);
+        if (a == act) act_logit = l;
+
+        if (l > max_logit) {
+            sum *= __expf(max_logit - l);
+            max_logit = l;
+        }
+        sum += __expf(l - max_logit);
+    }
+    float logsumexp = max_logit + __logf(sum);
+
+    float entropy = 0.0f;
+    for (int a = 0; a < A; a++) {
+        float l = float(logits[logits_offset + a]);
+        float logp = l - logsumexp;
+        float p = __expf(logp);
+        entropy -= p * logp;
+    }
+
+    // recompute values that were saved in forward
+    float new_logp = act_logit - logsumexp;
+    float ratio = __expf(new_logp - old_logp);
+    float v_error = val_pred - val;
+    float v_clipped = val + fmaxf(-vf_clip_coef, fminf(vf_clip_coef, v_error));
+
+    // nrmalize advantage
+    float adv_normalized = (adv - adv_mean[0]) / (adv_std[0] + 1e-8f);
+
+    // loss gradient scaling
+    float dL = grad_loss[0] * inv_NT;
+    float d_pg_loss = dL;
+    float d_entropy_term = dL * (-ent_coef);
+
+    // gradient wrt value function prediction
+    float v_loss_unclipped = (val_pred - ret) * (val_pred - ret);
+    float v_loss_clipped = (v_clipped - ret) * (v_clipped - ret);
+    bool use_clipped_vf = (v_loss_clipped > v_loss_unclipped);
+
+    float d_val_pred = 0.0f;
+    if (use_clipped_vf) {
+        if (v_error >= -vf_clip_coef && v_error <= vf_clip_coef) {
+            d_val_pred = v_clipped - ret;
+        }
+    } else {
+        d_val_pred = val_pred - ret;
+    }
+    grad_values_pred[nt] = T(dL * vf_coef * d_val_pred);
+
+    // policy loss gradient
+    float ratio_clipped = fmaxf(1.0f - clip_coef, fminf(1.0f + clip_coef, ratio));
+    float pg_loss1 = -w * adv_normalized * ratio;
+    float pg_loss2 = -w * adv_normalized * ratio_clipped;
+
+    float d_ratio = -w * adv_normalized * d_pg_loss;
+    if (pg_loss2 > pg_loss1) {
+        if (ratio <= (1.0f - clip_coef) || ratio >= (1.0f + clip_coef)) {
+            d_ratio = 0.0f;
+        }
+    }
+    float d_new_logp = d_ratio * ratio;
+
+    for (int a = 0; a < A; a++) {
+        float l = float(logits[logits_offset + a]);
+        float logp = l - logsumexp;
+        float p = __expf(logp);
+
+        float d_logit = (a == act) ? d_new_logp : 0.0f;
+        d_logit -= p * d_new_logp;
+
+        d_logit += d_entropy_term * p * (entropy - logp);
+        grad_logits[logits_offset + a] = T(d_logit);
+    }
+}
+
+template<typename T>
+inline void launch_ppo_loss_forward_optimized(
+    float* loss_output,
+    double* saved_for_backward,
+    const T* logits,
+    const T* values_pred,
+    const int64_t* actions,
+    const T* old_logprobs,
+    const T* advantages,
+    const T* prio,
+    const T* values,
+    const T* returns,
+    const float* adv_mean,
+    const float* adv_std,
+    float clip_coef,
+    float vf_clip_coef,
+    float vf_coef,
+    float ent_coef,
+    int T_seq,
+    int A,
+    int N,
+    cudaStream_t stream
+) {
+    int total = N * T_seq;
+    int grid = (total + PPO_THREADS - 1) / PPO_THREADS;
+    ppo_loss_forward_kernel_optimized<T><<<grid, PPO_THREADS, 0, stream>>>(
+        loss_output,
+        saved_for_backward,
+        logits,
+        values_pred,
+        actions,
+        old_logprobs,
+        advantages,
+        prio,
+        values,
+        returns,
+        adv_mean,
+        adv_std,
+        clip_coef,
+        vf_clip_coef,
+        vf_coef,
+        ent_coef,
+        T_seq,
+        A,
+        N
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "PPO forward optimized kernel error: %s\n", cudaGetErrorString(err));
+    }
+}
+
+template<typename T>
+void launch_ppo_loss_backward_optimized(
+    T* grad_logits,
+    T* grad_values_pred,
+    const float* grad_loss,
+    const T* logits,
+    const T* values_pred,    // added: need to read val_pred directly
+    const int64_t* actions,
+    const T* old_logprobs,
+    const T* advantages,
+    const T* prio,
+    const T* values,
+    const T* returns,
+    const float* adv_mean,
+    const float* adv_std,
+    float clip_coef,
+    float vf_clip_coef,
+    float vf_coef,
+    float ent_coef,
+    int T_seq,
+    int A,
+    int N,
+    cudaStream_t stream
+) {
+    int total = N * T_seq;
+    int grid = (total + PPO_THREADS - 1) / PPO_THREADS;
+
+    ppo_loss_backward_kernel_optimized<T><<<grid, PPO_THREADS, 0, stream>>>(
+        grad_logits,
+        grad_values_pred,
+        grad_loss,
+        logits,
+        values_pred,
+        actions,
+        old_logprobs,
+        advantages,
+        prio,
+        values,
+        returns,
+        adv_mean,
+        adv_std,
+        clip_coef,
+        vf_clip_coef,
+        vf_coef,
+        ent_coef,
+        T_seq,
+        A,
+        N
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "PPO backward optimized kernel error: %s\n", cudaGetErrorString(err));
+    }
+}
+
+
+template<typename T>
 __global__ void ppo_loss_forward_kernel(
     float* __restrict__ loss,
     double* __restrict__ saved_for_backward,
@@ -2060,6 +2402,20 @@ void launch_ppo_loss_backward_bf16(at::BFloat16* grad_logits, at::BFloat16* grad
 }
 void launch_sample_logits_bf16(double* actions, at::BFloat16* logprobs, at::BFloat16* value_out, const at::BFloat16* logits, const at::BFloat16* value, uint64_t seed, const int64_t* offset_ptr, int A, int B, int logits_stride, int value_stride, cudaStream_t stream) {
     launch_sample_logits<at::BFloat16>(actions, logprobs, value_out, logits, value, seed, offset_ptr, A, B, logits_stride, value_stride, stream);
+}
+
+void launch_ppo_loss_forward_optimized_float(float* loss_output, double* saved_for_backward, const float* logits, const float* values_pred, const int64_t* actions, const float* old_logprobs, const float* advantages, const float* prio, const float* values, const float* returns, const float* adv_mean, const float* adv_std, float clip_coef, float vf_clip_coef, float vf_coef, float ent_coef, int T_seq, int A, int N, cudaStream_t stream) {
+    launch_ppo_loss_forward_optimized<float>(loss_output, saved_for_backward, logits, values_pred, actions, old_logprobs, advantages, prio, values, returns, adv_mean, adv_std, clip_coef, vf_clip_coef, vf_coef, ent_coef, T_seq, A, N, stream);
+}
+void launch_ppo_loss_backward_optimized_float(float* grad_logits, float* grad_values_pred, const float* grad_loss, const float* logits, const float* values_pred, const int64_t* actions, const float* old_logprobs, const float* advantages, const float* prio, const float* values, const float* returns, const float* adv_mean, const float* adv_std, float clip_coef, float vf_clip_coef, float vf_coef, float ent_coef, int T_seq, int A, int N, cudaStream_t stream) {
+    launch_ppo_loss_backward_optimized<float>(grad_logits, grad_values_pred, grad_loss, logits, values_pred, actions, old_logprobs, advantages, prio, values, returns, adv_mean, adv_std, clip_coef, vf_clip_coef, vf_coef, ent_coef, T_seq, A, N, stream);
+}
+
+void launch_ppo_loss_forward_optimized_bf16(float* loss_output, double* saved_for_backward, const at::BFloat16* logits, const at::BFloat16* values_pred, const int64_t* actions, const at::BFloat16* old_logprobs, const at::BFloat16* advantages, const at::BFloat16* prio, const at::BFloat16* values, const at::BFloat16* returns, const float* adv_mean, const float* adv_std, float clip_coef, float vf_clip_coef, float vf_coef, float ent_coef, int T_seq, int A, int N, cudaStream_t stream) {
+    launch_ppo_loss_forward_optimized<at::BFloat16>(loss_output, saved_for_backward, logits, values_pred, actions, old_logprobs, advantages, prio, values, returns, adv_mean, adv_std, clip_coef, vf_clip_coef, vf_coef, ent_coef, T_seq, A, N, stream);
+}
+void launch_ppo_loss_backward_optimized_bf16(at::BFloat16* grad_logits, at::BFloat16* grad_values_pred, const float* grad_loss, const at::BFloat16* logits, const at::BFloat16* values_pred, const int64_t* actions, const at::BFloat16* old_logprobs, const at::BFloat16* advantages, const at::BFloat16* prio, const at::BFloat16* values, const at::BFloat16* returns, const float* adv_mean, const float* adv_std, float clip_coef, float vf_clip_coef, float vf_coef, float ent_coef, int T_seq, int A, int N, cudaStream_t stream) {
+    launch_ppo_loss_backward_optimized<at::BFloat16>(grad_logits, grad_values_pred, grad_loss, logits, values_pred, actions, old_logprobs, advantages, prio, values, returns, adv_mean, adv_std, clip_coef, vf_clip_coef, vf_coef, ent_coef, T_seq, A, N, stream);
 }
 
 #endif // PUFFERLIB_KERNELS_CU

--- a/pufferlib/extensions/cuda/kernels.cu
+++ b/pufferlib/extensions/cuda/kernels.cu
@@ -18,16 +18,12 @@
 
 #define SEQ_SIZE 256
 #define BLOCK_SIZE 256
-#define CHECKPOINT_INTERVAL 16  // Sparse checkpoint interval for optimized kernels
-#define OPT_BLOCK_SIZE 256     // Block size for optimized checkpointed kernels
+#define CHECKPOINT_INTERVAL 4  // Sparse checkpoint interval for optimized kernels
 inline int grid_size(int N) {
     return (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
 }
 inline int seq_size(int N) {
     return (N + SEQ_SIZE - 1) / SEQ_SIZE;
-}
-inline int opt_grid_size(int N) {
-    return (N + OPT_BLOCK_SIZE - 1) / OPT_BLOCK_SIZE;
 }
 
 // If you can get this to work, go ahead. I tried.
@@ -1185,9 +1181,9 @@ void launch_fused_scan_forward_checkpointed(
     cudaStream_t stream
 ) {
     int total = B * H;
-    int grid = opt_grid_size(total);
+    int grid = grid_size(total);
 
-    fused_scan_forward_kernel_checkpointed<T><<<grid, OPT_BLOCK_SIZE, 0, stream>>>(
+    fused_scan_forward_kernel_checkpointed<T><<<grid, BLOCK_SIZE, 0, stream>>>(
         out,
         next_state,
         a_star,
@@ -1266,9 +1262,9 @@ void launch_fused_scan_backward_checkpointed(
     cudaStream_t stream
 ) {
     int total = B * H;
-    int grid = opt_grid_size(total);
+    int grid = grid_size(total);
 
-    fused_scan_backward_kernel_checkpointed<T><<<grid, OPT_BLOCK_SIZE, 0, stream>>>(
+    fused_scan_backward_kernel_checkpointed<T><<<grid, BLOCK_SIZE, 0, stream>>>(
         grad_combined,
         grad_state,
         grad_out,

--- a/pufferlib/extensions/vecenv.h
+++ b/pufferlib/extensions/vecenv.h
@@ -5,7 +5,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>
+#ifndef __cplusplus
 #include <stdatomic.h>
+#endif
 #include <cuda_runtime.h>
 
 #define FLOAT 1
@@ -92,6 +94,10 @@ void dict_set_ptr(Dict* dict, const char* key, void* ptr) {
     dict->items[dict->size].key = key;
     dict->items[dict->size].ptr = ptr;
     dict->size++;
+}
+
+void dict_set_int(Dict* dict, const char* key, int value) {
+    dict_set(dict, key, (double)value);
 }
 
 void* my_shared(Env* env, Dict* kwargs);


### PR DESCRIPTION
This kernel mainly attains a speed up from doing an online softmax in both the forward and backward passes and doing computation in 32 bit instead of 64 bit precision. It also avoids writing intermediate values to be used in the backward pass in favor of recomputation.

```
ppo_loss (NT=32768, 512x64, A=4)
  	forward (original)   17.3 us  1897.58 M elem/s
  	backward (original)   14.4 us  2279.77 M elem/s
  	forward (optimized)    3.3 us  9848.82 M elem/s
  	backward (optimized)    3.3 us  9787.83 M elem/s
  	forward (torch)     17.3 us  1890.14 M elem/s
  	backward (torch)   141.5 us  231.54 M elem/s
  	forward (cpp)      220.1 us  148.87 M elem/s
  	backward (cpp)    1084.5 us   30.21 M elem/s
  	forward (graph)     49.2 us  666.60 M elem/s
 ```