### PR TITLE
[codex] fix native checkers render mode and batch alias

### DIFF
--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1174,7 +1174,12 @@ def load_env(env_name, args):
     module_name = 'pufferlib.ocean' if package == 'ocean' else f'pufferlib.environments.{package}'
     env_module = importlib.import_module(module_name)
     make_env = env_module.env_creator(env_name)
-    return pufferlib.vector.make(make_env, env_kwargs=args['env'], **args['vec'])
+    env_kwargs = dict(args['env'])
+    render_mode = args.get('render_mode', 'auto')
+    if render_mode != 'auto':
+        env_kwargs['render_mode'] = None if render_mode == 'None' else render_mode
+
+    return pufferlib.vector.make(make_env, env_kwargs=env_kwargs, **args['vec'])
 
 def load_policy(args, vecenv, env_name=''):
     package = args['package']

--- a/pufferlib/pufferlib.py
+++ b/pufferlib/pufferlib.py
@@ -75,6 +75,10 @@ class PufferEnv:
         return self.num_agents
 
     @property
+    def agents_per_batch(self):
+        return self.num_agents
+
+    @property
     def emulated(self):
         '''Native envs do not use emulation'''
         return False


### PR DESCRIPTION
## Summary

This change fixes two integration problems that showed up when running the native checkers environment through the `puffer` CLI. Together they made it harder to use native checkers for local training and rendering smoke tests even though the underlying environment itself was working.

The first issue was that the top-level CLI `--render-mode` flag stopped at argument parsing and never reached environment construction. In practice that meant a command like `puffer eval ... --render-mode human` could still instantiate the environment with its default render mode, which made CLI-driven rendering inconsistent and made debugging checkers sessions more awkward than it needed to be.

The second issue was a naming mismatch between the trainer and native environments. `PuffeRL` expects an `agents_per_batch` attribute, but `PufferEnv` only exposed `agent_per_batch`. That mismatch breaks native-environment training paths that rely on the trainer's batch-size plumbing, including the native checkers smoke run used here.

The root cause in both cases was a small interface gap between the CLI/trainer layer and the native environment wrapper layer rather than a problem in the checkers environment logic itself.

This patch fixes that by copying `args['env']` into a local `env_kwargs` dict inside `load_env`, forwarding the top-level render mode into those kwargs when the user explicitly sets one, and preserving the existing auto behavior otherwise. It also adds an `agents_per_batch` property on `PufferEnv` as a compatibility alias that returns `num_agents`, matching the trainer's expectation without changing the native environment semantics.

I validated the change with a native checkers smoke test on CPU using the `PufferEnv` backend. The run asserted that the constructed vector env reported `render_mode == 'human'`, then successfully completed `evaluate()` and `train()` on a short checkers run with no errors. I also used the same path to run local checkers training and launch rendered evaluation sessions afterward.
