### PR TITLE
Fix 2048 spawn count and add 16384 stat

### DIFF
--- a/pufferlib/ocean/g2048/binding.h
+++ b/pufferlib/ocean/g2048/binding.h
@@ -21,6 +21,7 @@ void my_log(Log* log, Dict* out) {
     dict_set(out, "episode_return", log->episode_return);
     dict_set(out, "episode_length", log->episode_length);
     dict_set(out, "lifetime_max_tile", log->lifetime_max_tile);
+    dict_set(out, "reached_16384", log->reached_16384);
     dict_set(out, "reached_32768", log->reached_32768);
     dict_set(out, "reached_65536", log->reached_65536);
     dict_set(out, "reached_131072", log->reached_131072);

--- a/pufferlib/ocean/g2048/eval.py
+++ b/pufferlib/ocean/g2048/eval.py
@@ -29,6 +29,7 @@ def evaluate(env_name, load_model_path):
     episode_lengths = sum(n * l for n, l in zip(stats['n'], stats['episode_length'])) / num_episodes
     max_tiles = sum(n * m for n, m in zip(stats['n'], stats['score'])) / num_episodes
     merge_scores = sum(n * s for n, s in zip(stats['n'], stats['merge_score'])) / num_episodes
+    reached_16384 = sum(n * s for n, s in zip(stats['n'], stats['reached_16384'])) / num_episodes
     reached_32768 = sum(n * s for n, s in zip(stats['n'], stats['reached_32768'])) / num_episodes
     reached_65536 = sum(n * s for n, s in zip(stats['n'], stats['reached_65536'])) / num_episodes
     reached_131072 = sum(n * s for n, s in zip(stats['n'], stats['reached_131072'])) / num_episodes
@@ -38,6 +39,7 @@ def evaluate(env_name, load_model_path):
     # The stats from vecenv are averaged across envs that were done in the same tick. Cannot get the single max.
     print(f"Episode length -- Avg: {episode_lengths:.1f}, Max: {max(stats['episode_length']):.1f}")
     print(f"Merge score -- Avg: {merge_scores:.1f}, Max: {max(stats['merge_score']):.1f}")
+    print(f"Reached 16384 prob: {reached_16384*100:.2f} %")
     print(f"Reached 32768 prob: {reached_32768*100:.2f} %")
     print(f"Reached 65536 prob: {reached_65536*100:.2f} %")
     print(f"Reached 131072 prob: {reached_131072*100:.2f} %")

--- a/pufferlib/ocean/g2048/g2048.h
+++ b/pufferlib/ocean/g2048/g2048.h
@@ -43,6 +43,7 @@ typedef struct Log {
     float episode_return;
     float episode_length;
     float lifetime_max_tile;
+    float reached_16384;
     float reached_32768;
     float reached_65536;
     float reached_131072;
@@ -134,6 +135,7 @@ void add_log(Game* game) {
     game->log.episode_length += game->tick;
     game->log.episode_return += game->episode_reward;
     game->log.lifetime_max_tile += (float)(1 << game->lifetime_max_tile);
+    game->log.reached_16384 += (game->max_tile >= 14);
     game->log.reached_32768 += (game->max_tile >= 15);
     game->log.reached_65536 += (game->max_tile >= 16);
     game->log.reached_131072 += (game->max_tile >= 17);
@@ -370,10 +372,10 @@ void c_step(Game* game) {
 
     if (did_move) {
         game->moves_made++;
+        // Refresh empty_count after merges so spawning uses the correct count.
+        update_stats(game);
         place_tile_at_random_cell(game, get_new_tile());
         game->score += score_add;
-
-        update_stats(game);
 
         // Observations only change if the grid changes
         update_observations(game);
@@ -415,9 +417,10 @@ void step_without_reset(Game* game) {
 
     if (did_move) {
         game->moves_made++;
+        // Refresh empty_count after merges so spawning uses the correct count.
+        update_stats(game);
         place_tile_at_random_cell(game, get_new_tile());
         game->score += score_add;
-        update_stats(game);
         // Observations only change if the grid changes
         update_observations(game);
     }


### PR DESCRIPTION
aminos9 at discord reported the 2048 bug (see https://discord.com/channels/1019421966429593712/1088863728646246491/1476191074581090425) , and it effectively gave agents a cheat skill. 

> The bug stems from a stale empty_count value when place_tile_at_random_cell is called within the c_step function. Specifically, when the board is full but a move creates new space through merges, the code attempts to spawn a tile before re-calculating the actual number of empty cells. Since place_tile_at_random_cell returns early if it sees an empty_count of zero, the environment fails to spawn a tile, leading to the missing tile behavior and significantly inflated  move counts. Moving the update_stats_and_get_heuristic_rewards call to occur before the spawning logic will ensure that newly opened cells are correctly identified.

After fixing it, the 2048 game got much harder and the agent barely reached 32k after the same training setup.
https://wandb.ai/kywch/pufferlib/runs/wbic5igz?nw=nwuserkywch

As it 2048 became much harder, tracking 16378 tile is useful for tracking process, so added it to logging.