### PR TITLE
fix division by zero in anneal_beta when total_timesteps < batch_size

### DIFF
--- a/pufferlib/extensions/pufferlib.cpp
+++ b/pufferlib/extensions/pufferlib.cpp
@@ -366,6 +366,7 @@ void train_impl(PuffeRL& pufferl) {
     Muon* muon = pufferl.muon;
 
     int total_epochs = hypers.total_timesteps / batch_size;
+    if (total_epochs < 1) total_epochs = 1;
 
     if (anneal_lr) {
         float lr_min = hypers.min_lr_ratio * hypers.lr;


### PR DESCRIPTION
`total_epochs = total_timesteps / batch_size` is integer division, so when `total_timesteps < batch_size` (e.g. short smoke tests with 50k steps), it evaluates to 0. this causes `anneal_beta` to compute `0/0 = NaN`, which propagates through `mb_prio` into the PPO loss.

`cosine_annealing()` already handles this case (`if (T == 0) return lr_base`) but `anneal_beta` didn't have the same guard.

fix: clamp `total_epochs` to at least 1.