### PR TITLE
Fix build.sh to use Homebrew Clang on mac

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -152,7 +152,10 @@ OUTPUT_NAME=${OUTPUT_NAME:-$ENV}
 # Standalone environment build
 # -mavx2 enables AVX2 intrinsics (__m256, _mm256_*) which drive.h and
 # src/bf16.h use directly. x86_64 only — strip if porting to ARM/Apple Silicon.
-SIMD_FLAGS=(-mavx2 -mfma)
+SIMD_FLAGS=()
+if [ "$(uname -m)" = "x86_64" ]; then
+    SIMD_FLAGS=(-mavx2 -mfma)
+fi
 if [ -n "$DEBUG" ] || [ "$MODE" = "local" ]; then
     CLANG_OPT=(-g -O0 "${CLANG_WARN[@]}" "${SANITIZE_FLAGS[@]}" "${SIMD_FLAGS[@]}")
     NVCC_OPT="-O0 -g"

--- a/build.sh
+++ b/build.sh
@@ -310,7 +310,7 @@ if [ -z "$MODE" ]; then
         -lcudart -lnccl -lnvidia-ml -lcublas -lcusolver -lcurand -lcudnn
         -lomp5 $LINK_OPT
         "${SHARED_LDFLAGS[@]}"
-        -o "$OUTPUT"
+
     )
     "${LINK_CMD[@]}"
     echo "Built: $OUTPUT"

--- a/build.sh
+++ b/build.sh
@@ -72,7 +72,9 @@ else
     SANITIZE_FLAGS=()
     # Homebrew "real" clang setup on mac
     LLVM_PREFIX=$(brew --prefix llvm)
-    export PATH="$LLVM_PREFIX/bin:$PATH"
+    export CC=${CC:-$LLVM_PREFIX/bin/clang}
+    export CXX=${CXX:-$LLVM_PREFIX/bin/clang++}
+    ln -sf $LLVM_PREFIX/lib/libomp.dylib $LLVM_PREFIX/lib/libomp5.dylib
     INCLUDES=(-I$LLVM_PREFIX/include)
     STANDALONE_LDFLAGS=(-framework Cocoa -framework IOKit -framework CoreVideo -framework OpenGL -L$LLVM_PREFIX/lib)
     SHARED_LDFLAGS=(-framework Cocoa -framework OpenGL -framework IOKit -undefined dynamic_lookup -L$LLVM_PREFIX/lib)

--- a/build.sh
+++ b/build.sh
@@ -54,16 +54,28 @@ fi
 PLATFORM="$(uname -s)"
 if [ "$PLATFORM" = "Linux" ]; then
     RAYLIB_NAME='raylib-5.5_linux_amd64'
-    OMP_LIB=-lomp5
     SANITIZE_FLAGS=(-fsanitize=address,undefined,bounds,pointer-overflow,leak -fno-omit-frame-pointer)
+    INCLUDES=()
     STANDALONE_LDFLAGS=(-lGL)
     SHARED_LDFLAGS=(-Bsymbolic-functions)
 else
+    if ! command -v brew &>/dev/null; then
+        echo "Homebrew is not installed."
+        exit 0
+    fi
+    # "--versions" is faster than normal "brew list llvm"
+    if ! brew list --versions llvm &>/dev/null; then
+        echo "LLVM is not installed via Homebrew. please 'brew install llvm'"
+        exit 0
+    fi
     RAYLIB_NAME='raylib-5.5_macos'
-    OMP_LIB=-lomp
     SANITIZE_FLAGS=()
-    STANDALONE_LDFLAGS=(-framework Cocoa -framework IOKit -framework CoreVideo -framework OpenGL)
-    SHARED_LDFLAGS=(-framework Cocoa -framework OpenGL -framework IOKit -undefined dynamic_lookup)
+    # Homebrew "real" clang setup on mac
+    LLVM_PREFIX=$(brew --prefix llvm)
+    export PATH="$LLVM_PREFIX/bin:$PATH"
+    INCLUDES+=(-I$LLVM_PREFIX/include)
+    STANDALONE_LDFLAGS=(-framework Cocoa -framework IOKit -framework CoreVideo -framework OpenGL -L$LLVM_PREFIX/lib)
+    SHARED_LDFLAGS=(-framework Cocoa -framework OpenGL -framework IOKit -undefined dynamic_lookup -L$LLVM_PREFIX/lib)
 fi
 
 CLANG_WARN=(
@@ -95,7 +107,7 @@ else
 fi
 
 RAYLIB_A="$RAYLIB_NAME/lib/libraylib.a"
-INCLUDES=(-I./$RAYLIB_NAME/include -I./src -I./vendor)
+INCLUDES+=(-I./$RAYLIB_NAME/include -I./src -I./vendor)
 LINK_ARCHIVES=("$RAYLIB_A")
 EXTRA_SRC=""
 EXTRA_LDFLAGS=()
@@ -301,7 +313,7 @@ if [ -z "$MODE" ]; then
         "${WHEEL_RPATH_FLAGS[@]}"
         "${EXTRA_LDFLAGS[@]}"
         -lcudart -lnccl -lnvidia-ml -lcublas -lcusolver -lcurand -lcudnn
-        $OMP_LIB $LINK_OPT
+        -lomp5 $LINK_OPT
         "${SHARED_LDFLAGS[@]}"
         -o "$OUTPUT"
     )

