### PR TITLE
Update cogames dependency to use public repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,8 +117,8 @@ metta = [
     'hydra-core',
     'duckdb',
     'raylib>=5.5.0',
-    'metta-common @ git+https://github.com/metta-ai/metta.git@main#subdirectory=common',
-    'metta-mettagrid @ git+https://github.com/metta-ai/metta.git@main#subdirectory=mettagrid',
+    'mettagrid @ git+https://github.com/metta-ai/mettagrid.git',
+    'cogames @ git+https://github.com/metta-ai/cogames.git',
 ]
 
 cogames = [
@@ -128,8 +128,8 @@ cogames = [
     'hydra-core',
     'duckdb',
     'raylib>=5.5.0',
-    'mettagrid @ git+https://github.com/metta-ai/metta.git@main#subdirectory=packages/mettagrid',
-    'cogames @ git+https://github.com/metta-ai/metta.git@main#subdirectory=packages/cogames',
+    'mettagrid @ git+https://github.com/metta-ai/mettagrid.git',
+    'cogames @ git+https://github.com/metta-ai/cogames.git',
 ]
 
 microrts = [


### PR DESCRIPTION
The Metta repository is now private, so dependency resolution fails for `cogames` and `mettagrid`. Switch to the public versions of the packages instead. This change is still blocked by Metta PR #5986: https://github.com/Metta-AI/metta/pull/5986
.