--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ else
     # Homebrew "real" clang setup on mac
     LLVM_PREFIX=$(brew --prefix llvm)
     export PATH="$LLVM_PREFIX/bin:$PATH"
-    INCLUDES+=(-I$LLVM_PREFIX/include)
+    INCLUDES=(-I$LLVM_PREFIX/include)
     STANDALONE_LDFLAGS=(-framework Cocoa -framework IOKit -framework CoreVideo -framework OpenGL -L$LLVM_PREFIX/lib)
     SHARED_LDFLAGS=(-framework Cocoa -framework OpenGL -framework IOKit -undefined dynamic_lookup -L$LLVM_PREFIX/lib)
 fi

--- a/build.sh
+++ b/build.sh
@@ -59,22 +59,15 @@ if [ "$PLATFORM" = "Linux" ]; then
     STANDALONE_LDFLAGS=(-lGL)
     SHARED_LDFLAGS=(-Bsymbolic-functions)
 else
-    if ! command -v brew &>/dev/null; then
-        echo "Homebrew is not installed."
-        exit 0
-    fi
-    # "--versions" is faster than normal "brew list llvm"
-    if ! brew list --versions llvm &>/dev/null; then
-        echo "LLVM is not installed via Homebrew. please 'brew install llvm'"
-        exit 0
-    fi
+    command -v brew &>/dev/null || {echo "Error: Homebrew isn't installed." && exit 1;}
+    brew ls --versions llvm &>/dev/null || {echo "Error: Homebrew LLVM isn't installed('brew install llvm')" && exit 1;}
     RAYLIB_NAME='raylib-5.5_macos'
     SANITIZE_FLAGS=()
     # Homebrew "real" clang setup on mac
     LLVM_PREFIX=$(brew --prefix llvm)
     export CC=${CC:-$LLVM_PREFIX/bin/clang}
     export CXX=${CXX:-$LLVM_PREFIX/bin/clang++}
-    ln -sf $LLVM_PREFIX/lib/libomp.dylib $LLVM_PREFIX/lib/libomp5.dylib
+    ln -sf $LLVM_PREFIX/lib/libomp.dylib $LLVM_PREFIX/lib/libomp5.dylib #f-ing mac
     INCLUDES=(-I$LLVM_PREFIX/include)
     STANDALONE_LDFLAGS=(-framework Cocoa -framework IOKit -framework CoreVideo -framework OpenGL -L$LLVM_PREFIX/lib)
     SHARED_LDFLAGS=(-framework Cocoa -framework OpenGL -framework IOKit -undefined dynamic_lookup -L$LLVM_PREFIX/lib)

--- a/build.sh
+++ b/build.sh
@@ -59,8 +59,8 @@ if [ "$PLATFORM" = "Linux" ]; then
     STANDALONE_LDFLAGS=(-lGL)
     SHARED_LDFLAGS=(-Bsymbolic-functions)
 else
-    command -v brew &>/dev/null || {echo "Error: Homebrew isn't installed." && exit 1;}
-    brew ls --versions llvm &>/dev/null || {echo "Error: Homebrew LLVM isn't installed('brew install llvm')" && exit 1;}
+    command -v brew &>/dev/null || { echo "Error: Homebrew not found" && exit 1; }
+    brew ls --versions llvm &>/dev/null || { echo "Error: Homebrew LLVM not found('brew install llvm')" && exit 1; }
     RAYLIB_NAME='raylib-5.5_macos'
     SANITIZE_FLAGS=()
     # Homebrew "real" clang setup on mac


### PR DESCRIPTION
## Original issue
Commit ab75881c3181d5d44c8030140b70d81ececceb40 addresses the -lomp5 compilation error on mac, however this doesn't fix the root cause.

## Root Cause
The root cause is that mac's non-standard clang(Apple Clang) links differently than normal clang. For example, the `-fopenmp` flag isn't supported in apple clang so it creates a compilation error even after the "-lomp5 fix".

This means that this issue will happen with other libs in the future and will have to be fixed and maintained constantly.

## The Fix
This PR addresses the original issue and root cause by forcing the user to use "real" clang in a clear way which makes compilation identical on Linux and Mac.

## Additional Notes
- Installing real clang on mac is **really easy**, its just `brew install llvm`. So this shouldn't make mac user's life that much harder.
- Additionally, its worth noting that I became aware of the -lomp5 and -fopenmp issues from this PR #507 first

## Working Build Commands on Mac
- [x] `./build.sh breakout --local`
- [x] `./build.sh breakout --cpu`