### PR TITLE
Add Craftax moonshot environment

### DIFF
--- a/config/craftax_moonshot.ini
+++ b/config/craftax_moonshot.ini
@@ -2,8 +2,8 @@
 env_name = craftax_moonshot
 
 [vec]
-total_agents = 8192
-num_buffers = 4
+total_agents = 16384
+num_buffers = 16
 num_threads = 16
 
 [env]
@@ -17,7 +17,7 @@ ent_coef = 0.02
 gamma = 0.997
 gae_lambda = 0.95
 horizon = 128
-minibatch_size = 16384
+minibatch_size = 32768
 
 [policy]
 hidden_size = 32

--- a/config/craftax_moonshot.ini
+++ b/config/craftax_moonshot.ini
@@ -1,0 +1,25 @@
+[base]
+env_name = craftax_moonshot
+
+[vec]
+total_agents = 8192
+num_buffers = 4
+num_threads = 16
+
+[env]
+seed_offset = 0
+reset_pool_size = 1024
+
+[train]
+total_timesteps = 200_000_000
+learning_rate = 0.008
+ent_coef = 0.02
+gamma = 0.997
+gae_lambda = 0.95
+horizon = 128
+minibatch_size = 16384
+
+[policy]
+hidden_size = 32
+num_layers = 1
+expansion_factor = 1

--- a/ocean/craftax_moonshot/MOONSHOT.md
+++ b/ocean/craftax_moonshot/MOONSHOT.md
@@ -1,0 +1,90 @@
+# Craftax Moonshot
+
+This folder is the isolated experimental target for high-risk CPU layout and SIMD work.
+The oracle remains `ocean/craftax`; the current production fast candidate remains
+`ocean/craftax_fast`.
+
+## Verification Contract
+
+Every implementation slice must pass the bitwise oracle harness before it is treated
+as a candidate:
+
+```bash
+uv run tests/craftax_diff.py \
+  --baseline-craftax-dir ocean/craftax \
+  --candidate-craftax-dir ocean/craftax_moonshot \
+  --seeds 16 \
+  --steps 2000 \
+  --action-seed 123 \
+  --reset-pool-size 1024
+
+uv run tests/craftax_diff.py \
+  --baseline-craftax-dir ocean/craftax \
+  --candidate-craftax-dir ocean/craftax_moonshot \
+  --seeds 16 \
+  --steps 2000 \
+  --action-seed 321 \
+  --reset-pool-size 0
+```
+
+The current moonshot observation is packed symbolic float format. It is smaller than
+the baseline full binary-float observation, so oracle checks must expand it before
+comparison:
+
+```bash
+uv run tests/craftax_diff.py \
+  --baseline-craftax-dir ocean/craftax \
+  --candidate-craftax-dir ocean/craftax_moonshot \
+  --candidate-obs-format packed_float \
+  --seeds 16 \
+  --steps 2000 \
+  --action-seed 123 \
+  --reset-pool-size 1024
+```
+
+Then run an env-only sweep and a Puffer training smoke. Training is required because
+raw harness SPS can lie about the production path, GPU copy overlap, and learning
+health.
+
+## CPU Target
+
+The Ryzen 9 9950X3D has one 96 MiB V-Cache CCD and one 32 MiB CCD. Benchmark env-only
+runs with explicit placement first:
+
+```bash
+env OMP_NUM_THREADS=16 OMP_PROC_BIND=close OMP_PLACES=threads \
+  taskset -c 0-7,16-23 \
+  uv run scratch/craftax_variant_sweep.py \
+    --candidates ocean/craftax_moonshot \
+    --candidate-obs-format packed_float \
+    --parity-seeds 4 \
+    --parity-steps 1000 \
+    --agents 2048 4096 8192 \
+    --bench-steps 3000
+```
+
+For training, check `nvidia-smi` first because this is a shared GPU machine.
+
+## Implementation Order
+
+1. Keep the Puffer boundary stable: same env name shape, obs dtype, action space,
+   reward, terminal, and log semantics.
+2. Convert hot state into packet-owned storage while retaining legacy state as the
+   oracle-compatible backing store.
+3. Convert one hot subsystem at a time, starting with read-only observation encode,
+   then spawn scan, then mob update.
+4. Avoid syncing hot state back to legacy state every step unless the converted slice
+   replaces a full contiguous phase. Per-step sync can erase the layout win.
+5. Each slice gets measured in three ways: bitwise oracle harness, env-only SPS, and
+   short Puffer training SPS/reward smoke.
+
+## Current Packed Observation
+
+`craftax_moonshot` emits `843` float channels instead of the baseline `3021`:
+
+- `99` visible cells x `8` symbolic channels: block id, item+1, visibility, and
+  one mob type+1 slot for each of the five mob classes.
+- `51` scalar channels copied exactly from the baseline scalar tail.
+
+This preserves exact expandability back to the baseline full observation while cutting
+the observation width by `3.58x`.

--- a/ocean/craftax_moonshot/PORT_NOTES.md
+++ b/ocean/craftax_moonshot/PORT_NOTES.md
@@ -1,0 +1,543 @@
+# Craftax Full Ocean Port Notes
+
+## Verification coverage
+
+The standalone parity harness now supports deterministic action policies beyond
+uniform random exploration:
+
+- `uniform`: the original random action stream.
+- `combat`: biases toward `DO`, arrows, fireballs, and iceballs when mobs and
+  resources make those actions meaningful, otherwise moves toward live mobs.
+- `descend`: uses the mirrored state to push toward down ladders, clear blocked
+  levels through combat, and exercise placement and crafting actions.
+- `suicide`: steers into adjacent lava, water, mob-occupied, or projectile-heavy
+  danger and otherwise paths toward the nearest known hazard.
+- `boss`: warms up with downward navigation and then repeatedly attempts
+  descent while continuing to route toward ladders.
+- `mixed`: round-robins the above every 500 steps.
+
+`tests/craftax_parity.py` now reports the policy, seed, step, action, reward
+delta, terminal delta, first symbolic-observation field, suspected subsystem,
+and the last 10 actions on any divergence. With `--reset-on-done` enabled, the
+harness tracks terminal counts and mean episode length by seed. JAX stepping is
+run through the no-auto-reset path with the same per-step key split used by the
+native env; when a terminal is observed, the mirrored state is advanced through
+the native reset helper keyed by the same auto-reset key, and that reset state
+and observation are checked field-by-field before continuing.
+
+The stress battery in `tests/craftax_parity_stress.py` runs:
+
+- 64 seeds times 10000 steps with `mixed`.
+- 16 seeds times 30000 steps with `descend`.
+- 32 seeds times 5000 steps with `suicide`.
+- 16 seeds times 5000 steps with `combat`.
+
+All stress cases use `atol=1e-5` for observations and rewards and exact terminal
+matching. The phase-10a run completed with zero divergences in 1033.0 seconds:
+2883 terminals in `mixed`, 2498 in `descend`, 622 in `suicide`, and 355 in
+`combat`.
+
+Residual caveats:
+
+- The harness observes live C step state through the public vector API, so step
+  diagnostics identify the first differing observation field and subsystem class
+  rather than dumping the entire private C state after every step.
+- CPU XLA can fuse reset worldgen noise normalization differently from
+  materialized JAX by one ULP on exact threshold cells. Materialized JAX
+  worldgen and native reset agree on the targeted sand-threshold keys covered by
+  `tests/craftax_worldgen_test.py`, so terminal continuation uses the native
+  reset helper after explicit reset-state verification.
+
+## 2026-04-18 Native Step Integration and Proxy Removal
+
+This phase wires the green native reset and all green native step subsystems
+into the live Ocean `c_step` path. The Python/JAX proxy has been fully removed:
+`c_init`, `c_reset`, `c_step`, and `c_close` are now 100% native.
+
+- `c_step_native` now mirrors the installed `craftax_step` subsystem order:
+  floor changes, crafting, action, placement, projectiles, spells, potions,
+  books, enchantment, boss logic, attributes, movement, mobs, spawning, plants,
+  intrinsics, clipping, inventory achievements, reward, timestep, light level,
+  terminal, and symbolic observation encoding.
+- The live env keeps the same outer RNG schedule as the old auto-reset proxy:
+  reset uses the reset key's inner worldgen split, each step splits the external
+  key once, then splits the per-step key into gameplay and auto-reset keys.
+- Step observations reuse the native symbolic encoder, now with mob channels and
+  boss-vulnerable special value populated for non-reset states.
+- `tests/craftax_step_full_test.py` adds the full side-by-side parity check for
+  16 seeds times 2000 random-action steps. `tests/craftax_parity.py` remains as
+  the standalone harness.
+
+Native-step roadmap checklist:
+
+- [x] Native reset PRNG, noise, 9-floor world generation, and reset observation.
+- [x] Standalone native simple step subsystems with JAX-parity tests.
+- [x] Standalone native medium step subsystems with JAX-parity tests.
+- [x] Standalone native crafting and placement subsystems with JAX-parity tests.
+- [x] Standalone native `do_action` subsystem with JAX-parity tests.
+- [x] Standalone native `spawn_mobs` subsystem with JAX-parity tests.
+- [x] Standalone native `update_mobs` subsystem with JAX-parity tests.
+- [x] Native reward, terminal, timestep, light-level, RNG, and achievement-delta
+  bookkeeping around the subsystem calls.
+- [x] Integrate all green subsystem ports into native `c_step` and remove all
+  Python/JAX proxy code paths.
+
+Remaining proxy paths:
+
+- None. The Craftax Ocean env no longer loads CPython symbols, constructs a JAX
+  env, or delegates reset/step/close through Python.
+
+Next phase:
+
+- Optimize the native path after correctness is locked down. Likely targets are
+  SIMD-friendly loops, cache-tiled symbolic observation encoding, and mob update
+  hot paths. Performance claims need measurement.
+
+## 2026-04-18 Standalone Update Mobs Step Subsystem
+
+This phase adds a native C port for the `update_mobs` subsystem, still
+deliberately without integrating it into `c_step`. The live Ocean environment
+continues to delegate step to the Python/JAX proxy.
+
+- `step_update_mobs.h` contains the standalone in-place helper for:
+  - `update_mobs`
+- The helper mirrors the installed JAX update order for melee mobs, passive
+  mobs, ranged mobs, mob projectiles, and player projectiles. It preserves the
+  scan-level Threefry threading, including the melee loop's final right-key
+  carry, and the top-level split before each mob class.
+- Mob movement and collision use the installed collision tables for land,
+  flying, aquatic, and amphibian mobs, including JAX-style clamped reads,
+  scatter-drop writes, mob-map exclusion, water/lava/solid checks, despawn
+  distance, boss-floor despawn suppression, and sequential mob-map updates.
+- Combat covers melee player attacks, ranged projectile spawning, projectile
+  movement, player damage with armour and enchantment defenses, sleeping/resting
+  wakeups, player projectile damage scaling, first-target mob attacks, kill
+  achievements, mob-map clearing, and `monsters_killed` updates.
+- `tests/craftax_step_update_mobs_test.py` builds a temporary C wrapper around
+  the inline helper and compares full copied states against the installed JAX
+  function for 16 reset-plus-RNG-action-stepped states. Targeted coverage
+  includes every mob class on every floor, melee attacks, ranged projectile
+  firing, mob projectiles hitting the player, walls, and out-of-bounds, player
+  projectile mob kills, despawn, cooldown decrement, and empty-mask live-effect
+  checks.
+
+Native-step roadmap checklist:
+
+- [x] Native reset PRNG, noise, 9-floor world generation, and reset observation.
+- [x] Standalone native simple step subsystems with JAX-parity tests.
+- [x] Standalone native medium step subsystems with JAX-parity tests.
+- [x] Standalone native crafting and placement subsystems with JAX-parity tests.
+- [x] Standalone native `do_action` subsystem with JAX-parity tests.
+- [x] Standalone native `spawn_mobs` subsystem with JAX-parity tests.
+- [x] Standalone native `update_mobs` subsystem with JAX-parity tests.
+- [ ] Native reward, terminal, timestep, light-level, RNG, and achievement-delta
+  bookkeeping around the subsystem calls.
+- [ ] Integrate all green subsystem ports into a native `c_step` behind one
+  explicit switch, then remove the Python/JAX proxy from the normal step path.
+- [ ] Restore production vector sizes in `config/ocean/craftax.ini` after native
+  step is the default.
+- [ ] Benchmark CPU throughput only after the proxy path is gone.
+
+Remaining proxy paths:
+
+- `c_step` still delegates to the Python/JAX proxy. None of the standalone
+  subsystem helpers are wired into the live environment yet.
+- All gameplay step subsystems now have standalone native ports with parity
+  tests. Reward/terminal bookkeeping, light-level updates, timestep updates,
+  RNG threading between subsystems, and achievement-delta logging are still not
+  integrated natively.
+- Rendering remains a no-op.
+- `config/ocean/craftax.ini` still uses a small proxy-friendly vector size. The
+  native port should raise this once step no longer calls Python.
+
+## 2026-04-18 Standalone Spawn Mobs Step Subsystem
+
+This phase adds a native C port for the `spawn_mobs` subsystem, still
+deliberately without integrating it into `c_step`. The live Ocean environment
+continues to delegate step to the Python/JAX proxy.
+
+- `step_spawn_mobs.h` contains the standalone in-place helper for:
+  - `spawn_mobs`
+- The helper mirrors the installed JAX split order: passive chance, passive
+  position, melee chance, melee position, ranged chance, ranged position. It
+  also keeps the JAX behavior where the selected slot's `type_id` is written
+  even when the spawn gate fails.
+- Spawn maps match the installed function's terrain and distance rules,
+  including passive distance rejection near the player, monster range gates,
+  overworld night-zombie light scaling, deep-thing water spawning, grave-only
+  boss-wave spawning, mob-map exclusion, caps, and sequential mob-map updates
+  between passive, melee, and ranged attempts.
+- `tests/craftax_step_spawn_mobs_test.py` builds a temporary C wrapper around
+  the inline helper and compares full copied states against the installed JAX
+  function for 16 reset-plus-NOOP-step seeds. Targeted coverage includes all
+  nine floors, full mob caps, empty-slot spawns at single candidate positions,
+  day versus night overworld melee chances, boss spawn-wave pacing, player-
+  adjacent candidate rejection, and land, water, and grave terrain constraints.
+
+Native-step roadmap checklist:
+
+- [x] Native reset PRNG, noise, 9-floor world generation, and reset observation.
+- [x] Standalone native simple step subsystems with JAX-parity tests.
+- [x] Standalone native medium step subsystems with JAX-parity tests.
+- [x] Standalone native crafting and placement subsystems with JAX-parity tests.
+- [x] Standalone native `do_action` subsystem with JAX-parity tests.
+- [x] Standalone native `spawn_mobs` subsystem with JAX-parity tests.
+- [ ] Standalone native `update_mobs` subsystem with JAX-parity tests.
+- [ ] Native reward, terminal, timestep, light-level, RNG, and achievement-delta
+  bookkeeping around the subsystem calls.
+- [ ] Integrate all green subsystem ports into a native `c_step` behind one
+  explicit switch, then remove the Python/JAX proxy from the normal step path.
+- [ ] Restore production vector sizes in `config/ocean/craftax.ini` after native
+  step is the default.
+- [ ] Benchmark CPU throughput only after the proxy path is gone.
+
+Remaining proxy paths:
+
+- `c_step` still delegates to the Python/JAX proxy. None of the standalone
+  subsystem helpers are wired into the live environment yet.
+- The only gameplay step subsystem still without a standalone native port is
+  `update_mobs`. Reward/terminal bookkeeping, light-level updates, timestep
+  updates, RNG threading between subsystems, and achievement-delta logging are
+  also still not integrated natively.
+- Rendering remains a no-op.
+- `config/ocean/craftax.ini` still uses a small proxy-friendly vector size. The
+  native port should raise this once step no longer calls Python.
+
+## 2026-04-18 Standalone Do Action Step Subsystem
+
+This phase adds a native C port for the `do_action` subsystem, still
+deliberately without integrating it into `c_step`. The live Ocean environment
+continues to delegate step to the Python/JAX proxy.
+
+- `step_do_action.h` contains the standalone in-place helper for:
+  - `do_action`
+- The helper mirrors the installed JAX ordering: mob attack resolution runs
+  before block interaction; block mining/eating/drinking/inventory/achievement
+  effects are gated by in-bounds and no mob attack; chest-open flags and boss
+  progress keep the JAX side effects that are not part of that gate.
+- Chest looting calls the existing native `craftax_add_items_from_chest_native`
+  helper after consuming the sapling RNG split, so first-open bow/book rewards
+  see the old `chests_opened` value and the chest RNG thread matches JAX.
+- Mob attacks cover passive, melee, and ranged mob arrays, including first-match
+  target selection, defense mapping, sword enchantment damage, strength and
+  intelligence scaling, passive food refill, kill achievements, mob-map updates,
+  and monster kill counts.
+- `tests/craftax_step_do_action_test.py` builds a temporary C wrapper around the
+  inline helper and compares full copied states against the installed JAX
+  function for 16 reset-plus-step-through seeds. Coverage includes a seeded
+  no-op-then-DO sequence, mining success and missing-pickaxe cases, sapling RNG
+  rolls, plant/passive food and water/fountain drink cases, all chest levels,
+  all passive/melee/ranged kill achievement mappings, damage modifier cases,
+  out-of-bounds targets, no-op target blocks, projectile-occupied targets, and
+  mob-on-chest gating.
+
+Native-step roadmap checklist:
+
+- [x] Native reset PRNG, noise, 9-floor world generation, and reset observation.
+- [x] Standalone native simple step subsystems with JAX-parity tests.
+- [x] Standalone native medium step subsystems with JAX-parity tests.
+- [x] Standalone native crafting and placement subsystems with JAX-parity tests.
+- [x] Standalone native `do_action` subsystem with JAX-parity tests.
+- [ ] Standalone native ports for the remaining mob step subsystems:
+  `update_mobs` and `spawn_mobs`.
+- [ ] Native reward, terminal, timestep, light-level, RNG, and achievement-delta
+  bookkeeping around the subsystem calls.
+- [ ] Integrate all green subsystem ports into a native `c_step` behind one
+  explicit switch, then remove the Python/JAX proxy from the normal step path.
+- [ ] Restore production vector sizes in `config/ocean/craftax.ini` after native
+  step is the default.
+- [ ] Benchmark CPU throughput only after the proxy path is gone.
+
+Remaining proxy paths:
+
+- `c_step` still delegates to the Python/JAX proxy. None of the standalone
+  subsystem helpers are wired into the live environment yet.
+- The only gameplay step subsystems still without standalone native ports are
+  `update_mobs` and `spawn_mobs`. Reward/terminal bookkeeping, light-level
+  updates, timestep updates, RNG threading between subsystems, and
+  achievement-delta logging are also still not integrated natively.
+- Rendering remains a no-op.
+- `config/ocean/craftax.ini` still uses a small proxy-friendly vector size. The
+  native port should raise this once step no longer calls Python.
+
+## 2026-04-18 Standalone Crafting And Placement Step Subsystems
+
+This phase adds native C ports for two more action subsystems, still
+deliberately without integrating them into `c_step`. The live Ocean environment
+continues to delegate step to the Python/JAX proxy.
+
+- `step_crafting.h` contains standalone in-place helpers for:
+  - `do_crafting`
+  - `place_block`
+  - `add_new_growing_plant`, used by plant placement and exposed to the test
+    wrapper as a translation-unit-local helper
+- `do_crafting` mirrors the JAX recipe order and sequential inventory updates
+  for all twelve `MAKE_*` actions present in the current Action enum:
+  pickaxes, swords, iron/diamond armour, arrows, and torches.
+- `place_block` mirrors table, furnace, stone, plant, and torch placement,
+  including original-block placement tests, item-map gating, mob/out-of-bounds
+  rollback, first-empty growing-plant slot selection, and the padded 9x9 torch
+  light update near map boundaries.
+- `tests/craftax_step_crafting_test.py` builds a temporary C wrapper around the
+  inline helpers and compares each subsystem against the installed JAX function
+  on reset-plus-step-through states for 16 seeds. Coverage includes success,
+  missing-resource/tool-cap, missing-station crafting cases; every JAX-legal
+  placement target block for each placement action; illegal wall/item/mob/water
+  cases where applicable; map-boundary rollback; and direct first-available-slot
+  checks for growing plants.
+
+Native-step roadmap checklist:
+
+- [x] Native reset PRNG, noise, 9-floor world generation, and reset observation.
+- [x] Standalone native simple step subsystems with JAX-parity tests.
+- [x] Standalone native medium step subsystems with JAX-parity tests.
+- [x] Standalone native crafting and placement subsystems with JAX-parity tests.
+- [x] Standalone native `do_action` subsystem with JAX-parity tests.
+- [ ] Standalone native ports for the remaining mob step subsystems:
+  `update_mobs` and `spawn_mobs`.
+- [ ] Native reward, terminal, timestep, light-level, RNG, and achievement-delta
+  bookkeeping around the subsystem calls.
+- [ ] Integrate all green subsystem ports into a native `c_step` behind one
+  explicit switch, then remove the Python/JAX proxy from the normal step path.
+- [ ] Restore production vector sizes in `config/ocean/craftax.ini` after native
+  step is the default.
+- [ ] Benchmark CPU throughput only after the proxy path is gone.
+
+Remaining proxy paths:
+
+- `c_step` still delegates to the Python/JAX proxy. None of the standalone
+  subsystem helpers are wired into the live environment yet.
+- The only gameplay step subsystems still without standalone native ports are
+  `update_mobs` and `spawn_mobs`. Reward/terminal bookkeeping, light-level
+  updates, timestep updates, RNG threading, and achievement-delta logging are
+  also still not integrated natively.
+- Rendering remains a no-op.
+- `config/ocean/craftax.ini` still uses a small proxy-friendly vector size. The
+  native port should raise this once step no longer calls Python.
+
+## 2026-04-18 Standalone Medium Step Subsystems
+
+This phase adds native C ports for five more step subsystems, again deliberately
+without integrating them into `c_step`. The live Ocean environment still
+delegates step to the Python/JAX proxy, so the full parity harness should remain
+unchanged.
+
+- `step_medium.h` contains standalone in-place helpers for:
+  - `shoot_projectile`
+  - `cast_spell`
+  - `enchant`
+  - `change_floor`
+  - `add_items_from_chest`
+- `add_items_from_chest` takes read-only `CraftaxState` context plus the
+  `CraftaxInventory` being mutated because the JAX helper's special chest drops
+  depend on `player_level` and `chests_opened`.
+- `tests/craftax_step_medium_test.py` builds a temporary C wrapper around the
+  inline helpers and compares each subsystem against the installed JAX function
+  on copied reset-plus-step-through states for 16 seeds and targeted cases:
+  projectile slot and resource gating, learned/unlearned spells, enchantment
+  table/gem/mana/item gating, every floor transition direction, and chest potion
+  and special-drop paths.
+- The helpers do not allocate, do not call Python, and preserve the JAX details
+  that matter for these routines, including clamped gather-style indexing,
+  first-free projectile slot selection, cumulative-probability `choice` with
+  `1 - uniform`, sequential Threefry split ordering, and the chest helper's
+  intentionally unused wood roll.
+
+Native-step roadmap checklist:
+
+- [x] Native reset PRNG, noise, 9-floor world generation, and reset observation.
+- [x] Standalone native simple step subsystems with JAX-parity tests.
+- [x] Standalone native medium step subsystems with JAX-parity tests.
+- [x] Standalone native crafting and placement subsystems with JAX-parity tests.
+- [x] Standalone native `do_action` subsystem with JAX-parity tests.
+- [ ] Standalone native ports for the remaining mob step subsystems:
+  `update_mobs` and `spawn_mobs`.
+- [ ] Native reward, terminal, timestep, light-level, RNG, and achievement-delta
+  bookkeeping around the subsystem calls.
+- [ ] Integrate all green subsystem ports into a native `c_step` behind one
+  explicit switch, then remove the Python/JAX proxy from the normal step path.
+- [ ] Restore production vector sizes in `config/ocean/craftax.ini` after native
+  step is the default.
+- [ ] Benchmark CPU throughput only after the proxy path is gone.
+
+Remaining proxy paths:
+
+- `c_step` still delegates to the Python/JAX proxy. None of the new medium
+  helpers are wired into the live environment yet.
+- The only gameplay step subsystems still without standalone native ports are
+  `update_mobs` and `spawn_mobs`. Reward/terminal bookkeeping, light-level
+  updates, timestep updates, RNG threading, and achievement-delta logging are
+  also still not integrated natively.
+- Rendering remains a no-op.
+- `config/ocean/craftax.ini` still uses a small proxy-friendly vector size. The
+  native port should raise this once step no longer calls Python.
+
+## 2026-04-18 Standalone Simple Step Subsystems
+
+This phase adds native C ports for the easy step subsystems, but deliberately
+does not integrate them into `c_step`. The live Ocean environment still delegates
+step to the Python/JAX proxy, so the full parity harness should remain unchanged.
+
+- `step_simple.h` contains standalone in-place helpers for:
+  - `move_player`
+  - `update_plants`
+  - `boss_logic`
+  - `level_up_attributes`
+  - `clip_inventory_and_intrinsics`
+  - `calculate_inventory_achievements`
+  - `update_player_intrinsics`
+  - `drink_potion`
+  - `read_book`
+- `tests/craftax_state_fixtures.py` provides test-only pickle payloads for JAX
+  `EnvState` values, a ctypes mirror of `CraftaxState`, C-to-JAX conversion, and
+  strict state diffing with exact integer/bool checks and `atol=1e-6` float
+  checks.
+- `tests/craftax_step_subsystem_test.py` builds a temporary C wrapper around the
+  inline helpers and compares each subsystem against the JAX function on copied
+  reset-plus-step-through states for 16 seeds and targeted stress cases.
+- The helpers do not allocate, do not call Python, and keep JAX details that
+  matter for these routines, including clamped gather-style indexing, `where` and
+  `select` ordering, potion `-1` indexing, and the `read_book` split plus
+  probability-choice path.
+
+Native-step roadmap checklist:
+
+- [x] Native reset PRNG, noise, 9-floor world generation, and reset observation.
+- [x] Standalone native simple step subsystems with JAX-parity tests.
+- [x] Standalone native medium step subsystems with JAX-parity tests.
+- [x] Standalone native crafting and placement subsystems with JAX-parity tests.
+- [x] Standalone native `do_action` subsystem with JAX-parity tests.
+- [ ] Standalone native ports for the remaining mob step subsystems:
+  `update_mobs` and `spawn_mobs`.
+- [ ] Native reward, terminal, timestep, light-level, RNG, and achievement-delta
+  bookkeeping around the subsystem calls.
+- [ ] Integrate all green subsystem ports into a native `c_step` behind one
+  explicit switch, then remove the Python/JAX proxy from the normal step path.
+- [ ] Restore production vector sizes in `config/ocean/craftax.ini` after native
+  step is the default.
+- [ ] Benchmark CPU throughput only after the proxy path is gone.
+
+## 2026-04-18 Native 9-Floor Reset Worldgen
+
+This phase replaces the JAX reset call with native C reset world generation for
+the default `Craftax-Symbolic-v1` environment parameters.
+
+- `worldgen.h` now mirrors `generate_world` for all nine floors:
+  - floor 0 overworld smoothworld
+  - floor 1 dungeon
+  - floor 2 gnomish mines smoothworld
+  - floor 3 sewers dungeon
+  - floor 4 vaults dungeon
+  - floor 5 troll mines smoothworld
+  - floor 6 fire smoothworld
+  - floor 7 ice smoothworld
+  - floor 8 boss smoothworld
+- Native reset generation covers `map`, `item_map`, `mob_map`, `light_map`,
+  ladders, chest flags, `monsters_killed[0] = 10`, empty mob/projectile arrays,
+  projectile directions, empty plants, the random `potion_mapping`, `state_rng`,
+  and the scalar reset fields used by symbolic observations.
+- `craftax_encode_reset_observation` encodes the native reset state into the
+  flat symbolic observation, so `c_reset` no longer imports Python or calls JAX.
+- `tests/craftax_worldgen_test.py` compares the native C reset state against JAX
+  `generate_world` for 16 seeds, with exact map/item/ladder/potion/scalar checks
+  and `atol=1e-6` for light and float state.
+- The Python/JAX proxy is still used for `c_step`. Because step state is still
+  JAX-owned, native `c_reset` marks the proxy dirty and the first delegated step
+  lazily calls the proxy reset before applying the action. This keeps reset
+  Python-free while preserving current step parity.
+
+Remaining proxy paths:
+
+- All step logic, rewards, achievements, auto-reset behavior after a delegated
+  step, mob updates, inventory updates, and logging data still come from the
+  Python/JAX proxy.
+- `c_step` still allocates through Python/JAX and serializes on the GIL. The
+  next porting phase should move gameplay state transitions native and remove
+  the lazy step-side proxy reset.
+- Rendering remains a no-op.
+- `config/ocean/craftax.ini` still uses a small proxy-friendly vector size. The
+  native port should raise this once step no longer calls Python.
+
+## 2026-04-18 Native Floor-0 Reset Slice
+
+This phase added the first native C replacement pieces while keeping the JAX
+proxy as the oracle for all live game state and step logic.
+
+- `threefry.h` ports JAX's `threefry2x32` PRNG for uint32 seeds, including
+  `PRNGKey(seed)`, partitionable `split`/`split_n`, `fold_in`, and
+  `uniform_u32`/float32 uniform helpers. `tests/craftax_threefry_test.py`
+  compares bitwise against `jax.random.PRNGKey`, `split`, `fold_in`, and
+  `bits`.
+- `noise.h` ports `craftax/craftax/util/noise.py` for Perlin and fractal 2D
+  noise. The test uses soft parity because C `sinf`/`cosf` and XLA
+  transcendental lowering can differ by a few ulps; no JAX FFT path is used.
+  `tests/craftax_noise_test.py` enforces `atol=rtol=2e-6`.
+- `worldgen.h` ports default overworld `generate_smoothworld` for floor 0:
+  `map`, `item_map`, `light_map`, `ladder_down`, and `ladder_up`.
+  `tests/craftax_worldgen_floor0_test.py` compares these arrays against JAX for
+  default reset seeds.
+- `c_reset` still calls the JAX proxy to build the full observation and retain
+  the JAX-owned state, then overwrites the visible floor-0 map/item/light
+  observation channels from native C. Because native floor-0 generation matches
+  the JAX reset data for default seeds, end-to-end step parity remains intact.
+
+Remaining proxy paths:
+
+- Floors 1..8 are still generated by JAX.
+- The live `EnvState`, all step logic, rewards, achievements, auto-reset, mobs,
+  inventory, and logging data still come from the Python/JAX proxy.
+- The native floor-0 arrays are not yet installed into the JAX state object;
+  this is safe only because the native generator currently matches the JAX
+  oracle for the covered default reset path.
+
+## Current Implementation
+
+`ocean/craftax/` is wired as a full Craftax Ocean environment with the correct
+symbolic observation size (`8268`) and action count (`43`). The C header declares
+the full Craftax enum set and an `EnvState`-shaped C struct matching the field
+order in `craftax_state.py`.
+
+Reset is native for the full initial `generate_world` state and symbolic
+observation. Step remains reference-backed: the C env acquires the Python GIL,
+calls the installed JAX `Craftax-Symbolic-v1` implementation, and copies the
+resulting float32 observation, reward, terminal flag, and terminal achievement
+log into PufferLib-owned buffers. After a native reset, the first delegated step
+performs a proxy reset internally so the JAX-owned step state starts from the
+same seed and remains aligned with the native reset observation.
+
+## Deliberate Divergences From The Requested Native Port
+
+- The Craftax game logic is not yet native C. Step logic, achievements, rewards,
+  auto-reset behavior after delegated steps, mobs, inventory updates, and other
+  transition logic are delegated to the JAX oracle.
+- `c_step` allocates through Python/JAX and serializes on the GIL. This violates
+  the final performance target and the intended no-allocation step path.
+- `c_close` asks the proxy to drop JAX arrays, then intentionally leaks the small
+  Python proxy wrapper objects. DECREFing JAX/XLA-owned wrappers during
+  PufferLib shutdown segfaulted in the proxy baseline; the native port removes
+  this path.
+- Rendering is a no-op.
+- `config/ocean/craftax.ini` uses a small proxy-friendly vector size. The native
+  port should raise this once step no longer calls Python.
+
+## Known Risks
+
+- Training throughput is expected to be poor. This baseline is for parity and ABI
+  validation, not for the Ryzen 9950X3D optimization target.
+- `uv run puffer train craftax` currently reaches rollout/train work, but a
+  128-step smoke run exits with code 139 during shutdown. The parity harness and
+  direct `VecEnv` close path exit cleanly; this appears specific to the GPU
+  trainer plus proxy/JAX runtime cleanup.
+- The helper forces `JAX_PLATFORM_NAME=cpu` before importing JAX to avoid using
+  the shared GPU from inside environment steps.
+- `build.sh` now embeds rpaths for wheel-provided CUDA libraries so
+  `pufferlib._C` can find `libnccl.so.2`. The parity harness still preloads NCCL
+  defensively for older local builds.
+
+## Next Native Port Steps
+
+1. Replace one step subsystem at a time with native logic and keep the proxy as a
+   local oracle until each subsystem matches.
+2. Remove Python/JAX calls from `c_step`, restore large vector sizes, then measure
+   CPU throughput before optimizing observation encoding, mob updates, and light
+   propagation.

--- a/ocean/craftax_moonshot/binding.c
+++ b/ocean/craftax_moonshot/binding.c
@@ -9,17 +9,17 @@
 #define ACT_SIZES {CRAFTAX_NUM_ACTIONS}
 #define OBS_TENSOR_T FloatTensor
 
+#define CRAFTAX_VEC_TILE_SIZE 128
 #define MY_VEC_INIT
 #define MY_VEC_CLOSE
 #define MY_VEC_STEP craftax_vec_step
+#define MY_VEC_STEP_RANGE craftax_vec_step_range
 #define Env Craftax
 #include "vecenv.h"
 
 // Tiled vector step: process agents in tiles that fit comfortably in cache.
 // Each thread processes a contiguous block of lightweight env handles while
 // the heavier CraftaxState storage lives in a separate arena.
-#define CRAFTAX_VEC_TILE_SIZE 128
-
 void craftax_vec_step(StaticVec* vec) {
     memset(vec->rewards, 0, vec->total_agents * sizeof(float));
     memset(vec->terminals, 0, vec->total_agents * sizeof(float));
@@ -29,6 +29,20 @@ void craftax_vec_step(StaticVec* vec) {
     for (int tile = 0; tile < size; tile += CRAFTAX_VEC_TILE_SIZE) {
         int end = tile + CRAFTAX_VEC_TILE_SIZE;
         if (end > size) end = size;
+        for (int i = tile; i < end; i++) {
+            c_step_gameplay(&envs[i]);
+            c_step_encode(&envs[i]);
+        }
+    }
+}
+
+void craftax_vec_step_range(StaticVec* vec, int env_start, int env_count, int num_workers) {
+    (void)num_workers;
+    Craftax* envs = (Craftax*)vec->envs;
+    int env_end = env_start + env_count;
+    for (int tile = env_start; tile < env_end; tile += CRAFTAX_VEC_TILE_SIZE) {
+        int end = tile + CRAFTAX_VEC_TILE_SIZE;
+        if (end > env_end) end = env_end;
         for (int i = tile; i < end; i++) {
             c_step_gameplay(&envs[i]);
             c_step_encode(&envs[i]);

--- a/ocean/craftax_moonshot/binding.c
+++ b/ocean/craftax_moonshot/binding.c
@@ -1,0 +1,146 @@
+#define CRAFTAX_ENABLE_ENV_IMPL
+#include "craftax.h"
+#include "step_crafting.h"
+#include "step_update_mobs.h"
+#include "step_spawn_mobs.h"
+
+#define OBS_SIZE CRAFTAX_OBS_SIZE
+#define NUM_ATNS 1
+#define ACT_SIZES {CRAFTAX_NUM_ACTIONS}
+#define OBS_TENSOR_T FloatTensor
+
+#define MY_VEC_INIT
+#define MY_VEC_CLOSE
+#define MY_VEC_STEP craftax_vec_step
+#define Env Craftax
+#include "vecenv.h"
+
+// Tiled vector step: process agents in tiles that fit comfortably in cache.
+// Each thread processes a contiguous block of lightweight env handles while
+// the heavier CraftaxState storage lives in a separate arena.
+#define CRAFTAX_VEC_TILE_SIZE 128
+
+void craftax_vec_step(StaticVec* vec) {
+    memset(vec->rewards, 0, vec->total_agents * sizeof(float));
+    memset(vec->terminals, 0, vec->total_agents * sizeof(float));
+    Craftax* envs = (Craftax*)vec->envs;
+    int size = vec->size;
+    #pragma omp parallel for schedule(static)
+    for (int tile = 0; tile < size; tile += CRAFTAX_VEC_TILE_SIZE) {
+        int end = tile + CRAFTAX_VEC_TILE_SIZE;
+        if (end > size) end = size;
+        for (int i = tile; i < end; i++) {
+            c_step_gameplay(&envs[i]);
+            c_step_encode(&envs[i]);
+        }
+    }
+}
+
+static CraftaxState* craftax_alloc_state_arena(int num_envs) {
+    return (CraftaxState*)calloc((size_t)num_envs, sizeof(CraftaxState));
+}
+
+Env* my_vec_init(
+    int* num_envs_out,
+    int* buffer_env_starts,
+    int* buffer_env_counts,
+    Dict* vec_kwargs,
+    Dict* env_kwargs
+) {
+    int total_agents = (int)dict_get(vec_kwargs, "total_agents")->value;
+    int num_buffers = (int)dict_get(vec_kwargs, "num_buffers")->value;
+    int agents_per_buffer = total_agents / num_buffers;
+    int num_envs = total_agents;
+
+    Env* envs = (Env*)calloc((size_t)num_envs, sizeof(Env));
+    CraftaxArena* arena = (CraftaxArena*)calloc(1, sizeof(CraftaxArena));
+    arena->states = craftax_alloc_state_arena(num_envs);
+    arena->num_envs = num_envs;
+    arena->packet_size = CRAFTAX_ARENA_PACKET_SIZE;
+    arena->num_packets = (num_envs + CRAFTAX_ARENA_PACKET_SIZE - 1)
+        / CRAFTAX_ARENA_PACKET_SIZE;
+
+    int buf = 0;
+    int buf_agents = 0;
+    buffer_env_starts[0] = 0;
+    buffer_env_counts[0] = 0;
+
+    for (int i = 0; i < num_envs; i++) {
+        Env* env = &envs[i];
+        env->rng = (unsigned int)i;
+        env->arena = arena;
+        env->state = &arena->states[i];
+        env->packet_id = i / arena->packet_size;
+        env->lane_id = i % arena->packet_size;
+        env->owns_state_storage = false;
+        my_init(env, env_kwargs);
+
+        buf_agents += env->num_agents;
+        buffer_env_counts[buf]++;
+        if (buf_agents >= agents_per_buffer && buf < num_buffers - 1) {
+            buf++;
+            buffer_env_starts[buf] = i + 1;
+            buffer_env_counts[buf] = 0;
+            buf_agents = 0;
+        }
+    }
+
+    *num_envs_out = num_envs;
+    return envs;
+}
+
+void my_vec_close(Env* envs) {
+    if (envs == NULL || envs[0].arena == NULL) {
+        return;
+    }
+
+    CraftaxArena* arena = envs[0].arena;
+    free(arena->states);
+    free(arena);
+}
+
+void my_init(Env* env, Dict* kwargs) {
+    env->num_agents = 1;
+
+    uint64_t seed_offset = 0;
+    DictItem* item = dict_get_unsafe(kwargs, "seed_offset");
+    if (item != NULL) {
+        seed_offset = (uint64_t)item->value;
+    }
+    env->seed = seed_offset + (uint64_t)env->rng;
+
+    // Process-wide reset pool (first caller wins, rest block until ready).
+    // 0 disables caching -- regenerate every reset (exact parity mode).
+    int reset_pool_size = 0;
+    DictItem* pool_item = dict_get_unsafe(kwargs, "reset_pool_size");
+    if (pool_item != NULL) reset_pool_size = (int)pool_item->value;
+    craftax_set_reset_pool_size(reset_pool_size);
+
+    c_init(env);
+}
+
+void my_log(Log* log, Dict* out) {
+    dict_set(out, "perf", log->perf);
+    dict_set(out, "score", log->score);
+    dict_set(out, "episode_return", log->episode_return);
+    dict_set(out, "episode_length", log->episode_length);
+
+    // Log 8 checkpoint achievements that form the tech / exploration curve.
+    // perf (above) already aggregates all 67 into a normalized score; the
+    // individual lines here are the milestones worth watching on a dashboard.
+    // The env still tracks all 67 internally for reward and perf; we just
+    // don't send every one through the log Dict.
+    struct { const char* name; int idx; } checkpoints[] = {
+        {"collect_wood",         0},
+        {"make_wood_pickaxe",    5},
+        {"make_stone_pickaxe",  13},
+        {"collect_iron",        18},
+        {"make_iron_pickaxe",   20},
+        {"collect_diamond",     19},
+        {"enter_gnomish_mines", 28},
+        {"defeat_necromancer",  48},
+    };
+    for (int i = 0; i < (int)(sizeof(checkpoints) / sizeof(checkpoints[0])); i++) {
+        dict_set(out, checkpoints[i].name, log->achievements[checkpoints[i].idx]);
+    }
+}

--- a/ocean/craftax_moonshot/craftax.c
+++ b/ocean/craftax_moonshot/craftax.c
@@ -1,0 +1,76 @@
+// Standalone viewer for Craftax (random-action policy).
+//
+// Build:
+//   ./build.sh craftax --fast         # optimized
+//   ./build.sh craftax --local        # debug with sanitizers
+// Run:
+//   ./craftax
+
+#define CRAFTAX_ENABLE_ENV_IMPL
+#include "craftax.h"
+#include "step_crafting.h"
+#include "step_update_mobs.h"
+#include "step_spawn_mobs.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+static uint32_t xorshift32(uint32_t* s) {
+    uint32_t x = *s;
+    x ^= x << 13; x ^= x >> 17; x ^= x << 5;
+    *s = x ? x : 0xdeadbeef;
+    return x;
+}
+
+int main(int argc, char** argv) {
+    uint64_t seed = (argc > 1) ? strtoull(argv[1], NULL, 10) : (uint64_t)time(NULL);
+
+    Craftax env;
+    memset(&env, 0, sizeof(env));
+    env.num_agents = 1;
+    env.seed = seed;
+    env.rng = (uint32_t)seed;
+
+    // Minimal buffers for a single agent
+    env.observations = calloc(CRAFTAX_OBS_SIZE, sizeof(float));
+    env.actions = calloc(1, sizeof(float));
+    env.rewards = calloc(1, sizeof(float));
+    env.terminals = calloc(1, sizeof(float));
+
+    c_init(&env);
+    c_reset(&env);
+
+    uint32_t action_rng = (uint32_t)(seed ^ 0x9E3779B9u);
+    bool human_control = false;
+    int human_action = CRAFTAX_ACTION_NOOP;
+
+    while (!WindowShouldClose()) {
+        // Toggle human control
+        if (IsKeyPressed(KEY_H)) human_control = !human_control;
+
+        if (human_control) {
+            human_action = CRAFTAX_ACTION_NOOP;
+            if (IsKeyPressed(KEY_A) || IsKeyPressed(KEY_LEFT))  human_action = CRAFTAX_ACTION_LEFT;
+            if (IsKeyPressed(KEY_D) || IsKeyPressed(KEY_RIGHT)) human_action = CRAFTAX_ACTION_RIGHT;
+            if (IsKeyPressed(KEY_W) || IsKeyPressed(KEY_UP))    human_action = CRAFTAX_ACTION_UP;
+            if (IsKeyPressed(KEY_S) || IsKeyPressed(KEY_DOWN))  human_action = CRAFTAX_ACTION_DOWN;
+            if (IsKeyPressed(KEY_SPACE)) human_action = CRAFTAX_ACTION_DO;
+            if (IsKeyPressed(KEY_Z)) human_action = CRAFTAX_ACTION_SLEEP;
+            env.actions[0] = (float)human_action;
+            if (human_action != CRAFTAX_ACTION_NOOP || IsKeyPressed(KEY_PERIOD)) c_step(&env);
+        } else {
+            env.actions[0] = (float)(xorshift32(&action_rng) % CRAFTAX_NUM_ACTIONS);
+            c_step(&env);
+        }
+
+        c_render(&env);
+    }
+
+    c_close(&env);
+    free(env.observations);
+    free(env.actions);
+    free(env.rewards);
+    free(env.terminals);
+    return 0;
+}

--- a/ocean/craftax_moonshot/craftax.h
+++ b/ocean/craftax_moonshot/craftax.h
@@ -1,0 +1,1177 @@
+// Full native Craftax environment for PufferLib Ocean.
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "worldgen.h"
+#include "raylib.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+// ============================================================
+// Optional step profiling (compile with -DCRAFTAX_PROFILE)
+// ============================================================
+#ifdef CRAFTAX_PROFILE
+
+#define CRAFTAX_NUM_PROFILE_ZONES 18
+
+typedef struct {
+    const char* name;
+    uint64_t total_ns;
+    uint64_t count;
+} CraftaxProfileZone;
+
+static CraftaxProfileZone craftax_profile_zones[CRAFTAX_NUM_PROFILE_ZONES] = {
+    {"change_floor", 0, 0},
+    {"crafting", 0, 0},
+    {"do_action", 0, 0},
+    {"place+shoot+spell+potion", 0, 0},
+    {"read_book", 0, 0},
+    {"enchant", 0, 0},
+    {"boss+attr+move", 0, 0},
+    {"update_mobs", 0, 0},
+    {"spawn_mobs", 0, 0},
+    {"plants+intrinsics+achieve", 0, 0},
+    {"reward+bookkeeping", 0, 0},
+    {"encode_obs", 0, 0},
+    {"rng_split", 0, 0},
+    {"is_game_over", 0, 0},
+    {"reset_on_done", 0, 0},
+    {"copy_achievements", 0, 0},
+    {"reward_bookkeeping", 0, 0},
+    {"unprofiled", 0, 0},
+};
+
+static inline uint64_t craftax_profile_now(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+static inline void craftax_profile_record(int zone, uint64_t start) {
+    craftax_profile_zones[zone].total_ns += craftax_profile_now() - start;
+    craftax_profile_zones[zone].count++;
+}
+
+static inline void craftax_profile_report(void) {
+    fprintf(stderr, "\n=== Craftax Step Profile ===\n");
+    uint64_t total = 0;
+    for (int i = 0; i < CRAFTAX_NUM_PROFILE_ZONES; i++) {
+        total += craftax_profile_zones[i].total_ns;
+    }
+    for (int i = 0; i < CRAFTAX_NUM_PROFILE_ZONES; i++) {
+        CraftaxProfileZone* z = &craftax_profile_zones[i];
+        if (z->count == 0) continue;
+        double pct = total > 0 ? (100.0 * (double)z->total_ns / (double)total) : 0.0;
+        double avg_us = (double)z->total_ns / (double)z->count / 1000.0;
+        fprintf(stderr, "%-28s %8.3f%%  %10.2f us/step  (%lu calls)\n",
+                z->name, pct, avg_us, (unsigned long)z->count);
+    }
+    fprintf(stderr, "%-28s %8.3f%%  %10.2f us/step\n",
+            "TOTAL", 100.0, (double)total / (double)craftax_profile_zones[0].count / 1000.0);
+}
+
+#define CRAFTAX_PROFILE_START() uint64_t _prof_start = craftax_profile_now(); uint64_t _prof_zone_start;
+#define CRAFTAX_PROFILE_ZONE(n) do { _prof_zone_start = craftax_profile_now(); } while(0)
+#define CRAFTAX_PROFILE_END(n) craftax_profile_record((n), _prof_zone_start)
+#define CRAFTAX_PROFILE_FINAL(n) craftax_profile_record((n), _prof_start)
+
+#else
+
+#define CRAFTAX_PROFILE_START() ((void)0)
+#define CRAFTAX_PROFILE_ZONE(n) ((void)0)
+#define CRAFTAX_PROFILE_END(n) ((void)0)
+#define CRAFTAX_PROFILE_FINAL(n) ((void)0)
+#define craftax_profile_report() ((void)0)
+
+#endif // CRAFTAX_PROFILE
+
+// ============================================================
+// Constants
+// ============================================================
+#define CRAFTAX_OBS_ROWS 9
+#define CRAFTAX_OBS_COLS 11
+#define CRAFTAX_MAP_SIZE 48
+#define CRAFTAX_NUM_LEVELS 9
+
+#define CRAFTAX_NUM_BLOCK_TYPES 37
+#define CRAFTAX_NUM_ITEM_TYPES 5
+#define CRAFTAX_NUM_MOB_CLASSES 5
+#define CRAFTAX_NUM_MOB_TYPES 8
+#define CRAFTAX_INVENTORY_OBS_SIZE 51
+#define CRAFTAX_OBS_SIZE CRAFTAX_WG_OBS_SIZE
+
+#define CRAFTAX_NUM_ACTIONS 43
+#define CRAFTAX_NUM_ACHIEVEMENTS 67
+
+#define CRAFTAX_MAX_MELEE_MOBS 3
+#define CRAFTAX_MAX_PASSIVE_MOBS 3
+#define CRAFTAX_MAX_RANGED_MOBS 2
+#define CRAFTAX_MAX_MOB_PROJECTILES 3
+#define CRAFTAX_MAX_PLAYER_PROJECTILES 3
+#define CRAFTAX_MAX_GROWING_PLANTS 10
+
+#define CRAFTAX_DEFAULT_MAX_TIMESTEPS 100000
+#define CRAFTAX_DAY_LENGTH 300
+#define CRAFTAX_MAX_ATTRIBUTE 5
+#define CRAFTAX_MOB_DESPAWN_DISTANCE 14
+#define CRAFTAX_MONSTERS_KILLED_TO_CLEAR_LEVEL 8
+
+// ============================================================
+// Enums copied from craftax/craftax/constants.py
+// ============================================================
+typedef enum CraftaxBlockType {
+    CRAFTAX_BLOCK_INVALID = 0,
+    CRAFTAX_BLOCK_OUT_OF_BOUNDS = 1,
+    CRAFTAX_BLOCK_GRASS = 2,
+    CRAFTAX_BLOCK_WATER = 3,
+    CRAFTAX_BLOCK_STONE = 4,
+    CRAFTAX_BLOCK_TREE = 5,
+    CRAFTAX_BLOCK_WOOD = 6,
+    CRAFTAX_BLOCK_PATH = 7,
+    CRAFTAX_BLOCK_COAL = 8,
+    CRAFTAX_BLOCK_IRON = 9,
+    CRAFTAX_BLOCK_DIAMOND = 10,
+    CRAFTAX_BLOCK_CRAFTING_TABLE = 11,
+    CRAFTAX_BLOCK_FURNACE = 12,
+    CRAFTAX_BLOCK_SAND = 13,
+    CRAFTAX_BLOCK_LAVA = 14,
+    CRAFTAX_BLOCK_PLANT = 15,
+    CRAFTAX_BLOCK_RIPE_PLANT = 16,
+    CRAFTAX_BLOCK_WALL = 17,
+    CRAFTAX_BLOCK_DARKNESS = 18,
+    CRAFTAX_BLOCK_WALL_MOSS = 19,
+    CRAFTAX_BLOCK_STALAGMITE = 20,
+    CRAFTAX_BLOCK_SAPPHIRE = 21,
+    CRAFTAX_BLOCK_RUBY = 22,
+    CRAFTAX_BLOCK_CHEST = 23,
+    CRAFTAX_BLOCK_FOUNTAIN = 24,
+    CRAFTAX_BLOCK_FIRE_GRASS = 25,
+    CRAFTAX_BLOCK_ICE_GRASS = 26,
+    CRAFTAX_BLOCK_GRAVEL = 27,
+    CRAFTAX_BLOCK_FIRE_TREE = 28,
+    CRAFTAX_BLOCK_ICE_SHRUB = 29,
+    CRAFTAX_BLOCK_ENCHANTMENT_TABLE_FIRE = 30,
+    CRAFTAX_BLOCK_ENCHANTMENT_TABLE_ICE = 31,
+    CRAFTAX_BLOCK_NECROMANCER = 32,
+    CRAFTAX_BLOCK_GRAVE = 33,
+    CRAFTAX_BLOCK_GRAVE2 = 34,
+    CRAFTAX_BLOCK_GRAVE3 = 35,
+    CRAFTAX_BLOCK_NECROMANCER_VULNERABLE = 36,
+} CraftaxBlockType;
+
+typedef enum CraftaxItemType {
+    CRAFTAX_ITEM_NONE = 0,
+    CRAFTAX_ITEM_TORCH = 1,
+    CRAFTAX_ITEM_LADDER_DOWN = 2,
+    CRAFTAX_ITEM_LADDER_UP = 3,
+    CRAFTAX_ITEM_LADDER_DOWN_BLOCKED = 4,
+} CraftaxItemType;
+
+typedef enum CraftaxAction {
+    CRAFTAX_ACTION_NOOP = 0,
+    CRAFTAX_ACTION_LEFT = 1,
+    CRAFTAX_ACTION_RIGHT = 2,
+    CRAFTAX_ACTION_UP = 3,
+    CRAFTAX_ACTION_DOWN = 4,
+    CRAFTAX_ACTION_DO = 5,
+    CRAFTAX_ACTION_SLEEP = 6,
+    CRAFTAX_ACTION_PLACE_STONE = 7,
+    CRAFTAX_ACTION_PLACE_TABLE = 8,
+    CRAFTAX_ACTION_PLACE_FURNACE = 9,
+    CRAFTAX_ACTION_PLACE_PLANT = 10,
+    CRAFTAX_ACTION_MAKE_WOOD_PICKAXE = 11,
+    CRAFTAX_ACTION_MAKE_STONE_PICKAXE = 12,
+    CRAFTAX_ACTION_MAKE_IRON_PICKAXE = 13,
+    CRAFTAX_ACTION_MAKE_WOOD_SWORD = 14,
+    CRAFTAX_ACTION_MAKE_STONE_SWORD = 15,
+    CRAFTAX_ACTION_MAKE_IRON_SWORD = 16,
+    CRAFTAX_ACTION_REST = 17,
+    CRAFTAX_ACTION_DESCEND = 18,
+    CRAFTAX_ACTION_ASCEND = 19,
+    CRAFTAX_ACTION_MAKE_DIAMOND_PICKAXE = 20,
+    CRAFTAX_ACTION_MAKE_DIAMOND_SWORD = 21,
+    CRAFTAX_ACTION_MAKE_IRON_ARMOUR = 22,
+    CRAFTAX_ACTION_MAKE_DIAMOND_ARMOUR = 23,
+    CRAFTAX_ACTION_SHOOT_ARROW = 24,
+    CRAFTAX_ACTION_MAKE_ARROW = 25,
+    CRAFTAX_ACTION_CAST_FIREBALL = 26,
+    CRAFTAX_ACTION_CAST_ICEBALL = 27,
+    CRAFTAX_ACTION_PLACE_TORCH = 28,
+    CRAFTAX_ACTION_DRINK_POTION_RED = 29,
+    CRAFTAX_ACTION_DRINK_POTION_GREEN = 30,
+    CRAFTAX_ACTION_DRINK_POTION_BLUE = 31,
+    CRAFTAX_ACTION_DRINK_POTION_PINK = 32,
+    CRAFTAX_ACTION_DRINK_POTION_CYAN = 33,
+    CRAFTAX_ACTION_DRINK_POTION_YELLOW = 34,
+    CRAFTAX_ACTION_READ_BOOK = 35,
+    CRAFTAX_ACTION_ENCHANT_SWORD = 36,
+    CRAFTAX_ACTION_ENCHANT_ARMOUR = 37,
+    CRAFTAX_ACTION_MAKE_TORCH = 38,
+    CRAFTAX_ACTION_LEVEL_UP_DEXTERITY = 39,
+    CRAFTAX_ACTION_LEVEL_UP_STRENGTH = 40,
+    CRAFTAX_ACTION_LEVEL_UP_INTELLIGENCE = 41,
+    CRAFTAX_ACTION_ENCHANT_BOW = 42,
+} CraftaxAction;
+
+typedef enum CraftaxMobType {
+    CRAFTAX_MOB_PASSIVE = 0,
+    CRAFTAX_MOB_MELEE = 1,
+    CRAFTAX_MOB_RANGED = 2,
+    CRAFTAX_MOB_PROJECTILE = 3,
+} CraftaxMobType;
+
+typedef enum CraftaxProjectileType {
+    CRAFTAX_PROJECTILE_ARROW = 0,
+    CRAFTAX_PROJECTILE_DAGGER = 1,
+    CRAFTAX_PROJECTILE_FIREBALL = 2,
+    CRAFTAX_PROJECTILE_ICEBALL = 3,
+    CRAFTAX_PROJECTILE_ARROW2 = 4,
+    CRAFTAX_PROJECTILE_SLIMEBALL = 5,
+    CRAFTAX_PROJECTILE_FIREBALL2 = 6,
+    CRAFTAX_PROJECTILE_ICEBALL2 = 7,
+} CraftaxProjectileType;
+
+typedef enum CraftaxAchievement {
+    CRAFTAX_ACH_COLLECT_WOOD = 0,
+    CRAFTAX_ACH_PLACE_TABLE = 1,
+    CRAFTAX_ACH_EAT_COW = 2,
+    CRAFTAX_ACH_COLLECT_SAPLING = 3,
+    CRAFTAX_ACH_COLLECT_DRINK = 4,
+    CRAFTAX_ACH_MAKE_WOOD_PICKAXE = 5,
+    CRAFTAX_ACH_MAKE_WOOD_SWORD = 6,
+    CRAFTAX_ACH_PLACE_PLANT = 7,
+    CRAFTAX_ACH_DEFEAT_ZOMBIE = 8,
+    CRAFTAX_ACH_COLLECT_STONE = 9,
+    CRAFTAX_ACH_PLACE_STONE = 10,
+    CRAFTAX_ACH_EAT_PLANT = 11,
+    CRAFTAX_ACH_DEFEAT_SKELETON = 12,
+    CRAFTAX_ACH_MAKE_STONE_PICKAXE = 13,
+    CRAFTAX_ACH_MAKE_STONE_SWORD = 14,
+    CRAFTAX_ACH_WAKE_UP = 15,
+    CRAFTAX_ACH_PLACE_FURNACE = 16,
+    CRAFTAX_ACH_COLLECT_COAL = 17,
+    CRAFTAX_ACH_COLLECT_IRON = 18,
+    CRAFTAX_ACH_COLLECT_DIAMOND = 19,
+    CRAFTAX_ACH_MAKE_IRON_PICKAXE = 20,
+    CRAFTAX_ACH_MAKE_IRON_SWORD = 21,
+    CRAFTAX_ACH_MAKE_ARROW = 22,
+    CRAFTAX_ACH_MAKE_TORCH = 23,
+    CRAFTAX_ACH_PLACE_TORCH = 24,
+    CRAFTAX_ACH_MAKE_DIAMOND_SWORD = 25,
+    CRAFTAX_ACH_MAKE_IRON_ARMOUR = 26,
+    CRAFTAX_ACH_MAKE_DIAMOND_ARMOUR = 27,
+    CRAFTAX_ACH_ENTER_GNOMISH_MINES = 28,
+    CRAFTAX_ACH_ENTER_DUNGEON = 29,
+    CRAFTAX_ACH_ENTER_SEWERS = 30,
+    CRAFTAX_ACH_ENTER_VAULT = 31,
+    CRAFTAX_ACH_ENTER_TROLL_MINES = 32,
+    CRAFTAX_ACH_ENTER_FIRE_REALM = 33,
+    CRAFTAX_ACH_ENTER_ICE_REALM = 34,
+    CRAFTAX_ACH_ENTER_GRAVEYARD = 35,
+    CRAFTAX_ACH_DEFEAT_GNOME_WARRIOR = 36,
+    CRAFTAX_ACH_DEFEAT_GNOME_ARCHER = 37,
+    CRAFTAX_ACH_DEFEAT_ORC_SOLIDER = 38,
+    CRAFTAX_ACH_DEFEAT_ORC_MAGE = 39,
+    CRAFTAX_ACH_DEFEAT_LIZARD = 40,
+    CRAFTAX_ACH_DEFEAT_KOBOLD = 41,
+    CRAFTAX_ACH_DEFEAT_TROLL = 42,
+    CRAFTAX_ACH_DEFEAT_DEEP_THING = 43,
+    CRAFTAX_ACH_DEFEAT_PIGMAN = 44,
+    CRAFTAX_ACH_DEFEAT_FIRE_ELEMENTAL = 45,
+    CRAFTAX_ACH_DEFEAT_FROST_TROLL = 46,
+    CRAFTAX_ACH_DEFEAT_ICE_ELEMENTAL = 47,
+    CRAFTAX_ACH_DAMAGE_NECROMANCER = 48,
+    CRAFTAX_ACH_DEFEAT_NECROMANCER = 49,
+    CRAFTAX_ACH_EAT_BAT = 50,
+    CRAFTAX_ACH_EAT_SNAIL = 51,
+    CRAFTAX_ACH_FIND_BOW = 52,
+    CRAFTAX_ACH_FIRE_BOW = 53,
+    CRAFTAX_ACH_COLLECT_SAPPHIRE = 54,
+    CRAFTAX_ACH_LEARN_FIREBALL = 55,
+    CRAFTAX_ACH_CAST_FIREBALL = 56,
+    CRAFTAX_ACH_LEARN_ICEBALL = 57,
+    CRAFTAX_ACH_CAST_ICEBALL = 58,
+    CRAFTAX_ACH_COLLECT_RUBY = 59,
+    CRAFTAX_ACH_MAKE_DIAMOND_PICKAXE = 60,
+    CRAFTAX_ACH_OPEN_CHEST = 61,
+    CRAFTAX_ACH_DRINK_POTION = 62,
+    CRAFTAX_ACH_ENCHANT_SWORD = 63,
+    CRAFTAX_ACH_ENCHANT_ARMOUR = 64,
+    CRAFTAX_ACH_DEFEAT_KNIGHT = 65,
+    CRAFTAX_ACH_DEFEAT_ARCHER = 66,
+} CraftaxAchievement;
+
+// ============================================================
+// State layout declarations matching craftax_state.py field order
+// ============================================================
+typedef struct CraftaxInventory {
+    int32_t wood;
+    int32_t stone;
+    int32_t coal;
+    int32_t iron;
+    int32_t diamond;
+    int32_t sapling;
+    int32_t pickaxe;
+    int32_t sword;
+    int32_t bow;
+    int32_t arrows;
+    int32_t armour[4];
+    int32_t torches;
+    int32_t ruby;
+    int32_t sapphire;
+    int32_t potions[6];
+    int32_t books;
+} CraftaxInventory;
+
+typedef struct CraftaxMobs3 {
+    int32_t position[CRAFTAX_NUM_LEVELS][3][2];
+    float health[CRAFTAX_NUM_LEVELS][3];
+    bool mask[CRAFTAX_NUM_LEVELS][3];
+    int32_t attack_cooldown[CRAFTAX_NUM_LEVELS][3];
+    int32_t type_id[CRAFTAX_NUM_LEVELS][3];
+} CraftaxMobs3;
+
+typedef struct CraftaxMobs2 {
+    int32_t position[CRAFTAX_NUM_LEVELS][2][2];
+    float health[CRAFTAX_NUM_LEVELS][2];
+    bool mask[CRAFTAX_NUM_LEVELS][2];
+    int32_t attack_cooldown[CRAFTAX_NUM_LEVELS][2];
+    int32_t type_id[CRAFTAX_NUM_LEVELS][2];
+} CraftaxMobs2;
+
+typedef struct CraftaxState {
+    // === Hot data (accessed every step) ===
+    int32_t player_position[2];
+    int32_t player_level;
+    int32_t player_direction;
+
+    float player_health;
+    int32_t player_food;
+    int32_t player_drink;
+    int32_t player_energy;
+    int32_t player_mana;
+    bool is_sleeping;
+    bool is_resting;
+
+    float player_recover;
+    float player_hunger;
+    float player_thirst;
+    float player_fatigue;
+    float player_recover_mana;
+
+    int32_t player_xp;
+    int32_t player_dexterity;
+    int32_t player_strength;
+    int32_t player_intelligence;
+
+    CraftaxInventory inventory;
+
+    CraftaxMobs3 melee_mobs;
+    CraftaxMobs3 passive_mobs;
+    CraftaxMobs2 ranged_mobs;
+
+    CraftaxMobs3 mob_projectiles;
+    int32_t mob_projectile_directions[CRAFTAX_NUM_LEVELS][CRAFTAX_MAX_MOB_PROJECTILES][2];
+    CraftaxMobs3 player_projectiles;
+    int32_t player_projectile_directions[CRAFTAX_NUM_LEVELS][CRAFTAX_MAX_PLAYER_PROJECTILES][2];
+
+    int32_t growing_plants_positions[CRAFTAX_MAX_GROWING_PLANTS][2];
+    int32_t growing_plants_age[CRAFTAX_MAX_GROWING_PLANTS];
+    bool growing_plants_mask[CRAFTAX_MAX_GROWING_PLANTS];
+
+    int32_t potion_mapping[6];
+    bool learned_spells[2];
+
+    int32_t sword_enchantment;
+    int32_t bow_enchantment;
+    int32_t armour_enchantments[4];
+
+    int32_t boss_progress;
+    int32_t boss_timesteps_to_spawn_this_round;
+
+    float light_level;
+    bool achievements[CRAFTAX_NUM_ACHIEVEMENTS];
+    uint32_t state_rng[2];
+    int32_t timestep;
+    int32_t fractal_noise_angles[4];
+
+    // === Medium-hot bitmaps, read during mob updates, spawn scans, encode_obs ===
+    uint64_t mob_bits[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE];
+    uint64_t spawn_all_bits[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE];
+    uint64_t spawn_grave_bits[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE];
+    uint64_t spawn_water_bits[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE];
+
+    // === Cold data (large maps, scattered access) ===
+    uint8_t map[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE][CRAFTAX_MAP_SIZE];
+    uint8_t item_map[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE][CRAFTAX_MAP_SIZE];
+    uint8_t light_map[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE][CRAFTAX_MAP_SIZE];
+
+    int32_t down_ladders[CRAFTAX_NUM_LEVELS][2];
+    int32_t up_ladders[CRAFTAX_NUM_LEVELS][2];
+    bool chests_opened[CRAFTAX_NUM_LEVELS];
+    int32_t monsters_killed[CRAFTAX_NUM_LEVELS];
+} CraftaxState;
+
+typedef char CraftaxStateMatchesWorldState[
+    (sizeof(CraftaxState) == sizeof(CraftaxWorldState)) ? 1 : -1
+];
+
+static inline uint64_t craftax_spawn_all_bit(uint8_t block) {
+    return (uint64_t)(
+        block == CRAFTAX_BLOCK_GRASS
+        || block == CRAFTAX_BLOCK_PATH
+        || block == CRAFTAX_BLOCK_FIRE_GRASS
+        || block == CRAFTAX_BLOCK_ICE_GRASS
+    );
+}
+
+static inline uint64_t craftax_spawn_grave_bit(uint8_t block) {
+    return (uint64_t)(
+        block == CRAFTAX_BLOCK_GRAVE
+        || block == CRAFTAX_BLOCK_GRAVE2
+        || block == CRAFTAX_BLOCK_GRAVE3
+    );
+}
+
+static inline uint64_t craftax_spawn_water_bit(uint8_t block) {
+    return (uint64_t)(block == CRAFTAX_BLOCK_WATER);
+}
+
+static inline void craftax_refresh_spawn_bits_cell(
+    CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    int32_t col
+) {
+    uint64_t bit = 1ULL << col;
+    uint8_t block = state->map[level][row][col];
+
+    state->spawn_all_bits[level][row] =
+        (state->spawn_all_bits[level][row] & ~bit)
+        | ((0ULL - craftax_spawn_all_bit(block)) & bit);
+    state->spawn_grave_bits[level][row] =
+        (state->spawn_grave_bits[level][row] & ~bit)
+        | ((0ULL - craftax_spawn_grave_bit(block)) & bit);
+    state->spawn_water_bits[level][row] =
+        (state->spawn_water_bits[level][row] & ~bit)
+        | ((0ULL - craftax_spawn_water_bit(block)) & bit);
+}
+
+static inline void craftax_set_map_block(
+    CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    int32_t col,
+    int32_t block
+) {
+    state->map[level][row][col] = (uint8_t)block;
+    craftax_refresh_spawn_bits_cell(state, level, row, col);
+}
+
+static inline void craftax_refresh_spawn_bits_all(CraftaxState* state) {
+    for (int32_t level = 0; level < CRAFTAX_NUM_LEVELS; level++) {
+        for (int32_t row = 0; row < CRAFTAX_MAP_SIZE; row++) {
+            uint64_t all_bits = 0;
+            uint64_t grave_bits = 0;
+            uint64_t water_bits = 0;
+            for (int32_t col = 0; col < CRAFTAX_MAP_SIZE; col++) {
+                uint8_t block = state->map[level][row][col];
+                uint64_t bit = 1ULL << col;
+                all_bits |= (0ULL - craftax_spawn_all_bit(block)) & bit;
+                grave_bits |= (0ULL - craftax_spawn_grave_bit(block)) & bit;
+                water_bits |= (0ULL - craftax_spawn_water_bit(block)) & bit;
+            }
+            state->spawn_all_bits[level][row] = all_bits;
+            state->spawn_grave_bits[level][row] = grave_bits;
+            state->spawn_water_bits[level][row] = water_bits;
+        }
+    }
+}
+
+#define CRAFTAX_ARENA_PACKET_SIZE 64
+
+typedef struct CraftaxArena {
+    CraftaxState* states;
+    int num_envs;
+    int packet_size;
+    int num_packets;
+} CraftaxArena;
+
+#ifdef CRAFTAX_ENABLE_ENV_IMPL
+static inline void craftax_change_floor_native(CraftaxState* state, int32_t action);
+static inline void craftax_do_crafting_native(CraftaxState* state, int32_t action);
+static inline void craftax_do_action_native(
+    CraftaxState* state,
+    int32_t action,
+    CraftaxThreefryKey rng
+);
+static inline void craftax_place_block_native(CraftaxState* state, int32_t action);
+static inline void craftax_shoot_projectile_native(
+    CraftaxState* state,
+    int32_t action
+);
+static inline void craftax_cast_spell_native(CraftaxState* state, int32_t action);
+static inline void craftax_drink_potion_native(CraftaxState* state, int32_t action);
+static inline void craftax_read_book_native(
+    CraftaxState* state,
+    const uint32_t rng_words[2],
+    int32_t action
+);
+static inline void craftax_enchant_native(
+    CraftaxState* state,
+    int32_t action,
+    CraftaxThreefryKey rng
+);
+static inline void craftax_boss_logic_native(CraftaxState* state);
+static inline void craftax_level_up_attributes_native(
+    CraftaxState* state,
+    int32_t action,
+    int32_t max_attribute
+);
+static inline void craftax_move_player_native(
+    CraftaxState* state,
+    int32_t action,
+    bool god_mode
+);
+static inline void craftax_update_mobs_native(
+    CraftaxState* state,
+    CraftaxThreefryKey rng
+);
+static inline void craftax_spawn_mobs_native(
+    CraftaxState* state,
+    CraftaxThreefryKey rng
+);
+static inline void craftax_update_plants_native(CraftaxState* state);
+static inline void craftax_update_player_intrinsics_native(
+    CraftaxState* state,
+    int32_t action
+);
+static inline void craftax_clip_inventory_and_intrinsics_native(
+    CraftaxState* state,
+    bool god_mode
+);
+static inline void craftax_calculate_inventory_achievements_native(
+    CraftaxState* state
+);
+#endif
+
+typedef struct Log {
+    float perf;
+    float score;
+    float episode_return;
+    float episode_length;
+    float achievements[CRAFTAX_NUM_ACHIEVEMENTS];
+    float n;
+} Log;
+
+typedef struct Client {
+    int unused;
+} Client;
+
+typedef struct Craftax {
+    Client* client;
+    Log log;
+
+    float* observations;
+    float* actions;
+    float* rewards;
+    float* terminals;
+    int num_agents;
+
+    unsigned int rng;
+    uint64_t seed;
+    CraftaxThreefryKey rng_key;
+    CraftaxArena* arena;
+    CraftaxState* state;
+    int32_t packet_id;
+    int32_t lane_id;
+    bool owns_state_storage;
+
+    float achievements[CRAFTAX_NUM_ACHIEVEMENTS];
+    float episode_return_accum;
+    int32_t episode_length_accum;
+} Craftax;
+
+#ifdef CRAFTAX_ENABLE_ENV_IMPL
+
+// ============================================================
+// Native reset, observation, reward, and step glue
+// ============================================================
+static const float CRAFTAX_ACHIEVEMENT_REWARD_MAP[CRAFTAX_NUM_ACHIEVEMENTS] = {
+    1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+    1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+    1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+    1.0f, 3.0f, 3.0f, 3.0f, 3.0f, 3.0f, 5.0f, 5.0f,
+    5.0f, 8.0f, 8.0f, 8.0f, 3.0f, 3.0f, 3.0f, 3.0f,
+    5.0f, 5.0f, 5.0f, 5.0f, 8.0f, 8.0f, 8.0f, 8.0f,
+    8.0f, 8.0f, 3.0f, 3.0f, 3.0f, 3.0f, 3.0f, 5.0f,
+    5.0f, 5.0f, 5.0f, 3.0f, 3.0f, 3.0f, 3.0f, 5.0f,
+    5.0f, 5.0f, 5.0f,
+};
+
+static inline CraftaxThreefryKey craftax_step_native_next_key(
+    CraftaxThreefryKey* rng
+) {
+    CraftaxThreefryKey subkey;
+    craftax_threefry_split(*rng, rng, &subkey);
+    return subkey;
+}
+
+static inline void craftax_copy_world_state_to_state(
+    CraftaxState* dst,
+    const CraftaxWorldState* src
+) {
+    memcpy(dst, src, sizeof(*dst));
+}
+
+static inline void craftax_generate_state_from_world_key(
+    CraftaxThreefryKey world_key,
+    CraftaxState* out
+) {
+    CraftaxWorldState world_state;
+    craftax_generate_world_from_key(world_key, &world_state);
+    craftax_copy_world_state_to_state(out, &world_state);
+    craftax_refresh_spawn_bits_all(out);
+}
+
+static inline void craftax_reset_state_from_reset_key(
+    CraftaxState* out,
+    CraftaxThreefryKey reset_key
+) {
+    CraftaxThreefryKey unused;
+    CraftaxThreefryKey world_key;
+    craftax_threefry_split(reset_key, &unused, &world_key);
+    craftax_generate_state_from_world_key(world_key, out);
+}
+
+// ============================================================
+// Reset pool: pre-generate N worlds once, then memcpy on reset.
+// Trades world diversity (<= pool_size unique maps per process) for
+// ~500x faster reset. Set pool_size=0 to disable (exact per-seed
+// world; required for the parity harness).
+// ============================================================
+static int g_craftax_reset_pool_size = 0;
+static CraftaxState* g_craftax_reset_pool = NULL;
+static int g_craftax_reset_pool_ready = 0;
+
+// Called from my_init which runs single-threaded during env creation
+// (vecenv.h iterates envs sequentially). First caller populates the
+// pool; subsequent callers are no-ops.
+static inline void craftax_set_reset_pool_size(int n) {
+    if (g_craftax_reset_pool_ready) return;
+    g_craftax_reset_pool_size = n;
+    if (n > 0) {
+        g_craftax_reset_pool = (CraftaxState*)calloc((size_t)n, sizeof(CraftaxState));
+        for (int i = 0; i < n; i++) {
+            CraftaxThreefryKey init_key = craftax_prng_key((uint32_t)i);
+            CraftaxThreefryKey discard, reset_key;
+            craftax_threefry_split(init_key, &discard, &reset_key);
+            craftax_reset_state_from_reset_key(&g_craftax_reset_pool[i], reset_key);
+        }
+    }
+    g_craftax_reset_pool_ready = 1;
+}
+
+static inline void craftax_ensure_state_storage(Craftax* env) {
+    if (env->state != NULL) {
+        return;
+    }
+
+    CraftaxArena* arena = (CraftaxArena*)calloc(1, sizeof(CraftaxArena));
+    arena->states = (CraftaxState*)calloc(1, sizeof(CraftaxState));
+    arena->num_envs = 1;
+    arena->packet_size = 1;
+    arena->num_packets = 1;
+
+    env->arena = arena;
+    env->state = arena->states;
+    env->packet_id = 0;
+    env->lane_id = 0;
+    env->owns_state_storage = true;
+}
+
+static inline void craftax_reset_state_from_seed(Craftax* env) {
+    craftax_ensure_state_storage(env);
+    CraftaxThreefryKey initial_key = craftax_prng_key((uint32_t)env->seed);
+    if (g_craftax_reset_pool_size > 0) {
+        CraftaxThreefryKey discard;
+        craftax_threefry_split(initial_key, &env->rng_key, &discard);
+        int idx = (int)(env->seed % (uint64_t)g_craftax_reset_pool_size);
+        memcpy(env->state, &g_craftax_reset_pool[idx], sizeof(CraftaxState));
+        return;
+    }
+    CraftaxThreefryKey reset_key;
+    craftax_threefry_split(initial_key, &env->rng_key, &reset_key);
+    craftax_reset_state_from_reset_key(env->state, reset_key);
+}
+
+// Hot-path reset used by c_step on episode-done. Consults the reset pool
+// when enabled, falls through to generate_world otherwise. Pool index is
+// derived from the reset_key so different done events pick different
+// pooled worlds. The direct craftax_reset_state_from_reset_key stays
+// pool-free so the parity harness and any other direct caller get exact
+// per-key determinism.
+static inline void craftax_reset_state_on_done(
+    CraftaxState* out,
+    CraftaxThreefryKey reset_key
+) {
+    if (g_craftax_reset_pool_size > 0) {
+        uint32_t idx = reset_key.word[0] % (uint32_t)g_craftax_reset_pool_size;
+        memcpy(out, &g_craftax_reset_pool[idx], sizeof(CraftaxState));
+        return;
+    }
+    craftax_reset_state_from_reset_key(out, reset_key);
+}
+
+static inline void craftax_encode_native_observation(
+    const CraftaxState* state,
+    float* obs
+) {
+    if (obs == NULL) {
+        return;
+    }
+    craftax_encode_reset_observation((const CraftaxWorldState*)(const void*)state, obs);
+}
+
+static inline float craftax_calculate_light_level_native(int32_t timestep) {
+    float progress = fmodf(
+        (float)timestep / (float)CRAFTAX_DAY_LENGTH,
+        1.0f
+    ) + 0.3f;
+    float c = cosf(CRAFTAX_WG_PI * progress);
+    return 1.0f - powf(fabsf(c), 3.0f);
+}
+
+static inline bool craftax_is_game_over_native(const CraftaxState* state) {
+    return state->timestep >= CRAFTAX_DEFAULT_MAX_TIMESTEPS
+        || state->player_health <= 0.0f;
+}
+
+static inline void craftax_copy_achievements_to_env(
+    Craftax* env,
+    const CraftaxState* state
+) {
+    for (int i = 0; i < CRAFTAX_NUM_ACHIEVEMENTS; i++) {
+        env->achievements[i] = state->achievements[i] ? 1.0f : 0.0f;
+    }
+}
+
+static void add_log(Craftax* env) {
+    int unlocked = 0;
+    for (int i = 0; i < CRAFTAX_NUM_ACHIEVEMENTS; i++) {
+        if (env->achievements[i] > 0.5f) {
+            unlocked++;
+            env->log.achievements[i] += 1.0f;
+        }
+    }
+    env->log.perf += (float)unlocked / (float)CRAFTAX_NUM_ACHIEVEMENTS;
+    env->log.score += env->episode_return_accum;
+    env->log.episode_return += env->episode_return_accum;
+    env->log.episode_length += (float)env->episode_length_accum;
+    env->log.n += 1.0f;
+}
+
+static float craftax_gameplay_step_native(
+    CraftaxState* state,
+    int32_t action,
+    CraftaxThreefryKey rng
+) {
+    CRAFTAX_PROFILE_START();
+    bool init_achievements[CRAFTAX_NUM_ACHIEVEMENTS];
+    memcpy(init_achievements, state->achievements, sizeof(init_achievements));
+    float init_health = state->player_health;
+
+    action = state->is_sleeping ? CRAFTAX_ACTION_NOOP : action;
+    action = state->is_resting ? CRAFTAX_ACTION_NOOP : action;
+
+    CRAFTAX_PROFILE_ZONE(0);
+    craftax_change_floor_native(state, action);
+    craftax_do_crafting_native(state, action);
+    CRAFTAX_PROFILE_END(0);
+
+    CraftaxThreefryKey subkey = craftax_step_native_next_key(&rng);
+    CRAFTAX_PROFILE_ZONE(2);
+    craftax_do_action_native(state, action, subkey);
+    CRAFTAX_PROFILE_END(2);
+
+    CRAFTAX_PROFILE_ZONE(3);
+    craftax_place_block_native(state, action);
+    craftax_shoot_projectile_native(state, action);
+    craftax_cast_spell_native(state, action);
+    craftax_drink_potion_native(state, action);
+    CRAFTAX_PROFILE_END(3);
+
+    subkey = craftax_step_native_next_key(&rng);
+    CRAFTAX_PROFILE_ZONE(4);
+    craftax_read_book_native(state, subkey.word, action);
+    CRAFTAX_PROFILE_END(4);
+
+    subkey = craftax_step_native_next_key(&rng);
+    CRAFTAX_PROFILE_ZONE(5);
+    craftax_enchant_native(state, action, subkey);
+    CRAFTAX_PROFILE_END(5);
+
+    CRAFTAX_PROFILE_ZONE(6);
+    craftax_boss_logic_native(state);
+    craftax_level_up_attributes_native(state, action, CRAFTAX_MAX_ATTRIBUTE);
+    craftax_move_player_native(state, action, false);
+    CRAFTAX_PROFILE_END(6);
+
+    subkey = craftax_step_native_next_key(&rng);
+    CRAFTAX_PROFILE_ZONE(7);
+    craftax_update_mobs_native(state, subkey);
+    CRAFTAX_PROFILE_END(7);
+
+    subkey = craftax_step_native_next_key(&rng);
+    CRAFTAX_PROFILE_ZONE(8);
+    craftax_spawn_mobs_native(state, subkey);
+    CRAFTAX_PROFILE_END(8);
+
+    CRAFTAX_PROFILE_ZONE(9);
+    craftax_update_plants_native(state);
+    craftax_update_player_intrinsics_native(state, action);
+    craftax_clip_inventory_and_intrinsics_native(state, false);
+    craftax_calculate_inventory_achievements_native(state);
+    CRAFTAX_PROFILE_END(9);
+
+    CRAFTAX_PROFILE_ZONE(10);
+    float reward = 0.0f;
+    for (int i = 0; i < CRAFTAX_NUM_ACHIEVEMENTS; i++) {
+        int32_t delta = (int32_t)state->achievements[i]
+            - (int32_t)init_achievements[i];
+        reward += (float)delta * CRAFTAX_ACHIEVEMENT_REWARD_MAP[i];
+    }
+    reward += (state->player_health - init_health) * 0.1f;
+
+    subkey = craftax_step_native_next_key(&rng);
+    state->timestep += 1;
+    state->light_level = craftax_calculate_light_level_native(state->timestep);
+    state->state_rng[0] = subkey.word[0];
+    state->state_rng[1] = subkey.word[1];
+    CRAFTAX_PROFILE_END(10);
+
+    return reward;
+}
+
+// ============================================================
+// Public API expected by vecenv.h
+// ============================================================
+static void c_init(Craftax* env) {
+    env->client = NULL;
+    env->num_agents = 1;
+    craftax_ensure_state_storage(env);
+    env->episode_return_accum = 0.0f;
+    env->episode_length_accum = 0;
+    memset(env->achievements, 0, sizeof(env->achievements));
+    memset(&env->log, 0, sizeof(env->log));
+    craftax_wg_init_cell_templates();
+    craftax_reset_state_from_seed(env);
+}
+
+static void c_reset(Craftax* env) {
+    if (env->rewards != NULL) {
+        env->rewards[0] = 0.0f;
+    }
+    if (env->terminals != NULL) {
+        env->terminals[0] = 0.0f;
+    }
+    env->episode_return_accum = 0.0f;
+    env->episode_length_accum = 0;
+    memset(env->achievements, 0, sizeof(env->achievements));
+
+    craftax_reset_state_from_seed(env);
+    craftax_encode_native_observation(env->state, env->observations);
+}
+
+#ifdef CRAFTAX_PROFILE
+static void c_step_native(Craftax* env) {
+    CRAFTAX_PROFILE_START();
+    env->rewards[0] = 0.0f;
+    env->terminals[0] = 0.0f;
+
+    int action = (int)env->actions[0];
+    if (action < 0) {
+        action = CRAFTAX_ACTION_NOOP;
+    }
+    if (action >= CRAFTAX_NUM_ACTIONS) {
+        action = CRAFTAX_NUM_ACTIONS - 1;
+    }
+
+    CRAFTAX_PROFILE_ZONE(12);
+    CraftaxThreefryKey step_key;
+    craftax_threefry_split(env->rng_key, &env->rng_key, &step_key);
+
+    CraftaxThreefryKey step_rng;
+    CraftaxThreefryKey reset_key;
+    craftax_threefry_split(step_key, &step_rng, &reset_key);
+    CRAFTAX_PROFILE_END(12);
+
+    float reward = craftax_gameplay_step_native(env->state, action, step_rng);
+
+    CRAFTAX_PROFILE_ZONE(13);
+    bool done = craftax_is_game_over_native(env->state);
+    CRAFTAX_PROFILE_END(13);
+
+    CRAFTAX_PROFILE_ZONE(15);
+    craftax_copy_achievements_to_env(env, env->state);
+    CRAFTAX_PROFILE_END(15);
+
+    CRAFTAX_PROFILE_ZONE(16);
+    env->rewards[0] = reward;
+    env->terminals[0] = done ? 1.0f : 0.0f;
+    env->episode_return_accum += reward;
+    env->episode_length_accum += 1;
+    CRAFTAX_PROFILE_END(16);
+
+    if (done) {
+        add_log(env);
+        env->episode_return_accum = 0.0f;
+        env->episode_length_accum = 0;
+        memset(env->achievements, 0, sizeof(env->achievements));
+        CRAFTAX_PROFILE_ZONE(14);
+        craftax_reset_state_on_done(env->state, reset_key);
+        CRAFTAX_PROFILE_END(14);
+    }
+
+    CRAFTAX_PROFILE_ZONE(11);
+    craftax_encode_native_observation(env->state, env->observations);
+    CRAFTAX_PROFILE_END(11);
+
+    // Record unprofiled time
+    CRAFTAX_PROFILE_ZONE(17);
+    CRAFTAX_PROFILE_END(17);
+
+#ifdef CRAFTAX_PROFILE
+    static int profile_step_count = 0;
+    profile_step_count++;
+    if (profile_step_count >= 100000) {
+        craftax_profile_report();
+        profile_step_count = 0;
+    }
+
+#endif
+}
+
+#endif
+
+static void c_step_gameplay(Craftax* env) {
+    env->rewards[0] = 0.0f;
+    env->terminals[0] = 0.0f;
+
+    int action = (int)env->actions[0];
+    if (action < 0) action = CRAFTAX_ACTION_NOOP;
+    if (action >= CRAFTAX_NUM_ACTIONS) action = CRAFTAX_NUM_ACTIONS - 1;
+
+    CraftaxThreefryKey step_key;
+    craftax_threefry_split(env->rng_key, &env->rng_key, &step_key);
+    CraftaxThreefryKey step_rng;
+    CraftaxThreefryKey reset_key;
+    craftax_threefry_split(step_key, &step_rng, &reset_key);
+
+    float reward = craftax_gameplay_step_native(env->state, action, step_rng);
+    bool done = craftax_is_game_over_native(env->state);
+    craftax_copy_achievements_to_env(env, env->state);
+
+    env->rewards[0] = reward;
+    env->terminals[0] = done ? 1.0f : 0.0f;
+    env->episode_return_accum += reward;
+    env->episode_length_accum += 1;
+
+    if (done) {
+        add_log(env);
+        env->episode_return_accum = 0.0f;
+        env->episode_length_accum = 0;
+        memset(env->achievements, 0, sizeof(env->achievements));
+        craftax_reset_state_on_done(env->state, reset_key);
+    }
+}
+
+static void c_step_encode(Craftax* env) {
+    craftax_encode_native_observation(env->state, env->observations);
+}
+
+static void c_step(Craftax* env) {
+    c_step_gameplay(env);
+    c_step_encode(env);
+}
+
+static void c_close(Craftax* env) {
+    if (!env->owns_state_storage || env->arena == NULL) {
+        return;
+    }
+    free(env->arena->states);
+    free(env->arena);
+    env->arena = NULL;
+    env->state = NULL;
+    env->owns_state_storage = false;
+}
+
+// ------------------------------------------------------------
+// Tile-based renderer using upstream Craftax 16x16 PNG assets
+// ------------------------------------------------------------
+// Packed layout (see ocean/craftax/pack_textures.py):
+//   [0..36] block textures (indexed by CraftaxBlockType)
+//   [37..41] player: down, up, left, right, sleep
+//   [42..46] items: none, torch, ladder_down, ladder_up, ladder_down_blocked
+
+#define CRAFTAX_TEX_TILE_PX 16
+#define CRAFTAX_TEX_SCALE 4   // on-screen px = 64
+#define CRAFTAX_TEX_DRAW_PX (CRAFTAX_TEX_TILE_PX * CRAFTAX_TEX_SCALE)
+#define CRAFTAX_TEX_NUM (37 + 5 + 5 + 3 + 4)
+
+// Render viewport (independent of agent obs window)
+#define CRAFTAX_RENDER_ROWS 16
+#define CRAFTAX_RENDER_COLS 16
+
+#define CRAFTAX_TEX_PLAYER_DOWN 37
+#define CRAFTAX_TEX_PLAYER_UP 38
+#define CRAFTAX_TEX_PLAYER_LEFT 39
+#define CRAFTAX_TEX_PLAYER_RIGHT 40
+#define CRAFTAX_TEX_PLAYER_SLEEP 41
+#define CRAFTAX_TEX_ITEM_BASE 42
+
+static Texture2D craftax_textures[CRAFTAX_TEX_NUM];
+static bool craftax_textures_loaded = false;
+
+static void craftax_load_textures(void) {
+    if (craftax_textures_loaded) return;
+    const char* candidates[] = {
+        "resources/craftax/textures.bin",
+        "../resources/craftax/textures.bin",
+        "../../resources/craftax/textures.bin",
+    };
+    FILE* f = NULL;
+    for (size_t i = 0; i < sizeof(candidates)/sizeof(candidates[0]); i++) {
+        f = fopen(candidates[i], "rb");
+        if (f) break;
+    }
+    if (!f) {
+        fprintf(stderr, "craftax: textures.bin not found in resources/craftax -- run ocean/craftax/pack_textures.py\n");
+        exit(1);
+    }
+    const size_t tile_bytes = CRAFTAX_TEX_TILE_PX * CRAFTAX_TEX_TILE_PX * 4;
+    uint8_t* buf = (uint8_t*)malloc(tile_bytes);
+    for (int i = 0; i < CRAFTAX_TEX_NUM; i++) {
+        if (fread(buf, 1, tile_bytes, f) != tile_bytes) {
+            fprintf(stderr, "craftax: short read on textures.bin at tile %d\n", i);
+            exit(1);
+        }
+        Image img = {
+            .data = buf,
+            .width = CRAFTAX_TEX_TILE_PX,
+            .height = CRAFTAX_TEX_TILE_PX,
+            .mipmaps = 1,
+            .format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8,
+        };
+        craftax_textures[i] = LoadTextureFromImage(img);
+        SetTextureFilter(craftax_textures[i], TEXTURE_FILTER_POINT);
+    }
+    free(buf);
+    fclose(f);
+    craftax_textures_loaded = true;
+}
+
+static int craftax_player_tex_id(int32_t direction, bool sleeping) {
+    if (sleeping) return CRAFTAX_TEX_PLAYER_SLEEP;
+    switch (direction) {
+        case 1: return CRAFTAX_TEX_PLAYER_LEFT;
+        case 2: return CRAFTAX_TEX_PLAYER_RIGHT;
+        case 3: return CRAFTAX_TEX_PLAYER_UP;
+        case 4: return CRAFTAX_TEX_PLAYER_DOWN;
+        default: return CRAFTAX_TEX_PLAYER_DOWN;
+    }
+}
+
+static void craftax_draw_tile(int tex_id, int dst_x, int dst_y, float tint_alpha) {
+    if (tex_id < 0 || tex_id >= CRAFTAX_TEX_NUM) return;
+    Rectangle src = {0, 0, CRAFTAX_TEX_TILE_PX, CRAFTAX_TEX_TILE_PX};
+    Rectangle dst = {(float)dst_x, (float)dst_y, CRAFTAX_TEX_DRAW_PX, CRAFTAX_TEX_DRAW_PX};
+    Color tint = {255, 255, 255, (unsigned char)(tint_alpha * 255.0f)};
+    DrawTexturePro(craftax_textures[tex_id], src, dst, (Vector2){0, 0}, 0.0f, tint);
+}
+
+static void c_render(Craftax* env) {
+    const int view_w = CRAFTAX_RENDER_COLS * CRAFTAX_TEX_DRAW_PX;
+    const int view_h = CRAFTAX_RENDER_ROWS * CRAFTAX_TEX_DRAW_PX;
+    const int hud_h = 80;
+
+    if (!IsWindowReady()) {
+        InitWindow(view_w, view_h + hud_h, "PufferLib Craftax");
+        SetTargetFPS(30);
+    }
+    if (!craftax_textures_loaded) craftax_load_textures();
+    if (IsKeyDown(KEY_ESCAPE)) exit(0);
+
+    CraftaxState* s = env->state;
+    int lvl = s->player_level;
+    int pr = s->player_position[0];
+    int pc = s->player_position[1];
+    int half_r = CRAFTAX_RENDER_ROWS / 2;
+    int half_c = CRAFTAX_RENDER_COLS / 2;
+
+    BeginDrawing();
+    ClearBackground(BLACK);
+
+    for (int vr = 0; vr < CRAFTAX_RENDER_ROWS; vr++) {
+        for (int vc = 0; vc < CRAFTAX_RENDER_COLS; vc++) {
+            int wr = pr - half_r + vr;
+            int wc = pc - half_c + vc;
+            int dst_x = vc * CRAFTAX_TEX_DRAW_PX;
+            int dst_y = vr * CRAFTAX_TEX_DRAW_PX;
+
+            int blk = CRAFTAX_BLOCK_OUT_OF_BOUNDS;
+            if (wr >= 0 && wr < CRAFTAX_MAP_SIZE && wc >= 0 && wc < CRAFTAX_MAP_SIZE) {
+                blk = s->map[lvl][wr][wc];
+                if (s->light_map[lvl][wr][wc] <= 12) blk = CRAFTAX_BLOCK_DARKNESS;
+            }
+            if (blk < 0 || blk >= CRAFTAX_NUM_BLOCK_TYPES) blk = 0;
+            craftax_draw_tile(blk, dst_x, dst_y, 1.0f);
+
+            // item overlay
+            if (wr >= 0 && wr < CRAFTAX_MAP_SIZE && wc >= 0 && wc < CRAFTAX_MAP_SIZE) {
+                int it = s->item_map[lvl][wr][wc];
+                if (it > 0 && it < 5) {
+                    craftax_draw_tile(CRAFTAX_TEX_ITEM_BASE + it, dst_x, dst_y, 1.0f);
+                }
+            }
+        }
+    }
+
+    // player in center
+    int pid = craftax_player_tex_id(s->player_direction, s->is_sleeping);
+    craftax_draw_tile(pid, half_c * CRAFTAX_TEX_DRAW_PX, half_r * CRAFTAX_TEX_DRAW_PX, 1.0f);
+
+    // night dim overlay
+    if (s->light_level < 1.0f) {
+        unsigned char a = (unsigned char)((1.0f - s->light_level) * 140.0f);
+        DrawRectangle(0, 0, view_w, view_h, (Color){0, 0, 40, a});
+    }
+
+    // HUD
+    int hud_y = view_h;
+    DrawRectangle(0, hud_y, view_w, hud_h, (Color){20, 20, 20, 255});
+    DrawText(TextFormat("HP:%.0f  F:%d  D:%d  E:%d  M:%d  L:%d  t:%d",
+             s->player_health, s->player_food, s->player_drink,
+             s->player_energy, s->player_mana, s->player_level, s->timestep),
+             4, hud_y + 4, 14, WHITE);
+    DrawText(TextFormat("XP:%d  DEX:%d  STR:%d  INT:%d  light:%.2f",
+             s->player_xp, s->player_dexterity, s->player_strength,
+             s->player_intelligence, s->light_level),
+             4, hud_y + 22, 14, (Color){200, 200, 200, 255});
+    int ach_count = 0;
+    for (int i = 0; i < CRAFTAX_NUM_ACHIEVEMENTS; i++) ach_count += s->achievements[i] ? 1 : 0;
+    DrawText(TextFormat("achievements: %d / %d", ach_count, CRAFTAX_NUM_ACHIEVEMENTS),
+             4, hud_y + 40, 14, (Color){180, 220, 180, 255});
+    DrawText(TextFormat("ret:%.2f len:%d", env->episode_return_accum, env->episode_length_accum),
+             4, hud_y + 58, 14, (Color){200, 200, 140, 255});
+
+    EndDrawing();
+}
+
+#endif

--- a/ocean/craftax_moonshot/craftax_moonshot.c
+++ b/ocean/craftax_moonshot/craftax_moonshot.c
@@ -1,0 +1,76 @@
+// Standalone viewer for Craftax moonshot (random-action policy).
+//
+// Build:
+//   ./build.sh craftax_moonshot --fast   # optimized
+//   ./build.sh craftax_moonshot --local  # debug with sanitizers
+// Run:
+//   ./craftax_moonshot
+
+#define CRAFTAX_ENABLE_ENV_IMPL
+#include "craftax.h"
+#include "step_crafting.h"
+#include "step_update_mobs.h"
+#include "step_spawn_mobs.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+static uint32_t xorshift32(uint32_t* s) {
+    uint32_t x = *s;
+    x ^= x << 13; x ^= x >> 17; x ^= x << 5;
+    *s = x ? x : 0xdeadbeef;
+    return x;
+}
+
+int main(int argc, char** argv) {
+    uint64_t seed = (argc > 1) ? strtoull(argv[1], NULL, 10) : (uint64_t)time(NULL);
+
+    Craftax env;
+    memset(&env, 0, sizeof(env));
+    env.num_agents = 1;
+    env.seed = seed;
+    env.rng = (uint32_t)seed;
+
+    // Minimal buffers for a single agent
+    env.observations = calloc(CRAFTAX_OBS_SIZE, sizeof(float));
+    env.actions = calloc(1, sizeof(float));
+    env.rewards = calloc(1, sizeof(float));
+    env.terminals = calloc(1, sizeof(float));
+
+    c_init(&env);
+    c_reset(&env);
+
+    uint32_t action_rng = (uint32_t)(seed ^ 0x9E3779B9u);
+    bool human_control = false;
+    int human_action = CRAFTAX_ACTION_NOOP;
+
+    while (!WindowShouldClose()) {
+        // Toggle human control
+        if (IsKeyPressed(KEY_H)) human_control = !human_control;
+
+        if (human_control) {
+            human_action = CRAFTAX_ACTION_NOOP;
+            if (IsKeyPressed(KEY_A) || IsKeyPressed(KEY_LEFT))  human_action = CRAFTAX_ACTION_LEFT;
+            if (IsKeyPressed(KEY_D) || IsKeyPressed(KEY_RIGHT)) human_action = CRAFTAX_ACTION_RIGHT;
+            if (IsKeyPressed(KEY_W) || IsKeyPressed(KEY_UP))    human_action = CRAFTAX_ACTION_UP;
+            if (IsKeyPressed(KEY_S) || IsKeyPressed(KEY_DOWN))  human_action = CRAFTAX_ACTION_DOWN;
+            if (IsKeyPressed(KEY_SPACE)) human_action = CRAFTAX_ACTION_DO;
+            if (IsKeyPressed(KEY_Z)) human_action = CRAFTAX_ACTION_SLEEP;
+            env.actions[0] = (float)human_action;
+            if (human_action != CRAFTAX_ACTION_NOOP || IsKeyPressed(KEY_PERIOD)) c_step(&env);
+        } else {
+            env.actions[0] = (float)(xorshift32(&action_rng) % CRAFTAX_NUM_ACTIONS);
+            c_step(&env);
+        }
+
+        c_render(&env);
+    }
+
+    c_close(&env);
+    free(env.observations);
+    free(env.actions);
+    free(env.rewards);
+    free(env.terminals);
+    return 0;
+}

--- a/ocean/craftax_moonshot/noise.h
+++ b/ocean/craftax_moonshot/noise.h
@@ -1,0 +1,206 @@
+// Native C port of craftax/craftax/util/noise.py.
+
+#pragma once
+
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "threefry.h"
+
+#ifndef CRAFTAX_NOISE_PI2
+#define CRAFTAX_NOISE_PI2 6.28318530717958647692f
+#endif
+
+#ifndef CRAFTAX_NOISE_SQRT2
+#define CRAFTAX_NOISE_SQRT2 1.41421356237309504880f
+#endif
+
+static inline float craftax_noise_interpolant(float t) {
+    return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f);
+}
+
+static inline float craftax_noise_gradient_angle(
+    CraftaxThreefryKey angle_key,
+    int res_cols,
+    int row,
+    int col,
+    const float* override_angles
+) {
+    int width = res_cols + 1;
+    uint64_t index = (uint64_t)row * (uint64_t)width + (uint64_t)col;
+    float unit = override_angles == NULL
+        ? craftax_threefry_uniform_f32_at(angle_key, index)
+        : override_angles[index];
+    return CRAFTAX_NOISE_PI2 * unit;
+}
+
+static inline void craftax_noise_gradient(
+    CraftaxThreefryKey angle_key,
+    int res_cols,
+    int row,
+    int col,
+    const float* override_angles,
+    float* gx,
+    float* gy
+) {
+    float angle = craftax_noise_gradient_angle(
+        angle_key,
+        res_cols,
+        row,
+        col,
+        override_angles
+    );
+    *gx = cosf(angle);
+    *gy = sinf(angle);
+}
+
+static inline void craftax_generate_perlin_noise_2d(
+    CraftaxThreefryKey rng,
+    int rows,
+    int cols,
+    int res_rows,
+    int res_cols,
+    const float* override_angles,
+    float* out
+) {
+    CraftaxThreefryKey unused;
+    CraftaxThreefryKey angle_key;
+    craftax_threefry_split(rng, &unused, &angle_key);
+
+    int cell_rows = rows / res_rows;
+    int cell_cols = cols / res_cols;
+
+    for (int row = 0; row < rows; row++) {
+        int grad_row = row / cell_rows;
+        float local_row = (float)(row - grad_row * cell_rows) / (float)cell_rows;
+        float interp_row = craftax_noise_interpolant(local_row);
+
+        for (int col = 0; col < cols; col++) {
+            int grad_col = col / cell_cols;
+            float local_col = (float)(col - grad_col * cell_cols) / (float)cell_cols;
+            float interp_col = craftax_noise_interpolant(local_col);
+
+            float g00x;
+            float g00y;
+            float g10x;
+            float g10y;
+            float g01x;
+            float g01y;
+            float g11x;
+            float g11y;
+            craftax_noise_gradient(
+                angle_key,
+                res_cols,
+                grad_row,
+                grad_col,
+                override_angles,
+                &g00x,
+                &g00y
+            );
+            craftax_noise_gradient(
+                angle_key,
+                res_cols,
+                grad_row + 1,
+                grad_col,
+                override_angles,
+                &g10x,
+                &g10y
+            );
+            craftax_noise_gradient(
+                angle_key,
+                res_cols,
+                grad_row,
+                grad_col + 1,
+                override_angles,
+                &g01x,
+                &g01y
+            );
+            craftax_noise_gradient(
+                angle_key,
+                res_cols,
+                grad_row + 1,
+                grad_col + 1,
+                override_angles,
+                &g11x,
+                &g11y
+            );
+
+            float n00 = local_row * g00x;
+            n00 += local_col * g00y;
+            float n10 = (local_row - 1.0f) * g10x;
+            n10 += local_col * g10y;
+            float n01 = local_row * g01x;
+            n01 += (local_col - 1.0f) * g01y;
+            float n11 = (local_row - 1.0f) * g11x;
+            n11 += (local_col - 1.0f) * g11y;
+
+            float n0 = n00 * (1.0f - interp_row) + interp_row * n10;
+            float n1 = n01 * (1.0f - interp_row) + interp_row * n11;
+            out[(size_t)row * (size_t)cols + (size_t)col] =
+                CRAFTAX_NOISE_SQRT2 * ((1.0f - interp_col) * n0 + interp_col * n1);
+        }
+    }
+}
+
+static inline void craftax_generate_fractal_noise_2d(
+    CraftaxThreefryKey rng,
+    int rows,
+    int cols,
+    int res_rows,
+    int res_cols,
+    int octaves,
+    float persistence,
+    int lacunarity,
+    const float* override_angles,
+    float* out
+) {
+    size_t size = (size_t)rows * (size_t)cols;
+    for (size_t i = 0; i < size; i++) {
+        out[i] = 0.0f;
+    }
+
+    int frequency = 1;
+    float amplitude = 1.0f;
+    float perlin[size];
+
+    for (int octave = 0; octave < octaves; octave++) {
+        CraftaxThreefryKey next_rng;
+        CraftaxThreefryKey noise_key;
+        craftax_threefry_split(rng, &next_rng, &noise_key);
+        rng = next_rng;
+
+        craftax_generate_perlin_noise_2d(
+            noise_key,
+            rows,
+            cols,
+            frequency * res_rows,
+            frequency * res_cols,
+            override_angles,
+            perlin
+        );
+
+        for (size_t i = 0; i < size; i++) {
+            out[i] += amplitude * perlin[i];
+        }
+
+        frequency *= lacunarity;
+        amplitude *= persistence;
+    }
+
+    float min_value = out[0];
+    float max_value = out[0];
+    for (size_t i = 1; i < size; i++) {
+        if (out[i] < min_value) {
+            min_value = out[i];
+        }
+        if (out[i] > max_value) {
+            max_value = out[i];
+        }
+    }
+
+    float scale = max_value - min_value;
+    for (size_t i = 0; i < size; i++) {
+        out[i] = (out[i] - min_value) / scale;
+    }
+}

--- a/ocean/craftax_moonshot/pack_textures.py
+++ b/ocean/craftax_moonshot/pack_textures.py
@@ -1,0 +1,138 @@
+"""Pack Craftax upstream 16x16 PNG assets into a single shared textures.bin.
+
+Consumed by both ocean/craftax (full) and ocean/craftax_classic. All files
+live in craftax's asset dir; the classic PNGs that overlap are byte-identical
+to the full ones.
+
+Layout: contiguous 16*16*4 RGBA tiles. Order must match the
+CRAFTAX_TEX_* / CC_TEX_* enums in the two env headers.
+
+  [0..36]  block textures (37) -- BlockType; first 17 entries also valid for classic
+  [37..41] player: down, up, left, right, sleep
+  [42..46] items: none(blank), torch, ladder_down, ladder_up, ladder_down_blocked
+  [47..49] mobs: zombie, skeleton, cow
+  [50..53] arrows: down, up, left, right
+"""
+
+from pathlib import Path
+from PIL import Image
+import numpy as np
+
+ASSETS = Path(__file__).resolve().parents[2] / (
+    ".venv/lib/python3.12/site-packages/craftax/craftax/assets"
+)
+OUT_BIN = Path(__file__).resolve().parents[2] / "resources" / "craftax" / "textures.bin"
+
+TILE = 16
+
+BLOCK_FILES = [
+    "debug_tile.png",            # 0 INVALID
+    "debug_tile.png",            # 1 OUT_OF_BOUNDS (overwritten solid grey below)
+    "grass.png",                 # 2
+    "water.png",                 # 3
+    "stone.png",                 # 4
+    "tree.png",                  # 5
+    "wood.png",                  # 6
+    "path.png",                  # 7
+    "coal.png",                  # 8
+    "iron.png",                  # 9
+    "diamond.png",               # 10
+    "table.png",                 # 11 crafting table
+    "furnace.png",               # 12
+    "sand.png",                  # 13
+    "lava.png",                  # 14
+    "plant_on_grass.png",        # 15
+    "ripe_plant_on_grass.png",   # 16
+    "wall2.png",                 # 17
+    "debug_tile.png",            # 18 DARKNESS (overwritten solid black below)
+    "wall_moss.png",             # 19
+    "stalagmite.png",            # 20
+    "sapphire.png",              # 21
+    "ruby.png",                  # 22
+    "chest.png",                 # 23
+    "fountain.png",              # 24
+    "fire_grass.png",            # 25
+    "ice_grass.png",             # 26
+    "gravel.png",                # 27
+    "fire_tree.png",             # 28
+    "ice_shrub.png",             # 29
+    "enchantment_table_fire.png",# 30
+    "enchantment_table_ice.png", # 31
+    "necromancer.png",           # 32
+    "grave.png",                 # 33
+    "grave2.png",                # 34
+    "grave3.png",                # 35
+    "necromancer_vulnerable.png",# 36
+]
+
+PLAYER_FILES = [
+    "player-down.png",
+    "player-up.png",
+    "player-left.png",
+    "player-right.png",
+    "player-sleep.png",
+]
+
+ITEM_FILES = [
+    None,                        # NONE -> fully transparent
+    "torch_on_path.png",
+    "ladder_down.png",
+    "ladder_up.png",
+    "ladder_down_blocked.png",
+]
+
+MOB_FILES = [
+    "zombie.png",
+    "skeleton.png",
+    "cow.png",
+]
+
+ARROW_FILES = [
+    "arrow-down.png",
+    "arrow-up.png",
+    "arrow-left.png",
+    "arrow-right.png",
+]
+
+
+def load_tile(name: str | None) -> np.ndarray:
+    if name is None:
+        return np.zeros((TILE, TILE, 4), dtype=np.uint8)
+    p = ASSETS / name
+    img = Image.open(p).convert("RGBA").resize((TILE, TILE), Image.NEAREST)
+    return np.asarray(img, dtype=np.uint8)
+
+
+def main() -> None:
+    tiles: list[np.ndarray] = []
+    for f in BLOCK_FILES:
+        tiles.append(load_tile(f))
+
+    # manual overrides to match upstream renderer
+    tiles[1] = np.full((TILE, TILE, 4), 128, dtype=np.uint8)
+    tiles[1][..., 3] = 255  # out of bounds
+    tiles[18] = np.zeros((TILE, TILE, 4), dtype=np.uint8)
+    tiles[18][..., 3] = 255  # darkness
+
+    for f in PLAYER_FILES:
+        tiles.append(load_tile(f))
+
+    # torch_in_walls doesn't exist in assets; fall back to torch.png if needed
+    for f in ITEM_FILES:
+        if f is not None and not (ASSETS / f).exists():
+            alt = "torch.png" if "torch" in f else f
+            tiles.append(load_tile(alt))
+        else:
+            tiles.append(load_tile(f))
+
+    for f in MOB_FILES + ARROW_FILES:
+        tiles.append(load_tile(f))
+
+    blob = np.stack(tiles, axis=0)  # (N, 16, 16, 4) uint8
+    assert blob.dtype == np.uint8
+    OUT_BIN.write_bytes(blob.tobytes(order="C"))
+    print(f"wrote {OUT_BIN} — {blob.shape[0]} tiles, {OUT_BIN.stat().st_size} bytes")
+
+
+if __name__ == "__main__":
+    main()

--- a/ocean/craftax_moonshot/step_crafting.h
+++ b/ocean/craftax_moonshot/step_crafting.h
@@ -1,0 +1,424 @@
+// Standalone native ports of Craftax crafting and placement subsystems.
+//
+// These helpers intentionally are not integrated into c_step yet. They mutate a
+// full CraftaxState in place so tests can compare each subsystem directly
+// against the installed JAX implementation.
+
+#pragma once
+
+#include "step_simple.h"
+
+static inline bool craftax_crafting_is_near_block(
+    const CraftaxState* state,
+    int32_t block_type
+) {
+    static const int32_t close_blocks[8][2] = {
+        {0, -1},
+        {0, 1},
+        {-1, 0},
+        {1, 0},
+        {-1, -1},
+        {-1, 1},
+        {1, -1},
+        {1, 1},
+    };
+
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    for (int32_t i = 0; i < 8; i++) {
+        int32_t row = state->player_position[0] + close_blocks[i][0];
+        int32_t col = state->player_position[1] + close_blocks[i][1];
+        bool in_bounds = row >= 0
+            && row < CRAFTAX_MAP_SIZE
+            && col >= 0
+            && col < CRAFTAX_MAP_SIZE;
+        if (in_bounds && state->map[level][row][col] == block_type) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static inline int32_t craftax_crafting_first_armour_below(
+    const CraftaxInventory* inventory,
+    int32_t threshold,
+    int32_t* count
+) {
+    int32_t first = 0;
+    *count = 0;
+    for (int32_t i = 0; i < 4; i++) {
+        bool below = inventory->armour[i] < threshold;
+        first = (*count == 0 && below) ? i : first;
+        *count += (int32_t)below;
+    }
+    return first;
+}
+
+static inline void craftax_do_crafting_native(
+    CraftaxState* state,
+    int32_t action
+) {
+    bool is_at_crafting_table = craftax_crafting_is_near_block(
+        state,
+        CRAFTAX_BLOCK_CRAFTING_TABLE
+    );
+    bool is_at_furnace = craftax_crafting_is_near_block(
+        state,
+        CRAFTAX_BLOCK_FURNACE
+    );
+
+    CraftaxInventory* inventory = &state->inventory;
+
+    bool can_craft_wood_pickaxe = inventory->wood >= 1;
+    bool is_crafting_wood_pickaxe =
+        action == CRAFTAX_ACTION_MAKE_WOOD_PICKAXE
+        && can_craft_wood_pickaxe
+        && is_at_crafting_table
+        && inventory->pickaxe < 1;
+    inventory->wood -= 1 * (int32_t)is_crafting_wood_pickaxe;
+    inventory->pickaxe =
+        inventory->pickaxe * (1 - (int32_t)is_crafting_wood_pickaxe)
+        + 1 * (int32_t)is_crafting_wood_pickaxe;
+
+    bool can_craft_stone_pickaxe =
+        inventory->wood >= 1 && inventory->stone >= 1;
+    bool is_crafting_stone_pickaxe =
+        action == CRAFTAX_ACTION_MAKE_STONE_PICKAXE
+        && can_craft_stone_pickaxe
+        && is_at_crafting_table
+        && inventory->pickaxe < 2;
+    inventory->stone -= 1 * (int32_t)is_crafting_stone_pickaxe;
+    inventory->wood -= 1 * (int32_t)is_crafting_stone_pickaxe;
+    inventory->pickaxe =
+        inventory->pickaxe * (1 - (int32_t)is_crafting_stone_pickaxe)
+        + 2 * (int32_t)is_crafting_stone_pickaxe;
+
+    bool can_craft_iron_pickaxe =
+        inventory->wood >= 1
+        && inventory->stone >= 1
+        && inventory->iron >= 1
+        && inventory->coal >= 1;
+    bool is_crafting_iron_pickaxe =
+        action == CRAFTAX_ACTION_MAKE_IRON_PICKAXE
+        && can_craft_iron_pickaxe
+        && is_at_furnace
+        && is_at_crafting_table
+        && inventory->pickaxe < 3;
+    inventory->iron -= 1 * (int32_t)is_crafting_iron_pickaxe;
+    inventory->wood -= 1 * (int32_t)is_crafting_iron_pickaxe;
+    inventory->stone -= 1 * (int32_t)is_crafting_iron_pickaxe;
+    inventory->coal -= 1 * (int32_t)is_crafting_iron_pickaxe;
+    inventory->pickaxe =
+        inventory->pickaxe * (1 - (int32_t)is_crafting_iron_pickaxe)
+        + 3 * (int32_t)is_crafting_iron_pickaxe;
+
+    bool can_craft_diamond_pickaxe =
+        inventory->wood >= 1 && inventory->diamond >= 3;
+    bool is_crafting_diamond_pickaxe =
+        action == CRAFTAX_ACTION_MAKE_DIAMOND_PICKAXE
+        && can_craft_diamond_pickaxe
+        && is_at_crafting_table
+        && inventory->pickaxe < 4;
+    inventory->diamond -= 3 * (int32_t)is_crafting_diamond_pickaxe;
+    inventory->wood -= 1 * (int32_t)is_crafting_diamond_pickaxe;
+    inventory->pickaxe =
+        inventory->pickaxe * (1 - (int32_t)is_crafting_diamond_pickaxe)
+        + 4 * (int32_t)is_crafting_diamond_pickaxe;
+
+    bool can_craft_wood_sword = inventory->wood >= 1;
+    bool is_crafting_wood_sword =
+        action == CRAFTAX_ACTION_MAKE_WOOD_SWORD
+        && can_craft_wood_sword
+        && is_at_crafting_table
+        && inventory->sword < 1;
+    inventory->wood -= 1 * (int32_t)is_crafting_wood_sword;
+    inventory->sword =
+        inventory->sword * (1 - (int32_t)is_crafting_wood_sword)
+        + 1 * (int32_t)is_crafting_wood_sword;
+
+    bool can_craft_stone_sword =
+        inventory->stone >= 1 && inventory->wood >= 1;
+    bool is_crafting_stone_sword =
+        action == CRAFTAX_ACTION_MAKE_STONE_SWORD
+        && can_craft_stone_sword
+        && is_at_crafting_table
+        && inventory->sword < 2;
+    inventory->wood -= 1 * (int32_t)is_crafting_stone_sword;
+    inventory->stone -= 1 * (int32_t)is_crafting_stone_sword;
+    inventory->sword =
+        inventory->sword * (1 - (int32_t)is_crafting_stone_sword)
+        + 2 * (int32_t)is_crafting_stone_sword;
+
+    bool can_craft_iron_sword =
+        inventory->iron >= 1
+        && inventory->wood >= 1
+        && inventory->stone >= 1
+        && inventory->coal >= 1;
+    bool is_crafting_iron_sword =
+        action == CRAFTAX_ACTION_MAKE_IRON_SWORD
+        && can_craft_iron_sword
+        && is_at_furnace
+        && is_at_crafting_table
+        && inventory->sword < 3;
+    inventory->wood -= 1 * (int32_t)is_crafting_iron_sword;
+    inventory->iron -= 1 * (int32_t)is_crafting_iron_sword;
+    inventory->stone -= 1 * (int32_t)is_crafting_iron_sword;
+    inventory->coal -= 1 * (int32_t)is_crafting_iron_sword;
+    inventory->sword =
+        inventory->sword * (1 - (int32_t)is_crafting_iron_sword)
+        + 3 * (int32_t)is_crafting_iron_sword;
+
+    bool can_craft_diamond_sword =
+        inventory->diamond >= 2 && inventory->wood >= 1;
+    bool is_crafting_diamond_sword =
+        action == CRAFTAX_ACTION_MAKE_DIAMOND_SWORD
+        && can_craft_diamond_sword
+        && is_at_crafting_table
+        && inventory->sword < 4;
+    inventory->wood -= 1 * (int32_t)is_crafting_diamond_sword;
+    inventory->diamond -= 2 * (int32_t)is_crafting_diamond_sword;
+    inventory->sword =
+        inventory->sword * (1 - (int32_t)is_crafting_diamond_sword)
+        + 4 * (int32_t)is_crafting_diamond_sword;
+
+    int32_t armour_count = 0;
+    int32_t iron_armour_index_to_craft =
+        craftax_crafting_first_armour_below(inventory, 1, &armour_count);
+    bool can_craft_iron_armour =
+        armour_count > 0 && inventory->iron >= 3 && inventory->coal >= 3;
+    bool is_crafting_iron_armour =
+        action == CRAFTAX_ACTION_MAKE_IRON_ARMOUR
+        && can_craft_iron_armour
+        && is_at_crafting_table
+        && is_at_furnace;
+    inventory->iron -= 3 * (int32_t)is_crafting_iron_armour;
+    inventory->coal -= 3 * (int32_t)is_crafting_iron_armour;
+    inventory->armour[iron_armour_index_to_craft] =
+        (int32_t)is_crafting_iron_armour * 1
+        + (1 - (int32_t)is_crafting_iron_armour)
+        * inventory->armour[iron_armour_index_to_craft];
+    state->achievements[CRAFTAX_ACH_MAKE_IRON_ARMOUR] =
+        state->achievements[CRAFTAX_ACH_MAKE_IRON_ARMOUR]
+        || is_crafting_iron_armour;
+
+    int32_t diamond_armour_count = 0;
+    int32_t diamond_armour_index_to_craft =
+        craftax_crafting_first_armour_below(inventory, 2, &diamond_armour_count);
+    bool can_craft_diamond_armour =
+        diamond_armour_count > 0 && inventory->diamond >= 3;
+    bool is_crafting_diamond_armour =
+        action == CRAFTAX_ACTION_MAKE_DIAMOND_ARMOUR
+        && can_craft_diamond_armour
+        && is_at_crafting_table;
+    inventory->diamond -= 3 * (int32_t)is_crafting_diamond_armour;
+    inventory->armour[diamond_armour_index_to_craft] =
+        (int32_t)is_crafting_diamond_armour * 2
+        + (1 - (int32_t)is_crafting_diamond_armour)
+        * inventory->armour[diamond_armour_index_to_craft];
+    state->achievements[CRAFTAX_ACH_MAKE_DIAMOND_ARMOUR] =
+        state->achievements[CRAFTAX_ACH_MAKE_DIAMOND_ARMOUR]
+        || is_crafting_diamond_armour;
+
+    bool can_craft_arrow = inventory->stone >= 1 && inventory->wood >= 1;
+    bool is_crafting_arrow =
+        action == CRAFTAX_ACTION_MAKE_ARROW
+        && can_craft_arrow
+        && is_at_crafting_table
+        && inventory->arrows < 99;
+    inventory->wood -= 1 * (int32_t)is_crafting_arrow;
+    inventory->stone -= 1 * (int32_t)is_crafting_arrow;
+    inventory->arrows += 2 * (int32_t)is_crafting_arrow;
+
+    bool can_craft_torch = inventory->coal >= 1 && inventory->wood >= 1;
+    bool is_crafting_torch =
+        action == CRAFTAX_ACTION_MAKE_TORCH
+        && can_craft_torch
+        && is_at_crafting_table
+        && inventory->torches < 99;
+    inventory->wood -= 1 * (int32_t)is_crafting_torch;
+    inventory->coal -= 1 * (int32_t)is_crafting_torch;
+    inventory->torches += 4 * (int32_t)is_crafting_torch;
+}
+
+static inline bool craftax_crafting_can_place_item(int32_t block) {
+    switch (block) {
+    case CRAFTAX_BLOCK_GRASS:
+    case CRAFTAX_BLOCK_SAND:
+    case CRAFTAX_BLOCK_PATH:
+    case CRAFTAX_BLOCK_FIRE_GRASS:
+    case CRAFTAX_BLOCK_ICE_GRASS:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static inline float craftax_crafting_torch_light(int32_t row, int32_t col) {
+    static const float torch_light_map[9][9] = {
+        {0.0f, 0.0f, 0.10557288f, 0.17537886f, 0.19999999f, 0.17537886f, 0.10557288f, 0.0f, 0.0f},
+        {0.0f, 0.15147191f, 0.27888972f, 0.36754447f, 0.39999998f, 0.36754447f, 0.27888972f, 0.15147191f, 0.0f},
+        {0.10557288f, 0.27888972f, 0.43431455f, 0.55278647f, 0.6f, 0.55278647f, 0.43431455f, 0.27888972f, 0.10557288f},
+        {0.17537886f, 0.36754447f, 0.55278647f, 0.71715724f, 0.8f, 0.71715724f, 0.55278647f, 0.36754447f, 0.17537886f},
+        {0.19999999f, 0.39999998f, 0.6f, 0.8f, 1.0f, 0.8f, 0.6f, 0.39999998f, 0.19999999f},
+        {0.17537886f, 0.36754447f, 0.55278647f, 0.71715724f, 0.8f, 0.71715724f, 0.55278647f, 0.36754447f, 0.17537886f},
+        {0.10557288f, 0.27888972f, 0.43431455f, 0.55278647f, 0.6f, 0.55278647f, 0.43431455f, 0.27888972f, 0.10557288f},
+        {0.0f, 0.15147191f, 0.27888972f, 0.36754447f, 0.39999998f, 0.36754447f, 0.27888972f, 0.15147191f, 0.0f},
+        {0.0f, 0.0f, 0.10557288f, 0.17537886f, 0.19999999f, 0.17537886f, 0.10557288f, 0.0f, 0.0f},
+    };
+    return torch_light_map[row][col];
+}
+
+static inline void craftax_crafting_add_torch_light(
+    CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    int32_t col
+) {
+    for (int32_t dr = -4; dr <= 4; dr++) {
+        int32_t map_row = row + dr;
+        if (map_row < 0 || map_row >= CRAFTAX_MAP_SIZE) {
+            continue;
+        }
+        for (int32_t dc = -4; dc <= 4; dc++) {
+            int32_t map_col = col + dc;
+            if (map_col < 0 || map_col >= CRAFTAX_MAP_SIZE) {
+                continue;
+            }
+            float light = state->light_map[level][map_row][map_col] / 255.0f
+                + craftax_crafting_torch_light(dr + 4, dc + 4);
+            state->light_map[level][map_row][map_col] =
+                (uint8_t)(craftax_step_minf32(craftax_step_maxf32(light, 0.0f), 1.0f) * 255.0f);
+        }
+    }
+}
+
+static inline void craftax_add_new_growing_plant_native(
+    CraftaxState* state,
+    const int32_t position[2],
+    bool is_placing_sapling
+) {
+    int32_t plant_index = 0;
+    int32_t empty_count = 0;
+    for (int32_t i = 0; i < CRAFTAX_MAX_GROWING_PLANTS; i++) {
+        bool is_empty = !state->growing_plants_mask[i];
+        plant_index = (empty_count == 0 && is_empty) ? i : plant_index;
+        empty_count += (int32_t)is_empty;
+    }
+
+    bool is_adding_plant = empty_count > 0 && is_placing_sapling;
+    if (!is_adding_plant) {
+        return;
+    }
+
+    state->growing_plants_positions[plant_index][0] = position[0];
+    state->growing_plants_positions[plant_index][1] = position[1];
+    state->growing_plants_age[plant_index] = 0;
+    state->growing_plants_mask[plant_index] = true;
+}
+
+static inline void craftax_place_block_native(
+    CraftaxState* state,
+    int32_t action
+) {
+    int32_t direction[2];
+    craftax_step_direction(state->player_direction, direction);
+
+    int32_t row = state->player_position[0] + direction[0];
+    int32_t col = state->player_position[1] + direction[1];
+    bool in_bounds = row >= 0
+        && row < CRAFTAX_MAP_SIZE
+        && col >= 0
+        && col < CRAFTAX_MAP_SIZE;
+    bool in_mob = in_bounds && craftax_step_is_in_mob(state, row, col);
+    if (!in_bounds || in_mob) {
+        return;
+    }
+
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    int32_t original_block = state->map[level][row][col];
+    int32_t original_item = state->item_map[level][row][col];
+    bool is_placement_on_solid_block_or_item =
+        craftax_step_is_solid_block(original_block)
+        || original_item != CRAFTAX_ITEM_NONE;
+
+    CraftaxInventory* inventory = &state->inventory;
+
+    bool is_placing_crafting_table =
+        action == CRAFTAX_ACTION_PLACE_TABLE
+        && !is_placement_on_solid_block_or_item
+        && inventory->wood >= 2;
+    if (is_placing_crafting_table) {
+        craftax_set_map_block(state, level, row, col, CRAFTAX_BLOCK_CRAFTING_TABLE);
+    }
+    inventory->wood -= 2 * (int32_t)is_placing_crafting_table;
+    state->achievements[CRAFTAX_ACH_PLACE_TABLE] =
+        state->achievements[CRAFTAX_ACH_PLACE_TABLE]
+        || is_placing_crafting_table;
+
+    bool is_placing_furnace =
+        action == CRAFTAX_ACTION_PLACE_FURNACE
+        && !is_placement_on_solid_block_or_item
+        && inventory->stone > 0;
+    if (is_placing_furnace) {
+        craftax_set_map_block(state, level, row, col, CRAFTAX_BLOCK_FURNACE);
+    }
+    inventory->stone -= 1 * (int32_t)is_placing_furnace;
+    state->achievements[CRAFTAX_ACH_PLACE_FURNACE] =
+        state->achievements[CRAFTAX_ACH_PLACE_FURNACE]
+        || is_placing_furnace;
+
+    bool is_placing_on_valid_stone_block =
+        original_block == CRAFTAX_BLOCK_WATER
+        || !is_placement_on_solid_block_or_item;
+    bool is_placing_stone =
+        action == CRAFTAX_ACTION_PLACE_STONE
+        && is_placing_on_valid_stone_block
+        && inventory->stone > 0;
+    if (is_placing_stone) {
+        craftax_set_map_block(state, level, row, col, CRAFTAX_BLOCK_STONE);
+    }
+    inventory->stone -= 1 * (int32_t)is_placing_stone;
+    state->achievements[CRAFTAX_ACH_PLACE_STONE] =
+        state->achievements[CRAFTAX_ACH_PLACE_STONE]
+        || is_placing_stone;
+
+    bool is_placing_on_valid_torch_block =
+        craftax_crafting_can_place_item(original_block)
+        && state->item_map[level][row][col] == CRAFTAX_ITEM_NONE;
+    bool is_placing_torch =
+        action == CRAFTAX_ACTION_PLACE_TORCH
+        && is_placing_on_valid_torch_block
+        && inventory->torches > 0;
+    if (is_placing_torch) {
+        state->item_map[level][row][col] = CRAFTAX_ITEM_TORCH;
+        craftax_crafting_add_torch_light(state, level, row, col);
+    }
+    inventory->torches -= 1 * (int32_t)is_placing_torch;
+    state->achievements[CRAFTAX_ACH_PLACE_TORCH] =
+        state->achievements[CRAFTAX_ACH_PLACE_TORCH]
+        || is_placing_torch;
+
+    bool is_placing_sapling =
+        action == CRAFTAX_ACTION_PLACE_PLANT
+        && state->map[level][row][col] == CRAFTAX_BLOCK_GRASS
+        && inventory->sapling > 0
+        && state->item_map[level][row][col] == CRAFTAX_ITEM_NONE;
+    if (is_placing_sapling) {
+        int32_t position[2] = {row, col};
+        craftax_set_map_block(state, level, row, col, CRAFTAX_BLOCK_PLANT);
+        craftax_add_new_growing_plant_native(
+            state,
+            position,
+            is_placing_sapling
+        );
+    }
+    inventory->sapling -= 1 * (int32_t)is_placing_sapling;
+    state->achievements[CRAFTAX_ACH_PLACE_PLANT] =
+        state->achievements[CRAFTAX_ACH_PLACE_PLANT]
+        || is_placing_sapling;
+}

--- a/ocean/craftax_moonshot/step_do_action.h
+++ b/ocean/craftax_moonshot/step_do_action.h
@@ -1,0 +1,610 @@
+// Standalone native port of Craftax do_action.
+//
+// This helper intentionally is not integrated into c_step yet. It mutates a
+// full CraftaxState in place so tests can compare the subsystem directly
+// against the installed JAX implementation.
+
+#pragma once
+
+#include "step_medium.h"
+
+#define CRAFTAX_DO_ACTION_BOSS_FIGHT_SPAWN_TURNS 7
+
+static inline float craftax_do_action_mob_defense(
+    int32_t type_id,
+    int32_t mob_class_index,
+    int32_t damage_index
+) {
+    static const float defenses[8][4][3] = {
+        {
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {0.5f, 0.0f, 0.0f},
+            {0.5f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {0.2f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {0.9f, 1.0f, 0.0f},
+            {0.9f, 1.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {0.9f, 0.0f, 1.0f},
+            {0.9f, 0.0f, 1.0f},
+            {0.0f, 0.0f, 0.0f},
+        },
+    };
+
+    int32_t type_index = craftax_step_jax_index(type_id, 8);
+    int32_t class_index = craftax_step_jax_index(mob_class_index, 4);
+    int32_t component = craftax_step_jax_index(damage_index, 3);
+    return defenses[type_index][class_index][component];
+}
+
+static inline int32_t craftax_do_action_mob_achievement(
+    int32_t mob_class_index,
+    int32_t type_id
+) {
+    static const int32_t achievements[3][8] = {
+        {
+            CRAFTAX_ACH_EAT_COW,
+            CRAFTAX_ACH_EAT_BAT,
+            CRAFTAX_ACH_EAT_SNAIL,
+            0,
+            0,
+            0,
+            0,
+            0,
+        },
+        {
+            CRAFTAX_ACH_DEFEAT_ZOMBIE,
+            CRAFTAX_ACH_DEFEAT_GNOME_WARRIOR,
+            CRAFTAX_ACH_DEFEAT_ORC_SOLIDER,
+            CRAFTAX_ACH_DEFEAT_LIZARD,
+            CRAFTAX_ACH_DEFEAT_KNIGHT,
+            CRAFTAX_ACH_DEFEAT_TROLL,
+            CRAFTAX_ACH_DEFEAT_PIGMAN,
+            CRAFTAX_ACH_DEFEAT_FROST_TROLL,
+        },
+        {
+            CRAFTAX_ACH_DEFEAT_SKELETON,
+            CRAFTAX_ACH_DEFEAT_GNOME_ARCHER,
+            CRAFTAX_ACH_DEFEAT_ORC_MAGE,
+            CRAFTAX_ACH_DEFEAT_KOBOLD,
+            CRAFTAX_ACH_DEFEAT_ARCHER,
+            CRAFTAX_ACH_DEFEAT_DEEP_THING,
+            CRAFTAX_ACH_DEFEAT_FIRE_ELEMENTAL,
+            CRAFTAX_ACH_DEFEAT_ICE_ELEMENTAL,
+        },
+    };
+
+    int32_t class_index = craftax_step_jax_index(mob_class_index, 3);
+    int32_t type_index = craftax_step_jax_index(type_id, 8);
+    return achievements[class_index][type_index];
+}
+
+static inline void craftax_do_action_player_damage_vector(
+    const CraftaxState* state,
+    float damage_vector[3]
+) {
+    static const float physical_damages[5] = {1.0f, 2.0f, 3.0f, 5.0f, 8.0f};
+
+    int32_t sword_index = craftax_step_jax_index(state->inventory.sword, 5);
+    float physical_damage = physical_damages[sword_index];
+    float fire_damage =
+        physical_damage * (float)(state->sword_enchantment == 1) * 0.5f;
+    float ice_damage =
+        physical_damage * (float)(state->sword_enchantment == 2) * 0.5f;
+
+    physical_damage *= 1.0f + 0.25f * (float)(state->player_strength - 1);
+    fire_damage *= 1.0f + 0.05f * (float)(state->player_intelligence - 1);
+    ice_damage *= 1.0f + 0.05f * (float)(state->player_intelligence - 1);
+
+    damage_vector[0] = physical_damage;
+    damage_vector[1] = fire_damage;
+    damage_vector[2] = ice_damage;
+}
+
+static inline float craftax_do_action_damage_done(
+    const float damage_vector[3],
+    int32_t type_id,
+    int32_t mob_class_index
+) {
+    float damage = 0.0f;
+    for (int32_t i = 0; i < 3; i++) {
+        float defense = craftax_do_action_mob_defense(
+            type_id,
+            mob_class_index,
+            i
+        );
+        damage += (1.0f - defense) * damage_vector[i];
+    }
+    return damage;
+}
+
+static inline void craftax_do_action_refresh_mobs3_masks(CraftaxMobs3* mobs) {
+    for (int32_t level = 0; level < CRAFTAX_NUM_LEVELS; level++) {
+        for (int32_t i = 0; i < 3; i++) {
+            mobs->mask[level][i] =
+                mobs->mask[level][i] && mobs->health[level][i] > 0.0f;
+        }
+    }
+}
+
+static inline void craftax_do_action_refresh_mobs2_masks(CraftaxMobs2* mobs) {
+    for (int32_t level = 0; level < CRAFTAX_NUM_LEVELS; level++) {
+        for (int32_t i = 0; i < 2; i++) {
+            mobs->mask[level][i] =
+                mobs->mask[level][i] && mobs->health[level][i] > 0.0f;
+        }
+    }
+}
+
+static inline void craftax_do_action_attack_mobs3(
+    CraftaxState* state,
+    CraftaxMobs3* mobs,
+    int32_t row,
+    int32_t col,
+    const float damage_vector[3],
+    bool can_get_achievement,
+    int32_t mob_class_index,
+    bool* did_kill_mob,
+    bool* is_attacking_mob
+) {
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    bool is_attacking_array[3];
+    *is_attacking_mob = false;
+    int32_t target_mob_index = 0;
+
+    for (int32_t i = 0; i < 3; i++) {
+        bool in_mob = mobs->position[level][i][0] == row
+            && mobs->position[level][i][1] == col;
+        is_attacking_array[i] = in_mob && mobs->mask[level][i];
+        if (is_attacking_array[i] && !*is_attacking_mob) {
+            target_mob_index = i;
+        }
+        *is_attacking_mob = *is_attacking_mob || is_attacking_array[i];
+    }
+
+    int32_t target_type_id = mobs->type_id[level][target_mob_index];
+    float damage = craftax_do_action_damage_done(
+        damage_vector,
+        target_type_id,
+        mob_class_index
+    );
+    mobs->health[level][target_mob_index] -=
+        damage * (float)(int32_t)(*is_attacking_mob);
+
+    bool old_mask = mobs->mask[level][target_mob_index];
+    craftax_do_action_refresh_mobs3_masks(mobs);
+    *did_kill_mob = old_mask && !mobs->mask[level][target_mob_index];
+
+    int32_t achievement_for_kill = craftax_do_action_mob_achievement(
+        mob_class_index,
+        target_type_id
+    );
+    bool unlock = *did_kill_mob && can_get_achievement;
+    state->achievements[achievement_for_kill] =
+        state->achievements[achievement_for_kill] || unlock;
+}
+
+static inline void craftax_do_action_attack_mobs2(
+    CraftaxState* state,
+    CraftaxMobs2* mobs,
+    int32_t row,
+    int32_t col,
+    const float damage_vector[3],
+    bool can_get_achievement,
+    int32_t mob_class_index,
+    bool* did_kill_mob,
+    bool* is_attacking_mob
+) {
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    bool is_attacking_array[2];
+    *is_attacking_mob = false;
+    int32_t target_mob_index = 0;
+
+    for (int32_t i = 0; i < 2; i++) {
+        bool in_mob = mobs->position[level][i][0] == row
+            && mobs->position[level][i][1] == col;
+        is_attacking_array[i] = in_mob && mobs->mask[level][i];
+        if (is_attacking_array[i] && !*is_attacking_mob) {
+            target_mob_index = i;
+        }
+        *is_attacking_mob = *is_attacking_mob || is_attacking_array[i];
+    }
+
+    int32_t target_type_id = mobs->type_id[level][target_mob_index];
+    float damage = craftax_do_action_damage_done(
+        damage_vector,
+        target_type_id,
+        mob_class_index
+    );
+    mobs->health[level][target_mob_index] -=
+        damage * (float)(int32_t)(*is_attacking_mob);
+
+    bool old_mask = mobs->mask[level][target_mob_index];
+    craftax_do_action_refresh_mobs2_masks(mobs);
+    *did_kill_mob = old_mask && !mobs->mask[level][target_mob_index];
+
+    int32_t achievement_for_kill = craftax_do_action_mob_achievement(
+        mob_class_index,
+        target_type_id
+    );
+    bool unlock = *did_kill_mob && can_get_achievement;
+    state->achievements[achievement_for_kill] =
+        state->achievements[achievement_for_kill] || unlock;
+}
+
+static inline bool craftax_do_action_update_index(
+    int32_t index,
+    int32_t size,
+    int32_t* mapped_index
+) {
+    if (index < -size || index >= size) {
+        return false;
+    }
+    *mapped_index = index < 0 ? index + size : index;
+    return true;
+}
+
+static inline void craftax_do_action_update_mob_map(
+    CraftaxState* state,
+    int32_t row,
+    int32_t col,
+    bool did_kill_mob
+) {
+    int32_t update_row;
+    int32_t update_col;
+    if (!craftax_do_action_update_index(row, CRAFTAX_MAP_SIZE, &update_row)
+        || !craftax_do_action_update_index(col, CRAFTAX_MAP_SIZE, &update_col)) {
+        return;
+    }
+
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    int32_t read_row = craftax_step_jax_index(row, CRAFTAX_MAP_SIZE);
+    int32_t read_col = craftax_step_jax_index(col, CRAFTAX_MAP_SIZE);
+    bool old_value = (state->mob_bits[level][read_row] >> read_col) & 1ULL;
+    bool new_value = old_value && !did_kill_mob;
+    if (new_value) {
+        state->mob_bits[level][update_row] |= (1ULL << update_col);
+    } else {
+        state->mob_bits[level][update_row] &= ~(1ULL << update_col);
+    }
+}
+
+static inline void craftax_do_action_attack_mob(
+    CraftaxState* state,
+    int32_t row,
+    int32_t col,
+    bool can_eat,
+    bool* did_attack_mob,
+    bool* did_kill_mob
+) {
+    float damage_vector[3];
+    craftax_do_action_player_damage_vector(state, damage_vector);
+
+    bool did_kill_melee_mob = false;
+    bool is_attacking_melee_mob = false;
+    craftax_do_action_attack_mobs3(
+        state,
+        &state->melee_mobs,
+        row,
+        col,
+        damage_vector,
+        true,
+        1,
+        &did_kill_melee_mob,
+        &is_attacking_melee_mob
+    );
+
+    bool did_kill_passive_mob = false;
+    bool is_attacking_passive_mob = false;
+    craftax_do_action_attack_mobs3(
+        state,
+        &state->passive_mobs,
+        row,
+        col,
+        damage_vector,
+        can_eat,
+        0,
+        &did_kill_passive_mob,
+        &is_attacking_passive_mob
+    );
+
+    if (did_kill_passive_mob && can_eat) {
+        state->player_food = craftax_step_mini32(
+            craftax_step_get_max_food(state),
+            state->player_food + 6
+        );
+        state->player_hunger = 0.0f;
+    }
+
+    bool did_kill_ranged_mob = false;
+    bool is_attacking_ranged_mob = false;
+    craftax_do_action_attack_mobs2(
+        state,
+        &state->ranged_mobs,
+        row,
+        col,
+        damage_vector,
+        true,
+        2,
+        &did_kill_ranged_mob,
+        &is_attacking_ranged_mob
+    );
+
+    *did_attack_mob = is_attacking_melee_mob
+        || is_attacking_passive_mob
+        || is_attacking_ranged_mob;
+    bool did_kill_monster = did_kill_melee_mob || did_kill_ranged_mob;
+    *did_kill_mob = did_kill_monster || did_kill_passive_mob;
+
+    craftax_do_action_update_mob_map(state, row, col, *did_kill_mob);
+
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    state->monsters_killed[level] += (int32_t)did_kill_monster;
+}
+
+static inline bool craftax_do_action_in_bounds(int32_t row, int32_t col) {
+    return row >= 0
+        && row < CRAFTAX_MAP_SIZE
+        && col >= 0
+        && col < CRAFTAX_MAP_SIZE;
+}
+
+static inline bool craftax_do_action_boss_vulnerable(
+    const CraftaxState* state
+) {
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    int32_t melee_count = 0;
+    int32_t ranged_count = 0;
+    for (int32_t i = 0; i < CRAFTAX_MAX_MELEE_MOBS; i++) {
+        melee_count += (int32_t)state->melee_mobs.mask[level][i];
+    }
+    for (int32_t i = 0; i < CRAFTAX_MAX_RANGED_MOBS; i++) {
+        ranged_count += (int32_t)state->ranged_mobs.mask[level][i];
+    }
+    return melee_count == 0
+        && ranged_count == 0
+        && state->boss_timesteps_to_spawn_this_round <= 0;
+}
+
+static inline void craftax_do_action_update_plants_with_eat(
+    CraftaxState* state,
+    int32_t row,
+    int32_t col
+) {
+    int32_t plant_index = 0;
+    bool found = false;
+    for (int32_t i = 0; i < CRAFTAX_MAX_GROWING_PLANTS; i++) {
+        bool is_plant = state->growing_plants_positions[i][0] == row
+            && state->growing_plants_positions[i][1] == col;
+        if (is_plant && !found) {
+            plant_index = i;
+            found = true;
+        }
+    }
+    state->growing_plants_age[plant_index] = 0;
+}
+
+static inline void craftax_do_action_native(
+    CraftaxState* state,
+    int32_t action,
+    CraftaxThreefryKey rng
+) {
+    if (action != CRAFTAX_ACTION_DO) {
+        return;
+    }
+
+    int32_t direction[2];
+    craftax_step_direction(state->player_direction, direction);
+    int32_t target_row = state->player_position[0] + direction[0];
+    int32_t target_col = state->player_position[1] + direction[1];
+
+    bool did_attack_mob = false;
+    bool did_kill_mob = false;
+    craftax_do_action_attack_mob(
+        state,
+        target_row,
+        target_col,
+        true,
+        &did_attack_mob,
+        &did_kill_mob
+    );
+    (void)did_kill_mob;
+
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    int32_t read_row = craftax_step_jax_index(target_row, CRAFTAX_MAP_SIZE);
+    int32_t read_col = craftax_step_jax_index(target_col, CRAFTAX_MAP_SIZE);
+    int32_t target_block = state->map[level][read_row][read_col];
+
+    CraftaxThreefryKey sapling_key = craftax_medium_next_random_key(&rng);
+    CraftaxThreefryKey chest_key = craftax_medium_next_random_key(&rng);
+
+    bool is_opening_chest = target_block == CRAFTAX_BLOCK_CHEST;
+    bool is_damaging_boss = target_block == CRAFTAX_BLOCK_NECROMANCER
+        && craftax_do_action_boss_vulnerable(state)
+        && craftax_step_is_fighting_boss(state);
+
+    bool action_block_in_bounds =
+        craftax_do_action_in_bounds(target_row, target_col) && !did_attack_mob;
+
+    if (action_block_in_bounds) {
+        bool is_block_tree = target_block == CRAFTAX_BLOCK_TREE;
+        bool is_block_fire_tree = target_block == CRAFTAX_BLOCK_FIRE_TREE;
+        bool is_block_ice_shrub = target_block == CRAFTAX_BLOCK_ICE_SHRUB;
+        bool is_mining_tree =
+            is_block_tree || is_block_fire_tree || is_block_ice_shrub;
+        if (is_mining_tree) {
+            int32_t replacement = is_block_tree
+                ? CRAFTAX_BLOCK_GRASS
+                : (is_block_fire_tree
+                    ? CRAFTAX_BLOCK_FIRE_GRASS
+                    : CRAFTAX_BLOCK_ICE_GRASS);
+            craftax_set_map_block(state, level, target_row, target_col, replacement);
+            state->inventory.wood += 1;
+        }
+
+        bool is_mining_stone = target_block == CRAFTAX_BLOCK_STONE
+            && state->inventory.pickaxe >= 1;
+        if (is_mining_stone) {
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
+            state->inventory.stone += 1;
+        }
+
+        if (target_block == CRAFTAX_BLOCK_FURNACE) {
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
+        }
+
+        if (target_block == CRAFTAX_BLOCK_CRAFTING_TABLE) {
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
+        }
+
+        bool is_mining_coal = target_block == CRAFTAX_BLOCK_COAL
+            && state->inventory.pickaxe >= 1;
+        if (is_mining_coal) {
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
+            state->inventory.coal += 1;
+        }
+
+        bool is_mining_iron = target_block == CRAFTAX_BLOCK_IRON
+            && state->inventory.pickaxe >= 2;
+        if (is_mining_iron) {
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
+            state->inventory.iron += 1;
+        }
+
+        bool is_mining_diamond = target_block == CRAFTAX_BLOCK_DIAMOND
+            && state->inventory.pickaxe >= 3;
+        if (is_mining_diamond) {
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
+            state->inventory.diamond += 1;
+        }
+
+        bool is_mining_sapphire = target_block == CRAFTAX_BLOCK_SAPPHIRE
+            && state->inventory.pickaxe >= 4;
+        if (is_mining_sapphire) {
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
+            state->inventory.sapphire += 1;
+        }
+
+        bool is_mining_ruby = target_block == CRAFTAX_BLOCK_RUBY
+            && state->inventory.pickaxe >= 4;
+        if (is_mining_ruby) {
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
+            state->inventory.ruby += 1;
+        }
+
+        bool is_mining_sapling = target_block == CRAFTAX_BLOCK_GRASS
+            && craftax_threefry_uniform_f32(sapling_key) < 0.1f;
+        state->inventory.sapling += (int32_t)is_mining_sapling;
+
+        bool is_drinking_water = target_block == CRAFTAX_BLOCK_WATER
+            || target_block == CRAFTAX_BLOCK_FOUNTAIN;
+        if (is_drinking_water) {
+            state->player_drink = craftax_step_mini32(
+                craftax_step_get_max_drink(state),
+                state->player_drink + 1
+            );
+            state->player_thirst = 0.0f;
+            state->achievements[CRAFTAX_ACH_COLLECT_DRINK] = true;
+        }
+
+        bool is_eating_plant = target_block == CRAFTAX_BLOCK_RIPE_PLANT;
+        if (is_eating_plant) {
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PLANT);
+            state->player_food = craftax_step_mini32(
+                craftax_step_get_max_food(state),
+                state->player_food + 4
+            );
+            state->player_hunger = 0.0f;
+            state->achievements[CRAFTAX_ACH_EAT_PLANT] = true;
+            craftax_do_action_update_plants_with_eat(
+                state,
+                target_row,
+                target_col
+            );
+        }
+
+        bool is_mining_stalagmite = target_block == CRAFTAX_BLOCK_STALAGMITE
+            && state->inventory.pickaxe >= 1;
+        if (is_mining_stalagmite) {
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
+            state->inventory.stone += 1;
+        }
+
+        if (is_opening_chest) {
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
+            craftax_add_items_from_chest_native(
+                state,
+                &state->inventory,
+                true,
+                chest_key
+            );
+            state->achievements[CRAFTAX_ACH_OPEN_CHEST] = true;
+        }
+
+        if (is_damaging_boss) {
+            state->achievements[CRAFTAX_ACH_DAMAGE_NECROMANCER] = true;
+        }
+    }
+
+    state->chests_opened[level] =
+        state->chests_opened[level] || is_opening_chest;
+
+    state->boss_progress += (int32_t)is_damaging_boss;
+    if (is_damaging_boss) {
+        state->boss_timesteps_to_spawn_this_round =
+            CRAFTAX_DO_ACTION_BOSS_FIGHT_SPAWN_TURNS;
+    }
+}

--- a/ocean/craftax_moonshot/step_medium.h
+++ b/ocean/craftax_moonshot/step_medium.h
@@ -1,0 +1,459 @@
+// Standalone native ports of medium Craftax step subsystems.
+//
+// These helpers intentionally are not integrated into c_step yet. They mutate a
+// full CraftaxState, or an Inventory plus read-only state context, so tests can
+// compare each subsystem directly against the installed JAX implementation.
+
+#pragma once
+
+#include "step_simple.h"
+
+static inline CraftaxThreefryKey craftax_medium_next_random_key(
+    CraftaxThreefryKey* rng
+) {
+    CraftaxThreefryKey draw;
+    craftax_threefry_split(*rng, rng, &draw);
+    return draw;
+}
+
+static inline int32_t craftax_medium_randint(
+    CraftaxThreefryKey key,
+    int32_t minval,
+    int32_t maxval
+) {
+    return craftax_randint_i32_at(key, 0u, minval, maxval);
+}
+
+static inline int32_t craftax_medium_choice_weighted(
+    CraftaxThreefryKey key,
+    const float* weights,
+    int32_t count
+) {
+    float total = 0.0f;
+    for (int32_t i = 0; i < count; i++) {
+        total += weights[i];
+    }
+
+    float draw = total * (1.0f - craftax_threefry_uniform_f32(key));
+    float cumulative = 0.0f;
+    for (int32_t i = 0; i < count; i++) {
+        cumulative += weights[i];
+        if (cumulative >= draw) {
+            return i;
+        }
+    }
+    return count - 1;
+}
+
+static inline int32_t craftax_medium_projectile_count(const CraftaxState* state) {
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    int32_t count = 0;
+    for (int32_t i = 0; i < CRAFTAX_MAX_PLAYER_PROJECTILES; i++) {
+        count += (int32_t)state->player_projectiles.mask[level][i];
+    }
+    return count;
+}
+
+static inline int32_t craftax_medium_first_projectile_slot(
+    const CraftaxState* state
+) {
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    for (int32_t i = 0; i < CRAFTAX_MAX_PLAYER_PROJECTILES; i++) {
+        if (!state->player_projectiles.mask[level][i]) {
+            return i;
+        }
+    }
+    return 0;
+}
+
+static inline void craftax_medium_spawn_player_projectile(
+    CraftaxState* state,
+    bool is_spawning_projectile,
+    const int32_t new_projectile_position[2],
+    const int32_t direction[2],
+    int32_t projectile_type
+) {
+    if (!is_spawning_projectile) {
+        return;
+    }
+
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    int32_t index = craftax_medium_first_projectile_slot(state);
+    state->player_projectiles.position[level][index][0] = new_projectile_position[0];
+    state->player_projectiles.position[level][index][1] = new_projectile_position[1];
+    state->player_projectiles.mask[level][index] = true;
+    state->player_projectiles.type_id[level][index] = projectile_type;
+    state->player_projectile_directions[level][index][0] = direction[0];
+    state->player_projectile_directions[level][index][1] = direction[1];
+}
+
+static inline int32_t craftax_medium_level_achievement(int32_t level) {
+    switch (craftax_step_jax_index(level, CRAFTAX_NUM_LEVELS)) {
+    case 1:
+        return CRAFTAX_ACH_ENTER_DUNGEON;
+    case 2:
+        return CRAFTAX_ACH_ENTER_GNOMISH_MINES;
+    case 3:
+        return CRAFTAX_ACH_ENTER_SEWERS;
+    case 4:
+        return CRAFTAX_ACH_ENTER_VAULT;
+    case 5:
+        return CRAFTAX_ACH_ENTER_TROLL_MINES;
+    case 6:
+        return CRAFTAX_ACH_ENTER_FIRE_REALM;
+    case 7:
+        return CRAFTAX_ACH_ENTER_ICE_REALM;
+    case 8:
+        return CRAFTAX_ACH_ENTER_GRAVEYARD;
+    default:
+        return CRAFTAX_ACH_COLLECT_WOOD;
+    }
+}
+
+static inline void craftax_shoot_projectile_native(
+    CraftaxState* state,
+    int32_t action
+) {
+    bool is_shooting_arrow = action == CRAFTAX_ACTION_SHOOT_ARROW
+        && state->inventory.bow >= 1
+        && state->inventory.arrows >= 1
+        && craftax_medium_projectile_count(state) < CRAFTAX_MAX_PLAYER_PROJECTILES;
+
+    int32_t direction[2];
+    craftax_step_direction(state->player_direction, direction);
+    craftax_medium_spawn_player_projectile(
+        state,
+        is_shooting_arrow,
+        state->player_position,
+        direction,
+        CRAFTAX_PROJECTILE_ARROW2
+    );
+
+    state->achievements[CRAFTAX_ACH_FIRE_BOW] =
+        state->achievements[CRAFTAX_ACH_FIRE_BOW] || is_shooting_arrow;
+    state->inventory.arrows -= (int32_t)is_shooting_arrow;
+}
+
+static inline void craftax_cast_spell_native(
+    CraftaxState* state,
+    int32_t action
+) {
+    bool has_projectile_slot =
+        craftax_medium_projectile_count(state) < CRAFTAX_MAX_PLAYER_PROJECTILES;
+    bool has_mana = state->player_mana >= 2;
+    bool is_casting_fireball = action == CRAFTAX_ACTION_CAST_FIREBALL
+        && has_mana
+        && has_projectile_slot
+        && state->learned_spells[0];
+    bool is_casting_iceball = action == CRAFTAX_ACTION_CAST_ICEBALL
+        && has_mana
+        && has_projectile_slot
+        && state->learned_spells[1];
+    bool is_casting_spell = is_casting_fireball || is_casting_iceball;
+
+    int32_t projectile_type =
+        (int32_t)is_casting_fireball * CRAFTAX_PROJECTILE_FIREBALL
+        + (int32_t)is_casting_iceball * CRAFTAX_PROJECTILE_ICEBALL;
+
+    int32_t direction[2];
+    craftax_step_direction(state->player_direction, direction);
+    craftax_medium_spawn_player_projectile(
+        state,
+        is_casting_spell,
+        state->player_position,
+        direction,
+        projectile_type
+    );
+
+    if (is_casting_fireball) {
+        state->achievements[CRAFTAX_ACH_CAST_FIREBALL] = true;
+    }
+    if (is_casting_iceball) {
+        state->achievements[CRAFTAX_ACH_CAST_ICEBALL] = true;
+    }
+    state->player_mana -= (int32_t)is_casting_spell * 2;
+}
+
+static inline void craftax_enchant_native(
+    CraftaxState* state,
+    int32_t action,
+    CraftaxThreefryKey rng
+) {
+    int32_t direction[2];
+    craftax_step_direction(state->player_direction, direction);
+
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    int32_t target_row = craftax_step_jax_index(
+        state->player_position[0] + direction[0],
+        CRAFTAX_MAP_SIZE
+    );
+    int32_t target_col = craftax_step_jax_index(
+        state->player_position[1] + direction[1],
+        CRAFTAX_MAP_SIZE
+    );
+    int32_t target_block = state->map[level][target_row][target_col];
+
+    bool is_fire_table = target_block == CRAFTAX_BLOCK_ENCHANTMENT_TABLE_FIRE;
+    bool is_ice_table = target_block == CRAFTAX_BLOCK_ENCHANTMENT_TABLE_ICE;
+    bool target_block_is_enchantment_table = is_fire_table || is_ice_table;
+    int32_t enchantment_type = is_fire_table ? 1 : 2;
+    int32_t num_gems = is_fire_table
+        ? state->inventory.ruby
+        : state->inventory.sapphire;
+
+    bool could_enchant = state->player_mana >= 9
+        && target_block_is_enchantment_table
+        && num_gems >= 1;
+    bool is_enchanting_bow = could_enchant
+        && action == CRAFTAX_ACTION_ENCHANT_BOW
+        && state->inventory.bow > 0;
+    bool is_enchanting_sword = could_enchant
+        && action == CRAFTAX_ACTION_ENCHANT_SWORD
+        && state->inventory.sword > 0;
+
+    int32_t armour_count = 0;
+    for (int32_t i = 0; i < 4; i++) {
+        armour_count += state->inventory.armour[i];
+    }
+    bool is_enchanting_armour = could_enchant
+        && action == CRAFTAX_ACTION_ENCHANT_ARMOUR
+        && armour_count > 0;
+
+    CraftaxThreefryKey armour_key = craftax_medium_next_random_key(&rng);
+    int32_t unenchanted_count = 0;
+    for (int32_t i = 0; i < 4; i++) {
+        unenchanted_count += (int32_t)(state->armour_enchantments[i] == 0);
+    }
+
+    float armour_targets[4];
+    for (int32_t i = 0; i < 4; i++) {
+        bool unenchanted = state->armour_enchantments[i] == 0;
+        bool opposite_enchanted = state->armour_enchantments[i] != 0
+            && state->armour_enchantments[i] != enchantment_type;
+        armour_targets[i] = (unenchanted || (
+            unenchanted_count == 0 && opposite_enchanted
+        )) ? 1.0f : 0.0f;
+    }
+    int32_t armour_target = craftax_medium_choice_weighted(
+        armour_key,
+        armour_targets,
+        4
+    );
+
+    bool is_enchanting = is_enchanting_sword
+        || is_enchanting_bow
+        || is_enchanting_armour;
+    if (is_enchanting_sword) {
+        state->sword_enchantment = enchantment_type;
+        state->achievements[CRAFTAX_ACH_ENCHANT_SWORD] = true;
+    }
+    if (is_enchanting_bow) {
+        state->bow_enchantment = enchantment_type;
+    }
+    if (is_enchanting_armour) {
+        state->armour_enchantments[armour_target] = enchantment_type;
+        state->achievements[CRAFTAX_ACH_ENCHANT_ARMOUR] = true;
+    }
+
+    state->inventory.sapphire -=
+        (int32_t)is_enchanting * (int32_t)(enchantment_type == 2);
+    state->inventory.ruby -=
+        (int32_t)is_enchanting * (int32_t)(enchantment_type == 1);
+    state->player_mana -= (int32_t)is_enchanting * 9;
+}
+
+static inline void craftax_change_floor_native(
+    CraftaxState* state,
+    int32_t action
+) {
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    int32_t player_row = craftax_step_jax_index(
+        state->player_position[0],
+        CRAFTAX_MAP_SIZE
+    );
+    int32_t player_col = craftax_step_jax_index(
+        state->player_position[1],
+        CRAFTAX_MAP_SIZE
+    );
+
+    bool on_down_ladder =
+        state->item_map[level][player_row][player_col] == CRAFTAX_ITEM_LADDER_DOWN;
+    bool is_moving_down = action == CRAFTAX_ACTION_DESCEND
+        && on_down_ladder
+        && state->monsters_killed[level] >= CRAFTAX_MONSTERS_KILLED_TO_CLEAR_LEVEL
+        && state->player_level < CRAFTAX_NUM_LEVELS - 1;
+
+    bool on_up_ladder =
+        state->item_map[level][player_row][player_col] == CRAFTAX_ITEM_LADDER_UP;
+    bool is_moving_up = action == CRAFTAX_ACTION_ASCEND
+        && on_up_ladder
+        && state->player_level > 0;
+
+    int32_t delta_floor = (int32_t)is_moving_down - (int32_t)is_moving_up;
+    int32_t new_level = state->player_level + delta_floor;
+    int32_t achievement = craftax_medium_level_achievement(new_level);
+    bool new_floor = new_level != 0 && !state->achievements[achievement];
+
+    if (is_moving_down) {
+        int32_t ladder_level = craftax_step_jax_index(
+            state->player_level + 1,
+            CRAFTAX_NUM_LEVELS
+        );
+        state->player_position[0] = state->up_ladders[ladder_level][0];
+        state->player_position[1] = state->up_ladders[ladder_level][1];
+    } else if (is_moving_up) {
+        int32_t ladder_level = craftax_step_jax_index(
+            state->player_level - 1,
+            CRAFTAX_NUM_LEVELS
+        );
+        state->player_position[0] = state->down_ladders[ladder_level][0];
+        state->player_position[1] = state->down_ladders[ladder_level][1];
+    }
+
+    state->player_level = new_level;
+    state->achievements[achievement] =
+        state->achievements[achievement] || new_level != 0;
+    state->player_xp += (int32_t)new_floor;
+}
+
+static inline void craftax_add_items_from_chest_native(
+    const CraftaxState* state,
+    CraftaxInventory* inventory,
+    bool is_opening_chest,
+    CraftaxThreefryKey rng
+) {
+    CraftaxThreefryKey draw_key;
+
+    draw_key = craftax_medium_next_random_key(&rng);
+    bool is_looting_wood = craftax_threefry_uniform_f32(draw_key) < 0.6f;
+    draw_key = craftax_medium_next_random_key(&rng);
+    int32_t wood_loot_amount =
+        craftax_medium_randint(draw_key, 1, 6) * (int32_t)is_looting_wood;
+    (void)wood_loot_amount;
+
+    draw_key = craftax_medium_next_random_key(&rng);
+    bool is_looting_torch = craftax_threefry_uniform_f32(draw_key) < 0.6f;
+    draw_key = craftax_medium_next_random_key(&rng);
+    int32_t torch_loot_amount =
+        craftax_medium_randint(draw_key, 4, 8) * (int32_t)is_looting_torch;
+
+    draw_key = craftax_medium_next_random_key(&rng);
+    bool is_looting_ore = craftax_threefry_uniform_f32(draw_key) < 0.6f;
+    draw_key = craftax_medium_next_random_key(&rng);
+    float ore_weights[5] = {0.3f, 0.3f, 0.15f, 0.125f, 0.125f};
+    int32_t ore_loot_id = craftax_medium_choice_weighted(
+        draw_key,
+        ore_weights,
+        5
+    );
+    draw_key = craftax_medium_next_random_key(&rng);
+
+    int32_t coal_loot_amount =
+        craftax_medium_randint(draw_key, 1, 4)
+        * (int32_t)(ore_loot_id == 0)
+        * (int32_t)is_looting_ore;
+    int32_t iron_loot_amount =
+        craftax_medium_randint(draw_key, 1, 3)
+        * (int32_t)(ore_loot_id == 1)
+        * (int32_t)is_looting_ore;
+    int32_t diamond_loot_amount =
+        craftax_medium_randint(draw_key, 1, 2)
+        * (int32_t)(ore_loot_id == 2)
+        * (int32_t)is_looting_ore;
+    int32_t sapphire_loot_amount =
+        craftax_medium_randint(draw_key, 1, 2)
+        * (int32_t)(ore_loot_id == 3)
+        * (int32_t)is_looting_ore;
+    int32_t ruby_loot_amount =
+        craftax_medium_randint(draw_key, 1, 2)
+        * (int32_t)(ore_loot_id == 4)
+        * (int32_t)is_looting_ore;
+
+    draw_key = craftax_medium_next_random_key(&rng);
+    bool is_looting_potion = craftax_threefry_uniform_f32(draw_key) < 0.5f;
+    draw_key = craftax_medium_next_random_key(&rng);
+    int32_t potion_loot_index = craftax_medium_randint(draw_key, 0, 6);
+    draw_key = craftax_medium_next_random_key(&rng);
+    int32_t potion_loot_amount = craftax_medium_randint(draw_key, 1, 3);
+
+    draw_key = craftax_medium_next_random_key(&rng);
+    bool is_looting_arrows = craftax_threefry_uniform_f32(draw_key) < 0.25f;
+    draw_key = craftax_medium_next_random_key(&rng);
+    int32_t arrows_loot_amount =
+        craftax_medium_randint(draw_key, 1, 5) * (int32_t)is_looting_arrows;
+
+    draw_key = craftax_medium_next_random_key(&rng);
+    bool is_looting_tool = craftax_threefry_uniform_f32(draw_key) < 0.2f;
+    draw_key = craftax_medium_next_random_key(&rng);
+    int32_t tool_id = craftax_medium_randint(draw_key, 0, 2);
+
+    bool is_looting_pickaxe = is_looting_tool
+        && tool_id == 0
+        && is_opening_chest;
+    draw_key = craftax_medium_next_random_key(&rng);
+    float tool_weights[4] = {0.4f, 0.3f, 0.2f, 0.1f};
+    int32_t pickaxe_loot_level = (
+        craftax_medium_choice_weighted(draw_key, tool_weights, 4) + 1
+    ) * (int32_t)is_looting_pickaxe;
+    pickaxe_loot_level = craftax_step_maxi32(
+        pickaxe_loot_level,
+        inventory->pickaxe
+    );
+    int32_t new_pickaxe_level = is_looting_pickaxe
+        ? pickaxe_loot_level
+        : inventory->pickaxe;
+
+    bool is_looting_sword = is_looting_tool
+        && tool_id == 1
+        && is_opening_chest;
+    draw_key = craftax_medium_next_random_key(&rng);
+    int32_t sword_loot_level = (
+        craftax_medium_choice_weighted(draw_key, tool_weights, 4) + 1
+    ) * (int32_t)is_looting_sword;
+    sword_loot_level = craftax_step_maxi32(sword_loot_level, inventory->sword);
+    int32_t new_sword_level = is_looting_sword
+        ? sword_loot_level
+        : inventory->sword;
+
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    bool is_looting_bow = is_opening_chest
+        && state->player_level == 1
+        && !state->chests_opened[level];
+    int32_t new_bow_level = is_looting_bow ? 1 : inventory->bow;
+
+    bool is_looting_book = !state->chests_opened[level]
+        && (state->player_level == 3 || state->player_level == 4);
+
+    int32_t opening = (int32_t)is_opening_chest;
+    inventory->torches += torch_loot_amount * opening;
+    inventory->coal += coal_loot_amount * opening;
+    inventory->iron += iron_loot_amount * opening;
+    inventory->diamond += diamond_loot_amount * opening;
+    inventory->sapphire += sapphire_loot_amount * opening;
+    inventory->ruby += ruby_loot_amount * opening;
+    inventory->arrows += arrows_loot_amount * opening;
+    inventory->pickaxe = new_pickaxe_level;
+    inventory->sword = new_sword_level;
+    inventory->potions[potion_loot_index] +=
+        potion_loot_amount * (int32_t)is_looting_potion * opening;
+    inventory->bow = new_bow_level;
+    inventory->books += (int32_t)is_looting_book * opening;
+}

--- a/ocean/craftax_moonshot/step_simple.h
+++ b/ocean/craftax_moonshot/step_simple.h
@@ -1,0 +1,556 @@
+// Standalone native ports of simple Craftax step subsystems.
+//
+// These helpers intentionally are not integrated into c_step yet. They mutate a
+// full CraftaxState in place so tests can compare each subsystem directly
+// against the installed JAX implementation.
+
+#pragma once
+
+#include "craftax.h"
+
+static inline int32_t craftax_step_jax_index(int32_t index, int32_t size) {
+    if (index < 0) {
+        index += size;
+    }
+    if (index < 0) {
+        return 0;
+    }
+    if (index >= size) {
+        return size - 1;
+    }
+    return index;
+}
+
+static inline int32_t craftax_step_mini32(int32_t a, int32_t b) {
+    return a < b ? a : b;
+}
+
+static inline int32_t craftax_step_maxi32(int32_t a, int32_t b) {
+    return a > b ? a : b;
+}
+
+static inline float craftax_step_minf32(float a, float b) {
+    if (isnan(a) || isnan(b)) {
+        return NAN;
+    }
+    return a < b ? a : b;
+}
+
+static inline float craftax_step_maxf32(float a, float b) {
+    if (isnan(a) || isnan(b)) {
+        return NAN;
+    }
+    return a > b ? a : b;
+}
+
+static inline int32_t craftax_step_get_max_health(const CraftaxState* state) {
+    return 8 + state->player_strength;
+}
+
+static inline int32_t craftax_step_get_max_food(const CraftaxState* state) {
+    return 7 + 2 * state->player_dexterity;
+}
+
+static inline int32_t craftax_step_get_max_drink(const CraftaxState* state) {
+    return 7 + 2 * state->player_dexterity;
+}
+
+static inline int32_t craftax_step_get_max_energy(const CraftaxState* state) {
+    return 7 + 2 * state->player_dexterity;
+}
+
+static inline int32_t craftax_step_get_max_mana(const CraftaxState* state) {
+    return 6 + 3 * state->player_intelligence;
+}
+
+static inline bool craftax_step_is_fighting_boss(const CraftaxState* state) {
+    return state->player_level == CRAFTAX_NUM_LEVELS - 1;
+}
+
+static inline bool craftax_step_has_beaten_boss(const CraftaxState* state) {
+    return state->boss_progress >= CRAFTAX_NUM_LEVELS - 1;
+}
+
+static inline void craftax_step_direction(int32_t action, int32_t direction[2]) {
+    direction[0] = 0;
+    direction[1] = 0;
+    int32_t direction_index = craftax_step_jax_index(action, 16);
+    if (direction_index == CRAFTAX_ACTION_LEFT) {
+        direction[1] = -1;
+    } else if (direction_index == CRAFTAX_ACTION_RIGHT) {
+        direction[1] = 1;
+    } else if (direction_index == CRAFTAX_ACTION_UP) {
+        direction[0] = -1;
+    } else if (direction_index == CRAFTAX_ACTION_DOWN) {
+        direction[0] = 1;
+    }
+}
+
+static inline bool craftax_step_is_solid_block(int32_t block) {
+    switch (block) {
+    case CRAFTAX_BLOCK_STONE:
+    case CRAFTAX_BLOCK_TREE:
+    case CRAFTAX_BLOCK_COAL:
+    case CRAFTAX_BLOCK_IRON:
+    case CRAFTAX_BLOCK_DIAMOND:
+    case CRAFTAX_BLOCK_CRAFTING_TABLE:
+    case CRAFTAX_BLOCK_FURNACE:
+    case CRAFTAX_BLOCK_PLANT:
+    case CRAFTAX_BLOCK_RIPE_PLANT:
+    case CRAFTAX_BLOCK_WALL:
+    case CRAFTAX_BLOCK_WALL_MOSS:
+    case CRAFTAX_BLOCK_STALAGMITE:
+    case CRAFTAX_BLOCK_RUBY:
+    case CRAFTAX_BLOCK_SAPPHIRE:
+    case CRAFTAX_BLOCK_CHEST:
+    case CRAFTAX_BLOCK_FOUNTAIN:
+    case CRAFTAX_BLOCK_FIRE_TREE:
+    case CRAFTAX_BLOCK_ENCHANTMENT_TABLE_FIRE:
+    case CRAFTAX_BLOCK_ENCHANTMENT_TABLE_ICE:
+    case CRAFTAX_BLOCK_GRAVE:
+    case CRAFTAX_BLOCK_GRAVE2:
+    case CRAFTAX_BLOCK_GRAVE3:
+    case CRAFTAX_BLOCK_NECROMANCER:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static inline bool craftax_step_is_in_mob(
+    const CraftaxState* state,
+    int32_t row,
+    int32_t col
+) {
+    int32_t level = craftax_step_jax_index(state->player_level, CRAFTAX_NUM_LEVELS);
+    int32_t map_row = craftax_step_jax_index(row, CRAFTAX_MAP_SIZE);
+    int32_t map_col = craftax_step_jax_index(col, CRAFTAX_MAP_SIZE);
+    bool player_here = state->player_position[0] == row
+        && state->player_position[1] == col;
+    return ((state->mob_bits[level][map_row] >> map_col) & 1ULL) || player_here;
+}
+
+static inline bool craftax_step_valid_land_position(
+    const CraftaxState* state,
+    int32_t row,
+    int32_t col
+) {
+    bool pos_in_bounds = row >= 0
+        && row < CRAFTAX_MAP_SIZE
+        && col >= 0
+        && col < CRAFTAX_MAP_SIZE;
+    int32_t level = craftax_step_jax_index(state->player_level, CRAFTAX_NUM_LEVELS);
+    int32_t map_row = craftax_step_jax_index(row, CRAFTAX_MAP_SIZE);
+    int32_t map_col = craftax_step_jax_index(col, CRAFTAX_MAP_SIZE);
+    int32_t block = state->map[level][map_row][map_col];
+    bool in_solid_block = craftax_step_is_solid_block(block);
+    bool in_mob = craftax_step_is_in_mob(state, row, col);
+    bool in_lava = block == CRAFTAX_BLOCK_LAVA;
+    bool in_water = block == CRAFTAX_BLOCK_WATER;
+
+    bool valid_move = pos_in_bounds && !in_mob && !in_solid_block;
+    valid_move = valid_move && !in_water;
+    valid_move = valid_move && !in_lava;
+    return valid_move;
+}
+
+static inline void craftax_move_player_native(
+    CraftaxState* state,
+    int32_t action,
+    bool god_mode
+) {
+    int32_t direction[2];
+    craftax_step_direction(action, direction);
+
+    int32_t proposed_row = state->player_position[0] + direction[0];
+    int32_t proposed_col = state->player_position[1] + direction[1];
+    bool valid_move = craftax_step_valid_land_position(
+        state,
+        proposed_row,
+        proposed_col
+    );
+    valid_move = valid_move || god_mode;
+
+    state->player_position[0] += (int32_t)valid_move * direction[0];
+    state->player_position[1] += (int32_t)valid_move * direction[1];
+
+    bool is_new_direction = direction[0] != 0 || direction[1] != 0;
+    state->player_direction = state->player_direction * (1 - (int32_t)is_new_direction)
+        + action * (int32_t)is_new_direction;
+}
+
+static inline void craftax_update_plants_native(CraftaxState* state) {
+    bool finished_growing_plants[CRAFTAX_MAX_GROWING_PLANTS];
+
+    for (int plant = 0; plant < CRAFTAX_MAX_GROWING_PLANTS; plant++) {
+        state->growing_plants_age[plant] =
+            (state->growing_plants_age[plant] + 1)
+            * (int32_t)state->growing_plants_mask[plant];
+        finished_growing_plants[plant] = state->growing_plants_age[plant] >= 600;
+    }
+
+    for (int plant = 0; plant < CRAFTAX_MAX_GROWING_PLANTS; plant++) {
+        int32_t row = craftax_step_jax_index(
+            state->growing_plants_positions[plant][0],
+            CRAFTAX_MAP_SIZE
+        );
+        int32_t col = craftax_step_jax_index(
+            state->growing_plants_positions[plant][1],
+            CRAFTAX_MAP_SIZE
+        );
+        int32_t new_block = finished_growing_plants[plant]
+            ? CRAFTAX_BLOCK_RIPE_PLANT
+            : state->map[0][row][col];
+        craftax_set_map_block(state, 0, row, col, new_block);
+    }
+}
+
+static inline void craftax_boss_logic_native(CraftaxState* state) {
+    state->achievements[CRAFTAX_ACH_DEFEAT_NECROMANCER] =
+        state->achievements[CRAFTAX_ACH_DEFEAT_NECROMANCER]
+        || craftax_step_has_beaten_boss(state);
+    state->boss_timesteps_to_spawn_this_round -=
+        (int32_t)craftax_step_is_fighting_boss(state);
+}
+
+static inline void craftax_level_up_attributes_native(
+    CraftaxState* state,
+    int32_t action,
+    int32_t max_attribute
+) {
+    bool can_level_up = state->player_xp >= 1;
+    bool is_levelling_up_dex = can_level_up
+        && action == CRAFTAX_ACTION_LEVEL_UP_DEXTERITY
+        && state->player_dexterity < max_attribute;
+    bool is_levelling_up_str = can_level_up
+        && action == CRAFTAX_ACTION_LEVEL_UP_STRENGTH
+        && state->player_strength < max_attribute;
+    bool is_levelling_up_int = can_level_up
+        && action == CRAFTAX_ACTION_LEVEL_UP_INTELLIGENCE
+        && state->player_intelligence < max_attribute;
+    bool is_levelling_up = is_levelling_up_dex
+        || is_levelling_up_str
+        || is_levelling_up_int;
+
+    state->player_dexterity += (int32_t)is_levelling_up_dex;
+    state->player_strength += (int32_t)is_levelling_up_str;
+    state->player_intelligence += (int32_t)is_levelling_up_int;
+    state->player_xp -= (int32_t)is_levelling_up;
+}
+
+static inline void craftax_clip_inventory_and_intrinsics_native(
+    CraftaxState* state,
+    bool god_mode
+) {
+    state->inventory.wood = craftax_step_mini32(state->inventory.wood, 99);
+    state->inventory.stone = craftax_step_mini32(state->inventory.stone, 99);
+    state->inventory.coal = craftax_step_mini32(state->inventory.coal, 99);
+    state->inventory.iron = craftax_step_mini32(state->inventory.iron, 99);
+    state->inventory.diamond = craftax_step_mini32(state->inventory.diamond, 99);
+    state->inventory.sapling = craftax_step_mini32(state->inventory.sapling, 99);
+    state->inventory.pickaxe = craftax_step_mini32(state->inventory.pickaxe, 99);
+    state->inventory.sword = craftax_step_mini32(state->inventory.sword, 99);
+    state->inventory.bow = craftax_step_mini32(state->inventory.bow, 99);
+    state->inventory.arrows = craftax_step_mini32(state->inventory.arrows, 99);
+    for (int i = 0; i < 4; i++) {
+        state->inventory.armour[i] = craftax_step_mini32(
+            state->inventory.armour[i],
+            99
+        );
+    }
+    state->inventory.torches = craftax_step_mini32(state->inventory.torches, 99);
+    state->inventory.ruby = craftax_step_mini32(state->inventory.ruby, 99);
+    state->inventory.sapphire = craftax_step_mini32(state->inventory.sapphire, 99);
+    for (int i = 0; i < 6; i++) {
+        state->inventory.potions[i] = craftax_step_mini32(
+            state->inventory.potions[i],
+            99
+        );
+    }
+    state->inventory.books = craftax_step_mini32(state->inventory.books, 99);
+
+    float min_health = god_mode ? 9.0f : 0.0f;
+    state->player_health = craftax_step_minf32(
+        craftax_step_maxf32(state->player_health, min_health),
+        (float)craftax_step_get_max_health(state)
+    );
+    state->player_food = craftax_step_mini32(
+        craftax_step_maxi32(state->player_food, 0),
+        craftax_step_get_max_food(state)
+    );
+    state->player_drink = craftax_step_mini32(
+        craftax_step_maxi32(state->player_drink, 0),
+        craftax_step_get_max_drink(state)
+    );
+    state->player_energy = craftax_step_mini32(
+        craftax_step_maxi32(state->player_energy, 0),
+        craftax_step_get_max_energy(state)
+    );
+    state->player_mana = craftax_step_mini32(
+        craftax_step_maxi32(state->player_mana, 0),
+        craftax_step_get_max_mana(state)
+    );
+}
+
+static inline void craftax_calculate_inventory_achievements_native(
+    CraftaxState* state
+) {
+    state->achievements[CRAFTAX_ACH_COLLECT_WOOD] =
+        state->achievements[CRAFTAX_ACH_COLLECT_WOOD] || state->inventory.wood > 0;
+    state->achievements[CRAFTAX_ACH_COLLECT_STONE] =
+        state->achievements[CRAFTAX_ACH_COLLECT_STONE] || state->inventory.stone > 0;
+    state->achievements[CRAFTAX_ACH_COLLECT_COAL] =
+        state->achievements[CRAFTAX_ACH_COLLECT_COAL] || state->inventory.coal > 0;
+    state->achievements[CRAFTAX_ACH_COLLECT_IRON] =
+        state->achievements[CRAFTAX_ACH_COLLECT_IRON] || state->inventory.iron > 0;
+    state->achievements[CRAFTAX_ACH_COLLECT_DIAMOND] =
+        state->achievements[CRAFTAX_ACH_COLLECT_DIAMOND] || state->inventory.diamond > 0;
+    state->achievements[CRAFTAX_ACH_COLLECT_RUBY] =
+        state->achievements[CRAFTAX_ACH_COLLECT_RUBY] || state->inventory.ruby > 0;
+    state->achievements[CRAFTAX_ACH_COLLECT_SAPPHIRE] =
+        state->achievements[CRAFTAX_ACH_COLLECT_SAPPHIRE]
+        || state->inventory.sapphire > 0;
+    state->achievements[CRAFTAX_ACH_COLLECT_SAPLING] =
+        state->achievements[CRAFTAX_ACH_COLLECT_SAPLING]
+        || state->inventory.sapling > 0;
+    state->achievements[CRAFTAX_ACH_FIND_BOW] =
+        state->achievements[CRAFTAX_ACH_FIND_BOW] || state->inventory.bow > 0;
+    state->achievements[CRAFTAX_ACH_MAKE_ARROW] =
+        state->achievements[CRAFTAX_ACH_MAKE_ARROW] || state->inventory.arrows > 0;
+    state->achievements[CRAFTAX_ACH_MAKE_TORCH] =
+        state->achievements[CRAFTAX_ACH_MAKE_TORCH] || state->inventory.torches > 0;
+
+    state->achievements[CRAFTAX_ACH_MAKE_WOOD_PICKAXE] =
+        state->achievements[CRAFTAX_ACH_MAKE_WOOD_PICKAXE]
+        || state->inventory.pickaxe >= 1;
+    state->achievements[CRAFTAX_ACH_MAKE_STONE_PICKAXE] =
+        state->achievements[CRAFTAX_ACH_MAKE_STONE_PICKAXE]
+        || state->inventory.pickaxe >= 2;
+    state->achievements[CRAFTAX_ACH_MAKE_IRON_PICKAXE] =
+        state->achievements[CRAFTAX_ACH_MAKE_IRON_PICKAXE]
+        || state->inventory.pickaxe >= 3;
+    state->achievements[CRAFTAX_ACH_MAKE_DIAMOND_PICKAXE] =
+        state->achievements[CRAFTAX_ACH_MAKE_DIAMOND_PICKAXE]
+        || state->inventory.pickaxe >= 4;
+
+    state->achievements[CRAFTAX_ACH_MAKE_WOOD_SWORD] =
+        state->achievements[CRAFTAX_ACH_MAKE_WOOD_SWORD]
+        || state->inventory.sword >= 1;
+    state->achievements[CRAFTAX_ACH_MAKE_STONE_SWORD] =
+        state->achievements[CRAFTAX_ACH_MAKE_STONE_SWORD]
+        || state->inventory.sword >= 2;
+    state->achievements[CRAFTAX_ACH_MAKE_IRON_SWORD] =
+        state->achievements[CRAFTAX_ACH_MAKE_IRON_SWORD]
+        || state->inventory.sword >= 3;
+    state->achievements[CRAFTAX_ACH_MAKE_DIAMOND_SWORD] =
+        state->achievements[CRAFTAX_ACH_MAKE_DIAMOND_SWORD]
+        || state->inventory.sword >= 4;
+}
+
+static inline void craftax_update_player_intrinsics_native(
+    CraftaxState* state,
+    int32_t action
+) {
+    bool is_starting_sleep = action == CRAFTAX_ACTION_SLEEP
+        && state->player_energy < craftax_step_get_max_energy(state);
+    state->is_sleeping = state->is_sleeping || is_starting_sleep;
+
+    bool is_waking_up = state->player_energy >= craftax_step_get_max_energy(state)
+        && state->is_sleeping;
+    state->is_sleeping = state->is_sleeping && !is_waking_up;
+    state->achievements[CRAFTAX_ACH_WAKE_UP] =
+        state->achievements[CRAFTAX_ACH_WAKE_UP] || is_waking_up;
+
+    bool is_starting_rest = action == CRAFTAX_ACTION_REST
+        && state->player_health < (float)craftax_step_get_max_health(state);
+    state->is_resting = state->is_resting || is_starting_rest;
+
+    is_waking_up = state->is_resting
+        && (
+            state->player_health >= (float)craftax_step_get_max_health(state)
+            || state->player_food <= 0
+            || state->player_drink <= 0
+        );
+    state->is_resting = state->is_resting && !is_waking_up;
+
+    bool not_boss = !craftax_step_is_fighting_boss(state);
+    float intrinsic_decay_coeff =
+        1.0f - (0.125f * (float)(state->player_dexterity - 1));
+
+    float hunger_add = (state->is_sleeping ? 0.5f : 1.0f) * intrinsic_decay_coeff;
+    float new_hunger = state->player_hunger + hunger_add;
+    int32_t hungered_food = craftax_step_maxi32(
+        state->player_food - (int32_t)not_boss,
+        0
+    );
+    int32_t new_food = new_hunger > 25.0f ? hungered_food : state->player_food;
+    new_hunger = new_hunger > 25.0f ? 0.0f : new_hunger;
+    state->player_hunger = new_hunger;
+    state->player_food = new_food;
+
+    float thirst_add = (state->is_sleeping ? 0.5f : 1.0f) * intrinsic_decay_coeff;
+    float new_thirst = state->player_thirst + thirst_add;
+    int32_t thirsted_drink = craftax_step_maxi32(
+        state->player_drink - (int32_t)not_boss,
+        0
+    );
+    int32_t new_drink = new_thirst > 20.0f ? thirsted_drink : state->player_drink;
+    new_thirst = new_thirst > 20.0f ? 0.0f : new_thirst;
+    state->player_thirst = new_thirst;
+    state->player_drink = new_drink;
+
+    float new_fatigue = state->is_sleeping
+        ? craftax_step_minf32(state->player_fatigue - 1.0f, 0.0f)
+        : state->player_fatigue + intrinsic_decay_coeff;
+    int32_t new_energy = new_fatigue > 30.0f
+        ? craftax_step_maxi32(state->player_energy - (int32_t)not_boss, 0)
+        : state->player_energy;
+    new_fatigue = new_fatigue > 30.0f ? 0.0f : new_fatigue;
+    new_energy = new_fatigue < -10.0f
+        ? craftax_step_mini32(
+            state->player_energy + 1,
+            craftax_step_get_max_energy(state)
+        )
+        : new_energy;
+    new_fatigue = new_fatigue < -10.0f ? 0.0f : new_fatigue;
+    state->player_fatigue = new_fatigue;
+    state->player_energy = new_energy;
+
+    bool all_necessities = state->player_food > 0
+        && state->player_drink > 0
+        && (state->player_energy > 0 || state->is_sleeping);
+    float recover_all = state->is_sleeping ? 2.0f : 1.0f;
+    float recover_not_all = (state->is_sleeping ? -0.5f : -1.0f)
+        * (float)(int32_t)not_boss;
+    float recover_add = all_necessities ? recover_all : recover_not_all;
+    float new_recover = state->player_recover + recover_add;
+
+    float recovered_health = craftax_step_minf32(
+        state->player_health + 1.0f,
+        (float)craftax_step_get_max_health(state)
+    );
+    float derecovered_health = state->player_health - 1.0f;
+    float new_health = new_recover > 25.0f
+        ? recovered_health
+        : state->player_health;
+    new_recover = new_recover > 25.0f ? 0.0f : new_recover;
+    new_health = new_recover < -15.0f ? derecovered_health : new_health;
+    new_recover = new_recover < -15.0f ? 0.0f : new_recover;
+    state->player_recover = new_recover;
+    state->player_health = new_health;
+
+    float mana_recover_coeff =
+        1.0f + 0.25f * (float)(state->player_intelligence - 1);
+    float new_recover_mana = (
+        state->is_sleeping
+            ? state->player_recover_mana + 2.0f
+            : state->player_recover_mana + 1.0f
+    ) * mana_recover_coeff;
+    int32_t new_mana = new_recover_mana > 30.0f
+        ? state->player_mana + 1
+        : state->player_mana;
+    new_recover_mana = new_recover_mana > 30.0f ? 0.0f : new_recover_mana;
+    state->player_recover_mana = new_recover_mana;
+    state->player_mana = new_mana;
+}
+
+static inline void craftax_drink_potion_native(
+    CraftaxState* state,
+    int32_t action
+) {
+    int32_t drinking_potion_index = -1;
+    bool is_drinking_potion = false;
+
+    bool is_drinking_red_potion = action == CRAFTAX_ACTION_DRINK_POTION_RED
+        && state->inventory.potions[0] > 0;
+    drinking_potion_index = (int32_t)is_drinking_red_potion * 0
+        + (1 - (int32_t)is_drinking_red_potion) * drinking_potion_index;
+    is_drinking_potion = is_drinking_potion || is_drinking_red_potion;
+
+    bool is_drinking_green_potion = action == CRAFTAX_ACTION_DRINK_POTION_GREEN
+        && state->inventory.potions[1] > 0;
+    drinking_potion_index = (int32_t)is_drinking_green_potion * 1
+        + (1 - (int32_t)is_drinking_green_potion) * drinking_potion_index;
+    is_drinking_potion = is_drinking_potion || is_drinking_green_potion;
+
+    bool is_drinking_blue_potion = action == CRAFTAX_ACTION_DRINK_POTION_BLUE
+        && state->inventory.potions[2] > 0;
+    drinking_potion_index = (int32_t)is_drinking_blue_potion * 2
+        + (1 - (int32_t)is_drinking_blue_potion) * drinking_potion_index;
+    is_drinking_potion = is_drinking_potion || is_drinking_blue_potion;
+
+    bool is_drinking_pink_potion = action == CRAFTAX_ACTION_DRINK_POTION_PINK
+        && state->inventory.potions[3] > 0;
+    drinking_potion_index = (int32_t)is_drinking_pink_potion * 3
+        + (1 - (int32_t)is_drinking_pink_potion) * drinking_potion_index;
+    is_drinking_potion = is_drinking_potion || is_drinking_pink_potion;
+
+    bool is_drinking_cyan_potion = action == CRAFTAX_ACTION_DRINK_POTION_CYAN
+        && state->inventory.potions[4] > 0;
+    drinking_potion_index = (int32_t)is_drinking_cyan_potion * 4
+        + (1 - (int32_t)is_drinking_cyan_potion) * drinking_potion_index;
+    is_drinking_potion = is_drinking_potion || is_drinking_cyan_potion;
+
+    bool is_drinking_yellow_potion = action == CRAFTAX_ACTION_DRINK_POTION_YELLOW
+        && state->inventory.potions[5] > 0;
+    drinking_potion_index = (int32_t)is_drinking_yellow_potion * 5
+        + (1 - (int32_t)is_drinking_yellow_potion) * drinking_potion_index;
+    is_drinking_potion = is_drinking_potion || is_drinking_yellow_potion;
+
+    int32_t potion_index = craftax_step_jax_index(drinking_potion_index, 6);
+    int32_t potion_effect_index = state->potion_mapping[potion_index];
+
+    int32_t delta_health = 0;
+    delta_health += (int32_t)is_drinking_potion * (int32_t)(potion_effect_index == 0) * 8;
+    delta_health += (int32_t)is_drinking_potion * (int32_t)(potion_effect_index == 1) * -3;
+
+    int32_t delta_mana = 0;
+    delta_mana += (int32_t)is_drinking_potion * (int32_t)(potion_effect_index == 2) * 8;
+    delta_mana += (int32_t)is_drinking_potion * (int32_t)(potion_effect_index == 3) * -3;
+
+    int32_t delta_energy = 0;
+    delta_energy += (int32_t)is_drinking_potion * (int32_t)(potion_effect_index == 4) * 8;
+    delta_energy += (int32_t)is_drinking_potion * (int32_t)(potion_effect_index == 5) * -3;
+
+    state->achievements[CRAFTAX_ACH_DRINK_POTION] =
+        state->achievements[CRAFTAX_ACH_DRINK_POTION] || is_drinking_potion;
+    state->inventory.potions[potion_index] =
+        state->inventory.potions[potion_index] - (int32_t)is_drinking_potion;
+    state->player_health += (float)delta_health;
+    state->player_mana += delta_mana;
+    state->player_energy += delta_energy;
+}
+
+static inline void craftax_read_book_native(
+    CraftaxState* state,
+    const uint32_t rng_words[2],
+    int32_t action
+) {
+    bool is_reading_book = action == CRAFTAX_ACTION_READ_BOOK
+        && state->inventory.books > 0;
+
+    CraftaxThreefryKey rng = {{rng_words[0], rng_words[1]}};
+    CraftaxThreefryKey unused;
+    CraftaxThreefryKey choice_key;
+    craftax_threefry_split(rng, &unused, &choice_key);
+
+    float p0 = state->learned_spells[0] ? 0.0f : 1.0f;
+    float p1 = state->learned_spells[1] ? 0.0f : 1.0f;
+    float p_sum = p0 + p1;
+    int32_t spell_to_learn_index = 0;
+    if (p_sum != 0.0f) {
+        p0 /= p_sum;
+        float r = 1.0f - craftax_threefry_uniform_f32(choice_key);
+        spell_to_learn_index = r <= p0 ? 0 : 1;
+    }
+
+    int32_t learn_spell_achievement = spell_to_learn_index
+        ? CRAFTAX_ACH_LEARN_ICEBALL
+        : CRAFTAX_ACH_LEARN_FIREBALL;
+
+    state->achievements[learn_spell_achievement] =
+        state->achievements[learn_spell_achievement] || is_reading_book;
+    state->inventory.books -= (int32_t)is_reading_book;
+    state->learned_spells[spell_to_learn_index] =
+        state->learned_spells[spell_to_learn_index] || is_reading_book;
+}

--- a/ocean/craftax_moonshot/step_spawn_mobs.h
+++ b/ocean/craftax_moonshot/step_spawn_mobs.h
@@ -1,0 +1,846 @@
+// Craftax spawn_mobs, optimized for CPU.
+//
+// Bitwise-equivalent to the prior JAX-transliterated baseline (verified by
+// ocean/craftax_exp/parity_vs_baseline.c over 1.28M paired steps), ~6-9x
+// faster per step by stripping JAX-isms:
+//   - full-grid validity masks -> compact coord list collected in one pass
+//   - bounding-box scan (only cells within MOB_DESPAWN_DISTANCE)
+//   - early return on mob-cap / probability-roll failure (no dead writes)
+//   - merged count + first_empty loops
+//
+// The prior reference implementation is archived at
+// ocean/craftax_exp/step_spawn_mobs_baseline.h.
+
+#pragma once
+
+#include "step_medium.h"
+
+#define CRAFTAX_SPAWN_MAP_CELLS (CRAFTAX_MAP_SIZE * CRAFTAX_MAP_SIZE)
+#define CRAFTAX_SPAWN_BBOX_MAX_CELLS 729  // (2*DESPAWN-1)^2 at 14 = 27*27
+#define CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK ( \
+    (1ULL << CRAFTAX_BLOCK_GRASS) \
+    | (1ULL << CRAFTAX_BLOCK_PATH) \
+    | (1ULL << CRAFTAX_BLOCK_FIRE_GRASS) \
+    | (1ULL << CRAFTAX_BLOCK_ICE_GRASS))
+#define CRAFTAX_SPAWN_GRAVE_BLOCK_MASK ( \
+    (1ULL << CRAFTAX_BLOCK_GRAVE) \
+    | (1ULL << CRAFTAX_BLOCK_GRAVE2) \
+    | (1ULL << CRAFTAX_BLOCK_GRAVE3))
+#define CRAFTAX_SPAWN_WATER_BLOCK_MASK (1ULL << CRAFTAX_BLOCK_WATER)
+
+typedef struct { int8_t dr, dc0, dc1; } CraftaxSpawnOffsetSpan;
+
+static CraftaxSpawnOffsetSpan craftax_spawn_passive_spans[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+static CraftaxSpawnOffsetSpan craftax_spawn_hostile_spans[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+static CraftaxSpawnOffsetSpan craftax_spawn_boss_spans[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+static int32_t craftax_spawn_passive_span_count = 0;
+static int32_t craftax_spawn_hostile_span_count = 0;
+static int32_t craftax_spawn_boss_span_count = 0;
+static int32_t craftax_spawn_offsets_initialized = 0;
+
+static inline void craftax_spawn_append_span(
+    CraftaxSpawnOffsetSpan* spans,
+    int32_t* count,
+    int32_t dr,
+    int32_t dc0,
+    int32_t dc1
+) {
+    spans[*count] = (CraftaxSpawnOffsetSpan){
+        (int8_t)dr, (int8_t)dc0, (int8_t)dc1
+    };
+    *count += 1;
+}
+
+static inline void craftax_spawn_build_spans_for_row(
+    CraftaxSpawnOffsetSpan* spans,
+    int32_t* count,
+    int32_t dr,
+    int32_t limit,
+    int32_t min_exclusive,
+    int32_t max_exclusive
+) {
+    bool active = false;
+    int32_t start = 0;
+    for (int32_t dc = -limit; dc <= limit; dc++) {
+        int32_t distance2 = dr * dr + dc * dc;
+        bool valid = distance2 > min_exclusive && distance2 < max_exclusive;
+        if (valid && !active) {
+            active = true;
+            start = dc;
+        } else if (!valid && active) {
+            craftax_spawn_append_span(spans, count, dr, start, dc - 1);
+            active = false;
+        }
+    }
+    if (active) {
+        craftax_spawn_append_span(spans, count, dr, start, limit);
+    }
+}
+
+static inline void craftax_spawn_init_offsets_once(void) {
+    if (__atomic_load_n(
+            &craftax_spawn_offsets_initialized, __ATOMIC_ACQUIRE
+    )) return;
+
+    #pragma omp critical(craftax_spawn_offsets_init)
+    {
+        if (!__atomic_load_n(
+                &craftax_spawn_offsets_initialized, __ATOMIC_RELAXED
+        )) {
+            int32_t passive_count = 0;
+            int32_t hostile_count = 0;
+            int32_t boss_count = 0;
+            int32_t limit = CRAFTAX_MOB_DESPAWN_DISTANCE - 1;
+            int32_t limit2 = CRAFTAX_MOB_DESPAWN_DISTANCE
+                           * CRAFTAX_MOB_DESPAWN_DISTANCE;
+            for (int32_t dr = -limit; dr <= limit; dr++) {
+                craftax_spawn_build_spans_for_row(
+                    craftax_spawn_passive_spans,
+                    &passive_count,
+                    dr,
+                    limit,
+                    9,
+                    limit2
+                );
+                craftax_spawn_build_spans_for_row(
+                    craftax_spawn_hostile_spans,
+                    &hostile_count,
+                    dr,
+                    limit,
+                    81,
+                    limit2
+                );
+                craftax_spawn_build_spans_for_row(
+                    craftax_spawn_boss_spans,
+                    &boss_count,
+                    dr,
+                    limit,
+                    -1,
+                    37
+                );
+            }
+            craftax_spawn_passive_span_count = passive_count;
+            craftax_spawn_hostile_span_count = hostile_count;
+            craftax_spawn_boss_span_count = boss_count;
+            __atomic_store_n(
+                &craftax_spawn_offsets_initialized, 1, __ATOMIC_RELEASE
+            );
+        }
+    }
+}
+
+static inline bool craftax_spawn_block_matches(uint8_t block, uint64_t mask) {
+    return ((mask >> block) & 1ULL) != 0;
+}
+
+static inline uint64_t craftax_spawn_row_bits_for_mask(
+    const CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    uint64_t terrain_mask
+) {
+    if (terrain_mask == CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK) {
+        return state->spawn_all_bits[level][row];
+    }
+    if (terrain_mask == CRAFTAX_SPAWN_GRAVE_BLOCK_MASK) {
+        return state->spawn_grave_bits[level][row];
+    }
+    return state->spawn_water_bits[level][row];
+}
+
+static inline uint64_t craftax_spawn_col_mask(int32_t col0, int32_t col1) {
+    uint64_t hi = (1ULL << (col1 + 1)) - 1ULL;
+    uint64_t lo = col0 <= 0 ? 0ULL : ((1ULL << col0) - 1ULL);
+    return hi & ~lo;
+}
+
+static inline CraftaxThreefryKey craftax_spawn_next_random_key(
+    CraftaxThreefryKey* rng
+) {
+    CraftaxThreefryKey draw;
+    craftax_threefry_split(*rng, rng, &draw);
+    return draw;
+}
+
+static inline int32_t craftax_spawn_floor_mob_type(
+    int32_t floor, int32_t mob_class
+) {
+    static const int32_t mapping[CRAFTAX_NUM_LEVELS][3] = {
+        {0, 0, 0}, {2, 2, 2}, {1, 1, 1}, {2, 3, 3}, {2, 4, 4},
+        {1, 5, 5}, {1, 6, 6}, {1, 7, 7}, {0, 0, 0},
+    };
+    int32_t level = craftax_step_jax_index(floor, CRAFTAX_NUM_LEVELS);
+    int32_t class_index = craftax_step_jax_index(mob_class, 3);
+    return mapping[level][class_index];
+}
+
+static inline float craftax_spawn_floor_spawn_chance(
+    int32_t floor, int32_t chance_index
+) {
+    static const float chances[CRAFTAX_NUM_LEVELS][4] = {
+        {0.1f, 0.02f, 0.05f, 0.1f},
+        {0.1f, 0.06f, 0.05f, 0.0f},
+        {0.1f, 0.06f, 0.05f, 0.0f},
+        {0.1f, 0.06f, 0.05f, 0.0f},
+        {0.1f, 0.06f, 0.05f, 0.0f},
+        {0.1f, 0.06f, 0.05f, 0.0f},
+        {0.1f, 0.06f, 0.05f, 0.0f},
+        {0.0f, 0.06f, 0.05f, 0.0f},
+        {0.1f, 0.06f, 0.05f, 0.0f},
+    };
+    int32_t level = craftax_step_jax_index(floor, CRAFTAX_NUM_LEVELS);
+    int32_t index = craftax_step_jax_index(chance_index, 4);
+    return chances[level][index];
+}
+
+static inline float craftax_spawn_mob_type_health(
+    int32_t mob_type, int32_t mob_class
+) {
+    static const float health[CRAFTAX_NUM_MOB_TYPES][4] = {
+        {3.0f, 5.0f, 3.0f, 0.0f}, {4.0f, 7.0f, 5.0f, 0.0f},
+        {6.0f, 9.0f, 6.0f, 0.0f}, {8.0f, 11.0f, 8.0f, 0.0f},
+        {0.0f, 12.0f, 12.0f, 0.0f}, {0.0f, 20.0f, 4.0f, 0.0f},
+        {0.0f, 20.0f, 14.0f, 0.0f}, {0.0f, 24.0f, 16.0f, 0.0f},
+    };
+    int32_t type_index = craftax_step_jax_index(mob_type, CRAFTAX_NUM_MOB_TYPES);
+    int32_t class_index = craftax_step_jax_index(mob_class, 4);
+    return health[type_index][class_index];
+}
+
+static inline bool craftax_spawn_is_all_valid_block(int32_t block) {
+    static const uint8_t flags[CRAFTAX_NUM_BLOCK_TYPES] = {
+        [CRAFTAX_BLOCK_GRASS] = 1,
+        [CRAFTAX_BLOCK_PATH] = 1,
+        [CRAFTAX_BLOCK_FIRE_GRASS] = 1,
+        [CRAFTAX_BLOCK_ICE_GRASS] = 1,
+    };
+    int32_t idx = craftax_step_jax_index(block, CRAFTAX_NUM_BLOCK_TYPES);
+    return flags[idx] != 0;
+}
+
+static inline bool craftax_spawn_is_grave_block(int32_t block) {
+    static const uint8_t flags[CRAFTAX_NUM_BLOCK_TYPES] = {
+        [CRAFTAX_BLOCK_GRAVE] = 1,
+        [CRAFTAX_BLOCK_GRAVE2] = 1,
+        [CRAFTAX_BLOCK_GRAVE3] = 1,
+    };
+    int32_t idx = craftax_step_jax_index(block, CRAFTAX_NUM_BLOCK_TYPES);
+    return flags[idx] != 0;
+}
+
+static inline bool craftax_spawn_is_water_block(int32_t block) {
+    static const uint8_t flags[CRAFTAX_NUM_BLOCK_TYPES] = {
+        [CRAFTAX_BLOCK_WATER] = 1,
+    };
+    int32_t idx = craftax_step_jax_index(block, CRAFTAX_NUM_BLOCK_TYPES);
+    return flags[idx] != 0;
+}
+
+static inline int32_t craftax_spawn_player_distance_squared(
+    const CraftaxState* state, int32_t row, int32_t col
+) {
+    int32_t dr = row - state->player_position[0];
+    int32_t dc = col - state->player_position[1];
+    if (dr < 0) dr = -dr;
+    if (dc < 0) dc = -dc;
+    return dr * dr + dc * dc;
+}
+
+static inline int32_t craftax_spawn_count_mobs3(
+    const CraftaxMobs3* mobs, int32_t level
+) {
+    int32_t count = 0;
+    for (int32_t i = 0; i < 3; i++) count += (int32_t)mobs->mask[level][i];
+    return count;
+}
+
+static inline int32_t craftax_spawn_count_mobs2(
+    const CraftaxMobs2* mobs, int32_t level
+) {
+    int32_t count = 0;
+    for (int32_t i = 0; i < 2; i++) count += (int32_t)mobs->mask[level][i];
+    return count;
+}
+
+static inline int32_t craftax_spawn_first_empty_mobs3(
+    const CraftaxMobs3* mobs, int32_t level
+) {
+    for (int32_t i = 0; i < 3; i++) if (!mobs->mask[level][i]) return i;
+    return 0;
+}
+
+static inline int32_t craftax_spawn_first_empty_mobs2(
+    const CraftaxMobs2* mobs, int32_t level
+) {
+    for (int32_t i = 0; i < 2; i++) if (!mobs->mask[level][i]) return i;
+    return 0;
+}
+
+static inline void craftax_spawn_mobs3_count_and_empty(
+    const CraftaxMobs3* mobs, int32_t level,
+    int32_t* count_out, int32_t* first_empty_out
+) {
+    int32_t count = 0, first_empty = 0;
+    bool found = false;
+    for (int32_t i = 0; i < 3; i++) {
+        bool m = mobs->mask[level][i];
+        count += (int32_t)m;
+        if (!m && !found) { first_empty = i; found = true; }
+    }
+    *count_out = count;
+    *first_empty_out = first_empty;
+}
+
+static inline void craftax_spawn_mobs2_count_and_empty(
+    const CraftaxMobs2* mobs, int32_t level,
+    int32_t* count_out, int32_t* first_empty_out
+) {
+    int32_t count = 0, first_empty = 0;
+    bool found = false;
+    for (int32_t i = 0; i < 2; i++) {
+        bool m = mobs->mask[level][i];
+        count += (int32_t)m;
+        if (!m && !found) { first_empty = i; found = true; }
+    }
+    *count_out = count;
+    *first_empty_out = first_empty;
+}
+
+// Baseline algorithm on a bool mask:
+//   draw = valid_count * (1.0 - uniform_f32(key));
+//   cum = 0;
+//   for i: if valid[i] { cum += 1.0; if (cum >= draw) return i; }
+// Over a compact list of length valid_count this collapses to a short loop
+// using the same FP arithmetic, preserving bitwise-identical choice.
+static inline int32_t craftax_spawn_pick_kth(
+    int32_t valid_count, CraftaxThreefryKey key
+) {
+    float draw = (float)valid_count * (1.0f - craftax_threefry_uniform_f32(key));
+    float cum = 0.0f;
+    for (int32_t k = 0; k < valid_count; k++) {
+        cum += 1.0f;
+        if (cum >= draw) return k;
+    }
+    return valid_count - 1;
+}
+
+typedef struct { int16_t row, col; } CraftaxSpawnCoord;
+
+typedef struct {
+    CraftaxSpawnCoord passive[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+    CraftaxSpawnCoord melee[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+    CraftaxSpawnCoord ranged[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+    int32_t passive_count;
+    int32_t melee_count;
+    int32_t ranged_count;
+} CraftaxSpawnLists;
+
+static inline int32_t craftax_spawn_collect_spans(
+    const CraftaxState* state,
+    int32_t level,
+    const CraftaxSpawnOffsetSpan* spans,
+    int32_t span_count,
+    uint64_t terrain_mask,
+    CraftaxSpawnCoord* coords
+) {
+    int32_t pr = state->player_position[0];
+    int32_t pc = state->player_position[1];
+    int32_t n = 0;
+    for (int32_t i = 0; i < span_count; i++) {
+        int32_t row = pr + spans[i].dr;
+        if ((uint32_t)row >= CRAFTAX_MAP_SIZE) continue;
+        int32_t col0 = pc + spans[i].dc0;
+        int32_t col1 = pc + spans[i].dc1;
+        if (col0 < 0) col0 = 0;
+        if (col1 >= CRAFTAX_MAP_SIZE) col1 = CRAFTAX_MAP_SIZE - 1;
+        if (col0 > col1) continue;
+        uint64_t candidates =
+            craftax_spawn_row_bits_for_mask(state, level, row, terrain_mask)
+            & ~state->mob_bits[level][row]
+            & craftax_spawn_col_mask(col0, col1);
+        while (candidates != 0) {
+            int32_t col = __builtin_ctzll(candidates);
+            coords[n].row = (int16_t)row;
+            coords[n].col = (int16_t)col;
+            n++;
+            candidates &= candidates - 1;
+        }
+    }
+    return n;
+}
+
+static inline bool craftax_spawn_scan_spans(
+    const CraftaxState* state,
+    int32_t level,
+    const CraftaxSpawnOffsetSpan* spans,
+    int32_t span_count,
+    uint64_t terrain_mask,
+    CraftaxThreefryKey pos_key,
+    int32_t* out_row,
+    int32_t* out_col
+) {
+    CraftaxSpawnCoord coords[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+    int32_t n = craftax_spawn_collect_spans(
+        state, level, spans, span_count, terrain_mask, coords
+    );
+    if (n == 0) return false;
+    int32_t k = craftax_spawn_pick_kth(n, pos_key);
+    *out_row = coords[k].row;
+    *out_col = coords[k].col;
+    return true;
+}
+
+static inline bool craftax_spawn_coord_matches(
+    CraftaxSpawnCoord coord, bool exclude, int32_t row, int32_t col
+) {
+    return exclude && coord.row == row && coord.col == col;
+}
+
+static inline bool craftax_spawn_pick_excluding(
+    const CraftaxSpawnCoord* coords, int32_t count, CraftaxThreefryKey key,
+    bool exclude_a, int32_t row_a, int32_t col_a,
+    bool exclude_b, int32_t row_b, int32_t col_b,
+    int32_t* out_row, int32_t* out_col
+) {
+    int32_t valid_count = 0;
+    for (int32_t i = 0; i < count; i++) {
+        bool excluded = craftax_spawn_coord_matches(
+            coords[i], exclude_a, row_a, col_a
+        ) || craftax_spawn_coord_matches(coords[i], exclude_b, row_b, col_b);
+        valid_count += excluded ? 0 : 1;
+    }
+    if (valid_count == 0) return false;
+
+    int32_t k = craftax_spawn_pick_kth(valid_count, key);
+    for (int32_t i = 0; i < count; i++) {
+        bool excluded = craftax_spawn_coord_matches(
+            coords[i], exclude_a, row_a, col_a
+        ) || craftax_spawn_coord_matches(coords[i], exclude_b, row_b, col_b);
+        if (excluded) continue;
+        if (k == 0) {
+            *out_row = coords[i].row;
+            *out_col = coords[i].col;
+            return true;
+        }
+        k--;
+    }
+    return false;
+}
+
+static inline void craftax_spawn_scan_all(
+    const CraftaxState* state,
+    int32_t level,
+    int32_t ranged_type,
+    bool fighting_boss,
+    bool need_passive,
+    bool need_melee,
+    bool need_ranged,
+    CraftaxSpawnLists* out
+) {
+    out->passive_count = 0;
+    out->melee_count = 0;
+    out->ranged_count = 0;
+
+    craftax_spawn_init_offsets_once();
+
+    if (need_passive) {
+        out->passive_count = craftax_spawn_collect_spans(
+            state,
+            level,
+            craftax_spawn_passive_spans,
+            craftax_spawn_passive_span_count,
+            CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK,
+            out->passive
+        );
+    }
+
+    if (!need_melee && !need_ranged) return;
+
+    int32_t pr = state->player_position[0];
+    int32_t pc = state->player_position[1];
+    const CraftaxSpawnOffsetSpan* spans = fighting_boss
+        ? craftax_spawn_boss_spans
+        : craftax_spawn_hostile_spans;
+    int32_t span_count = fighting_boss
+        ? craftax_spawn_boss_span_count
+        : craftax_spawn_hostile_span_count;
+    bool ranged_water_type = (ranged_type == 5);
+
+    uint64_t melee_terrain_mask = fighting_boss
+        ? CRAFTAX_SPAWN_GRAVE_BLOCK_MASK
+        : CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK;
+    uint64_t ranged_terrain_mask;
+    if (fighting_boss) {
+        ranged_terrain_mask = CRAFTAX_SPAWN_GRAVE_BLOCK_MASK;
+    } else if (ranged_water_type) {
+        ranged_terrain_mask = CRAFTAX_SPAWN_WATER_BLOCK_MASK;
+    } else {
+        ranged_terrain_mask = CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK;
+    }
+
+    for (int32_t i = 0; i < span_count; i++) {
+        int32_t row = pr + spans[i].dr;
+        if ((uint32_t)row >= CRAFTAX_MAP_SIZE) continue;
+        int32_t col0 = pc + spans[i].dc0;
+        int32_t col1 = pc + spans[i].dc1;
+        if (col0 < 0) col0 = 0;
+        if (col1 >= CRAFTAX_MAP_SIZE) col1 = CRAFTAX_MAP_SIZE - 1;
+        if (col0 > col1) continue;
+        uint64_t open_bits =
+            ~state->mob_bits[level][row] & craftax_spawn_col_mask(col0, col1);
+
+        if (need_melee) {
+            uint64_t melee_candidates =
+                craftax_spawn_row_bits_for_mask(
+                    state, level, row, melee_terrain_mask
+                ) & open_bits;
+            while (melee_candidates != 0) {
+                int32_t col = __builtin_ctzll(melee_candidates);
+                int32_t n = out->melee_count++;
+                out->melee[n].row = (int16_t)row;
+                out->melee[n].col = (int16_t)col;
+                melee_candidates &= melee_candidates - 1;
+            }
+        }
+
+        if (need_ranged) {
+            uint64_t ranged_candidates =
+                craftax_spawn_row_bits_for_mask(
+                    state, level, row, ranged_terrain_mask
+                ) & open_bits;
+            while (ranged_candidates != 0) {
+                int32_t col = __builtin_ctzll(ranged_candidates);
+                int32_t n = out->ranged_count++;
+                out->ranged[n].row = (int16_t)row;
+                out->ranged[n].col = (int16_t)col;
+                ranged_candidates &= ranged_candidates - 1;
+            }
+        }
+    }
+}
+
+static inline bool craftax_spawn_scan_passive(
+    const CraftaxState* state, int32_t level, CraftaxThreefryKey pos_key,
+    int32_t* out_row, int32_t* out_col
+) {
+    craftax_spawn_init_offsets_once();
+    return craftax_spawn_scan_spans(
+        state,
+        level,
+        craftax_spawn_passive_spans,
+        craftax_spawn_passive_span_count,
+        CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK,
+        pos_key,
+        out_row,
+        out_col
+    );
+}
+
+static inline bool craftax_spawn_scan_melee(
+    const CraftaxState* state, int32_t level, bool fighting_boss,
+    CraftaxThreefryKey pos_key, int32_t* out_row, int32_t* out_col
+) {
+    craftax_spawn_init_offsets_once();
+    const CraftaxSpawnOffsetSpan* spans = fighting_boss
+        ? craftax_spawn_boss_spans
+        : craftax_spawn_hostile_spans;
+    int32_t span_count = fighting_boss
+        ? craftax_spawn_boss_span_count
+        : craftax_spawn_hostile_span_count;
+    uint64_t terrain_mask = fighting_boss
+        ? CRAFTAX_SPAWN_GRAVE_BLOCK_MASK
+        : CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK;
+    return craftax_spawn_scan_spans(
+        state, level, spans, span_count, terrain_mask, pos_key,
+        out_row, out_col
+    );
+}
+
+static inline bool craftax_spawn_scan_ranged(
+    const CraftaxState* state, int32_t level, int32_t new_type,
+    bool fighting_boss, CraftaxThreefryKey pos_key,
+    int32_t* out_row, int32_t* out_col
+) {
+    craftax_spawn_init_offsets_once();
+    const CraftaxSpawnOffsetSpan* spans = fighting_boss
+        ? craftax_spawn_boss_spans
+        : craftax_spawn_hostile_spans;
+    int32_t span_count = fighting_boss
+        ? craftax_spawn_boss_span_count
+        : craftax_spawn_hostile_span_count;
+    uint64_t terrain_mask;
+    if (fighting_boss) {
+        terrain_mask = CRAFTAX_SPAWN_GRAVE_BLOCK_MASK;
+    } else if (new_type == 5) {
+        terrain_mask = CRAFTAX_SPAWN_WATER_BLOCK_MASK;
+    } else {
+        terrain_mask = CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK;
+    }
+    return craftax_spawn_scan_spans(
+        state, level, spans, span_count, terrain_mask, pos_key,
+        out_row, out_col
+    );
+}
+
+// Both RNG keys are always consumed (preserves baseline RNG sequence).
+// Baseline quirk: type_id[level][slot] is written unconditionally, even
+// when no mob spawns. We match that for bitwise parity.
+
+static inline void craftax_spawn_passive_mob(
+    CraftaxState* state, CraftaxThreefryKey* rng,
+    int32_t level, bool fighting_boss
+) {
+    int32_t count, slot;
+    craftax_spawn_mobs3_count_and_empty(&state->passive_mobs, level, &count, &slot);
+
+    CraftaxThreefryKey prob_key = craftax_spawn_next_random_key(rng);
+    CraftaxThreefryKey pos_key  = craftax_spawn_next_random_key(rng);
+
+    int32_t type = craftax_spawn_floor_mob_type(level, CRAFTAX_MOB_PASSIVE);
+    state->passive_mobs.type_id[level][slot] = type;
+
+    if (fighting_boss) return;
+    if (count >= CRAFTAX_MAX_PASSIVE_MOBS) return;
+    if (craftax_threefry_uniform_f32(prob_key)
+        >= craftax_spawn_floor_spawn_chance(level, 0)) return;
+
+    int32_t row, col;
+    if (!craftax_spawn_scan_passive(state, level, pos_key, &row, &col)) return;
+
+    state->passive_mobs.position[level][slot][0] = row;
+    state->passive_mobs.position[level][slot][1] = col;
+    state->passive_mobs.health[level][slot]      =
+        craftax_spawn_mob_type_health(type, CRAFTAX_MOB_PASSIVE);
+    state->passive_mobs.mask[level][slot]        = true;
+    state->mob_bits[level][row] |= (1ULL << col);
+}
+
+static inline void craftax_spawn_melee_mob(
+    CraftaxState* state, CraftaxThreefryKey* rng,
+    int32_t level, bool fighting_boss, int32_t monster_spawn_coeff
+) {
+    int32_t count, slot;
+    craftax_spawn_mobs3_count_and_empty(&state->melee_mobs, level, &count, &slot);
+
+    int32_t type = fighting_boss
+        ? craftax_spawn_floor_mob_type(state->boss_progress, CRAFTAX_MOB_MELEE)
+        : craftax_spawn_floor_mob_type(level, CRAFTAX_MOB_MELEE);
+
+    CraftaxThreefryKey prob_key = craftax_spawn_next_random_key(rng);
+    float night_coeff = 1.0f - state->light_level;
+    float spawn_chance = craftax_spawn_floor_spawn_chance(level, 1)
+        + craftax_spawn_floor_spawn_chance(level, 3) * night_coeff * night_coeff;
+    CraftaxThreefryKey pos_key = craftax_spawn_next_random_key(rng);
+
+    state->melee_mobs.type_id[level][slot] = type;
+
+    if (count >= CRAFTAX_MAX_MELEE_MOBS) return;
+    if (craftax_threefry_uniform_f32(prob_key)
+        >= spawn_chance * (float)monster_spawn_coeff) return;
+
+    int32_t row, col;
+    if (!craftax_spawn_scan_melee(state, level, fighting_boss, pos_key, &row, &col))
+        return;
+
+    state->melee_mobs.position[level][slot][0] = row;
+    state->melee_mobs.position[level][slot][1] = col;
+    state->melee_mobs.health[level][slot]      =
+        craftax_spawn_mob_type_health(type, CRAFTAX_MOB_MELEE);
+    state->melee_mobs.mask[level][slot]        = true;
+    state->mob_bits[level][row] |= (1ULL << col);
+}
+
+static inline void craftax_spawn_ranged_mob(
+    CraftaxState* state, CraftaxThreefryKey* rng,
+    int32_t level, bool fighting_boss, int32_t monster_spawn_coeff
+) {
+    int32_t count, slot;
+    craftax_spawn_mobs2_count_and_empty(&state->ranged_mobs, level, &count, &slot);
+
+    int32_t type = fighting_boss
+        ? craftax_spawn_floor_mob_type(state->boss_progress, CRAFTAX_MOB_RANGED)
+        : craftax_spawn_floor_mob_type(level, CRAFTAX_MOB_RANGED);
+
+    CraftaxThreefryKey prob_key = craftax_spawn_next_random_key(rng);
+    CraftaxThreefryKey pos_key  = craftax_spawn_next_random_key(rng);
+
+    state->ranged_mobs.type_id[level][slot] = type;
+
+    if (count >= CRAFTAX_MAX_RANGED_MOBS) return;
+    if (craftax_threefry_uniform_f32(prob_key)
+        >= craftax_spawn_floor_spawn_chance(level, 2) * (float)monster_spawn_coeff)
+        return;
+
+    int32_t row, col;
+    if (!craftax_spawn_scan_ranged(state, level, type, fighting_boss, pos_key,
+                                    &row, &col)) return;
+
+    state->ranged_mobs.position[level][slot][0] = row;
+    state->ranged_mobs.position[level][slot][1] = col;
+    state->ranged_mobs.health[level][slot]      =
+        craftax_spawn_mob_type_health(type, CRAFTAX_MOB_RANGED);
+    state->ranged_mobs.mask[level][slot]        = true;
+    state->mob_bits[level][row] |= (1ULL << col);
+}
+
+static inline void craftax_spawn_mobs_native(
+    CraftaxState* state, CraftaxThreefryKey rng
+) {
+    int32_t level = craftax_step_jax_index(
+        state->player_level, CRAFTAX_NUM_LEVELS
+    );
+    bool fighting_boss = craftax_step_is_fighting_boss(state);
+    int32_t monster_spawn_coeff =
+        1
+        + (int32_t)(state->monsters_killed[level]
+                    < CRAFTAX_MONSTERS_KILLED_TO_CLEAR_LEVEL) * 2;
+
+    bool boss_spawn_wave =
+        fighting_boss && state->boss_timesteps_to_spawn_this_round >= 1;
+    if (fighting_boss) {
+        monster_spawn_coeff *= (int32_t)boss_spawn_wave * 1000;
+    }
+
+    int32_t passive_count, passive_slot;
+    craftax_spawn_mobs3_count_and_empty(
+        &state->passive_mobs, level, &passive_count, &passive_slot
+    );
+    CraftaxThreefryKey passive_prob_key = craftax_spawn_next_random_key(&rng);
+    CraftaxThreefryKey passive_pos_key = craftax_spawn_next_random_key(&rng);
+    int32_t passive_type = craftax_spawn_floor_mob_type(
+        level, CRAFTAX_MOB_PASSIVE
+    );
+    state->passive_mobs.type_id[level][passive_slot] = passive_type;
+
+    int32_t melee_count, melee_slot;
+    craftax_spawn_mobs3_count_and_empty(
+        &state->melee_mobs, level, &melee_count, &melee_slot
+    );
+    int32_t melee_type = fighting_boss
+        ? craftax_spawn_floor_mob_type(state->boss_progress, CRAFTAX_MOB_MELEE)
+        : craftax_spawn_floor_mob_type(level, CRAFTAX_MOB_MELEE);
+    CraftaxThreefryKey melee_prob_key = craftax_spawn_next_random_key(&rng);
+    float night_coeff = 1.0f - state->light_level;
+    float melee_spawn_chance = craftax_spawn_floor_spawn_chance(level, 1)
+        + craftax_spawn_floor_spawn_chance(level, 3) * night_coeff * night_coeff;
+    CraftaxThreefryKey melee_pos_key = craftax_spawn_next_random_key(&rng);
+    state->melee_mobs.type_id[level][melee_slot] = melee_type;
+
+    int32_t ranged_count, ranged_slot;
+    craftax_spawn_mobs2_count_and_empty(
+        &state->ranged_mobs, level, &ranged_count, &ranged_slot
+    );
+    int32_t ranged_type = fighting_boss
+        ? craftax_spawn_floor_mob_type(state->boss_progress, CRAFTAX_MOB_RANGED)
+        : craftax_spawn_floor_mob_type(level, CRAFTAX_MOB_RANGED);
+    CraftaxThreefryKey ranged_prob_key = craftax_spawn_next_random_key(&rng);
+    CraftaxThreefryKey ranged_pos_key = craftax_spawn_next_random_key(&rng);
+    state->ranged_mobs.type_id[level][ranged_slot] = ranged_type;
+
+    bool try_passive = !fighting_boss
+        && passive_count < CRAFTAX_MAX_PASSIVE_MOBS
+        && craftax_threefry_uniform_f32(passive_prob_key)
+            < craftax_spawn_floor_spawn_chance(level, 0);
+    bool try_melee = melee_count < CRAFTAX_MAX_MELEE_MOBS
+        && craftax_threefry_uniform_f32(melee_prob_key)
+            < melee_spawn_chance * (float)monster_spawn_coeff;
+    bool try_ranged = ranged_count < CRAFTAX_MAX_RANGED_MOBS
+        && craftax_threefry_uniform_f32(ranged_prob_key)
+            < craftax_spawn_floor_spawn_chance(level, 2)
+                * (float)monster_spawn_coeff;
+
+    if (!try_passive && !try_melee && !try_ranged) return;
+
+    int32_t try_count = (int32_t)try_passive
+        + (int32_t)try_melee
+        + (int32_t)try_ranged;
+    if (try_count == 1) {
+        int32_t row, col;
+        if (try_passive && craftax_spawn_scan_passive(
+                state, level, passive_pos_key, &row, &col
+        )) {
+            state->passive_mobs.position[level][passive_slot][0] = row;
+            state->passive_mobs.position[level][passive_slot][1] = col;
+            state->passive_mobs.health[level][passive_slot] =
+                craftax_spawn_mob_type_health(
+                    passive_type, CRAFTAX_MOB_PASSIVE
+                );
+            state->passive_mobs.mask[level][passive_slot] = true;
+            state->mob_bits[level][row] |= (1ULL << col);
+        } else if (try_melee && craftax_spawn_scan_melee(
+                state, level, fighting_boss, melee_pos_key, &row, &col
+        )) {
+            state->melee_mobs.position[level][melee_slot][0] = row;
+            state->melee_mobs.position[level][melee_slot][1] = col;
+            state->melee_mobs.health[level][melee_slot] =
+                craftax_spawn_mob_type_health(melee_type, CRAFTAX_MOB_MELEE);
+            state->melee_mobs.mask[level][melee_slot] = true;
+            state->mob_bits[level][row] |= (1ULL << col);
+        } else if (try_ranged && craftax_spawn_scan_ranged(
+                state, level, ranged_type, fighting_boss, ranged_pos_key,
+                &row, &col
+        )) {
+            state->ranged_mobs.position[level][ranged_slot][0] = row;
+            state->ranged_mobs.position[level][ranged_slot][1] = col;
+            state->ranged_mobs.health[level][ranged_slot] =
+                craftax_spawn_mob_type_health(ranged_type, CRAFTAX_MOB_RANGED);
+            state->ranged_mobs.mask[level][ranged_slot] = true;
+            state->mob_bits[level][row] |= (1ULL << col);
+        }
+        return;
+    }
+
+    CraftaxSpawnLists lists;
+    craftax_spawn_scan_all(
+        state, level, ranged_type, fighting_boss,
+        try_passive, try_melee, try_ranged, &lists
+    );
+
+    bool passive_spawned = false;
+    int32_t passive_row = 0;
+    int32_t passive_col = 0;
+    if (try_passive && craftax_spawn_pick_excluding(
+            lists.passive, lists.passive_count, passive_pos_key,
+            false, 0, 0, false, 0, 0, &passive_row, &passive_col
+        )) {
+        state->passive_mobs.position[level][passive_slot][0] = passive_row;
+        state->passive_mobs.position[level][passive_slot][1] = passive_col;
+        state->passive_mobs.health[level][passive_slot] =
+            craftax_spawn_mob_type_health(passive_type, CRAFTAX_MOB_PASSIVE);
+        state->passive_mobs.mask[level][passive_slot] = true;
+        state->mob_bits[level][passive_row] |= (1ULL << passive_col);
+        passive_spawned = true;
+    }
+
+    bool melee_spawned = false;
+    int32_t melee_row = 0;
+    int32_t melee_col = 0;
+    if (try_melee && craftax_spawn_pick_excluding(
+            lists.melee, lists.melee_count, melee_pos_key,
+            passive_spawned, passive_row, passive_col,
+            false, 0, 0, &melee_row, &melee_col
+        )) {
+        state->melee_mobs.position[level][melee_slot][0] = melee_row;
+        state->melee_mobs.position[level][melee_slot][1] = melee_col;
+        state->melee_mobs.health[level][melee_slot] =
+            craftax_spawn_mob_type_health(melee_type, CRAFTAX_MOB_MELEE);
+        state->melee_mobs.mask[level][melee_slot] = true;
+        state->mob_bits[level][melee_row] |= (1ULL << melee_col);
+        melee_spawned = true;
+    }
+
+    int32_t ranged_row = 0;
+    int32_t ranged_col = 0;
+    if (try_ranged && craftax_spawn_pick_excluding(
+            lists.ranged, lists.ranged_count, ranged_pos_key,
+            passive_spawned, passive_row, passive_col,
+            melee_spawned, melee_row, melee_col, &ranged_row, &ranged_col
+        )) {
+        state->ranged_mobs.position[level][ranged_slot][0] = ranged_row;
+        state->ranged_mobs.position[level][ranged_slot][1] = ranged_col;
+        state->ranged_mobs.health[level][ranged_slot] =
+            craftax_spawn_mob_type_health(ranged_type, CRAFTAX_MOB_RANGED);
+        state->ranged_mobs.mask[level][ranged_slot] = true;
+        state->mob_bits[level][ranged_row] |= (1ULL << ranged_col);
+    }
+}

--- a/ocean/craftax_moonshot/step_update_mobs.h
+++ b/ocean/craftax_moonshot/step_update_mobs.h
@@ -1,0 +1,1119 @@
+// Standalone native port of Craftax update_mobs.
+//
+// This helper intentionally is not integrated into c_step yet. It mutates a
+// full CraftaxState in place so tests can compare the subsystem directly
+// against the installed JAX implementation.
+
+#pragma once
+
+#include "step_do_action.h"
+
+#define CRAFTAX_UPDATE_BOSS_FIGHT_EXTRA_DAMAGE 0.5f
+
+static inline CraftaxThreefryKey craftax_update_mobs_next_random_key(
+    CraftaxThreefryKey* rng
+) {
+    CraftaxThreefryKey draw;
+    craftax_threefry_split(*rng, rng, &draw);
+    return draw;
+}
+
+static inline bool craftax_update_mobs_scatter_index(
+    int32_t index,
+    int32_t size,
+    int32_t* mapped_index
+) {
+    if (index < -size || index >= size) {
+        return false;
+    }
+    *mapped_index = index < 0 ? index + size : index;
+    return true;
+}
+
+static inline bool craftax_update_mobs_in_bounds(
+    int32_t row,
+    int32_t col
+) {
+    return row >= 0
+        && row < CRAFTAX_MAP_SIZE
+        && col >= 0
+        && col < CRAFTAX_MAP_SIZE;
+}
+
+static inline int32_t craftax_update_mobs_read_block(
+    const CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    int32_t col
+) {
+    int32_t map_level = craftax_step_jax_index(level, CRAFTAX_NUM_LEVELS);
+    int32_t map_row = craftax_step_jax_index(row, CRAFTAX_MAP_SIZE);
+    int32_t map_col = craftax_step_jax_index(col, CRAFTAX_MAP_SIZE);
+    return state->map[map_level][map_row][map_col];
+}
+
+static inline void craftax_update_mobs_set_block(
+    CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    int32_t col,
+    int32_t block
+) {
+    int32_t map_level;
+    int32_t map_row;
+    int32_t map_col;
+    if (!craftax_update_mobs_scatter_index(
+            level,
+            CRAFTAX_NUM_LEVELS,
+            &map_level
+        )
+        || !craftax_update_mobs_scatter_index(
+            row,
+            CRAFTAX_MAP_SIZE,
+            &map_row
+        )
+        || !craftax_update_mobs_scatter_index(
+            col,
+            CRAFTAX_MAP_SIZE,
+            &map_col
+        )) {
+        return;
+    }
+    craftax_set_map_block(state, map_level, map_row, map_col, block);
+}
+
+static inline bool craftax_update_mobs_read_mob_map(
+    const CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    int32_t col
+) {
+    int32_t map_level = craftax_step_jax_index(level, CRAFTAX_NUM_LEVELS);
+    int32_t map_row = craftax_step_jax_index(row, CRAFTAX_MAP_SIZE);
+    int32_t map_col = craftax_step_jax_index(col, CRAFTAX_MAP_SIZE);
+    return (state->mob_bits[map_level][map_row] >> map_col) & 1ULL;
+}
+
+static inline void craftax_update_mobs_set_mob_map(
+    CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    int32_t col,
+    bool value
+) {
+    int32_t map_level;
+    int32_t map_row;
+    int32_t map_col;
+    if (!craftax_update_mobs_scatter_index(
+            level,
+            CRAFTAX_NUM_LEVELS,
+            &map_level
+        )
+        || !craftax_update_mobs_scatter_index(
+            row,
+            CRAFTAX_MAP_SIZE,
+            &map_row
+        )
+        || !craftax_update_mobs_scatter_index(
+            col,
+            CRAFTAX_MAP_SIZE,
+            &map_col
+        )) {
+        return;
+    }
+    if (value) {
+        state->mob_bits[map_level][map_row] |= (1ULL << map_col);
+    } else {
+        state->mob_bits[map_level][map_row] &= ~(1ULL << map_col);
+    }
+}
+
+static inline void craftax_update_mobs_clear_old_map_entry(
+    CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    int32_t col,
+    bool old_mask
+) {
+    bool old_value = craftax_update_mobs_read_mob_map(state, level, row, col);
+    craftax_update_mobs_set_mob_map(
+        state,
+        level,
+        row,
+        col,
+        old_value && !old_mask
+    );
+}
+
+static inline void craftax_update_mobs_enter_new_map_entry(
+    CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    int32_t col,
+    bool new_mask
+) {
+    bool old_value = craftax_update_mobs_read_mob_map(state, level, row, col);
+    craftax_update_mobs_set_mob_map(
+        state,
+        level,
+        row,
+        col,
+        old_value || new_mask
+    );
+}
+
+static inline void craftax_update_mobs_damage_vector(
+    int32_t type_id,
+    int32_t mob_class_index,
+    float damage[3]
+) {
+    static const float damages[CRAFTAX_NUM_MOB_TYPES][4][3] = {
+        {
+            {0.0f, 0.0f, 0.0f},
+            {2.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {2.0f, 0.0f, 0.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {4.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {4.0f, 0.0f, 0.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {3.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 3.0f, 0.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {5.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 3.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {6.0f, 0.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {5.0f, 0.0f, 0.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {6.0f, 1.0f, 1.0f},
+            {0.0f, 0.0f, 0.0f},
+            {4.0f, 3.0f, 3.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {3.0f, 5.0f, 0.0f},
+            {0.0f, 0.0f, 0.0f},
+            {3.0f, 5.0f, 0.0f},
+        },
+        {
+            {0.0f, 0.0f, 0.0f},
+            {4.0f, 0.0f, 5.0f},
+            {0.0f, 0.0f, 0.0f},
+            {4.0f, 0.0f, 5.0f},
+        },
+    };
+
+    int32_t type_index = craftax_step_jax_index(
+        type_id,
+        CRAFTAX_NUM_MOB_TYPES
+    );
+    int32_t class_index = craftax_step_jax_index(mob_class_index, 4);
+    for (int32_t i = 0; i < 3; i++) {
+        damage[i] = damages[type_index][class_index][i];
+    }
+}
+
+static inline void craftax_update_mobs_collision_map(
+    int32_t type_id,
+    int32_t mob_class_index,
+    bool collision[3]
+) {
+    static const bool collisions[CRAFTAX_NUM_MOB_TYPES][4][3] = {
+        {
+            {false, true, true},
+            {false, true, true},
+            {false, true, true},
+            {false, false, false},
+        },
+        {
+            {false, false, false},
+            {false, true, true},
+            {false, true, true},
+            {false, false, false},
+        },
+        {
+            {false, true, true},
+            {false, true, true},
+            {false, true, true},
+            {false, false, false},
+        },
+        {
+            {false, true, true},
+            {false, false, true},
+            {false, true, true},
+            {false, false, false},
+        },
+        {
+            {false, true, true},
+            {false, true, true},
+            {false, true, true},
+            {false, false, false},
+        },
+        {
+            {false, true, true},
+            {false, true, true},
+            {true, false, true},
+            {false, false, false},
+        },
+        {
+            {false, true, true},
+            {false, true, true},
+            {false, false, false},
+            {false, false, false},
+        },
+        {
+            {false, true, true},
+            {false, true, true},
+            {false, false, false},
+            {false, false, false},
+        },
+    };
+
+    int32_t type_index = craftax_step_jax_index(
+        type_id,
+        CRAFTAX_NUM_MOB_TYPES
+    );
+    int32_t class_index = craftax_step_jax_index(mob_class_index, 4);
+    for (int32_t i = 0; i < 3; i++) {
+        collision[i] = collisions[type_index][class_index][i];
+    }
+}
+
+static inline int32_t craftax_update_mobs_projectile_type_for_ranged(
+    int32_t ranged_type
+) {
+    static const int32_t mapping[CRAFTAX_NUM_MOB_TYPES] = {
+        CRAFTAX_PROJECTILE_ARROW,
+        CRAFTAX_PROJECTILE_ARROW,
+        CRAFTAX_PROJECTILE_FIREBALL,
+        CRAFTAX_PROJECTILE_DAGGER,
+        CRAFTAX_PROJECTILE_ARROW2,
+        CRAFTAX_PROJECTILE_SLIMEBALL,
+        CRAFTAX_PROJECTILE_FIREBALL2,
+        CRAFTAX_PROJECTILE_ICEBALL2,
+    };
+    int32_t type_index = craftax_step_jax_index(
+        ranged_type,
+        CRAFTAX_NUM_MOB_TYPES
+    );
+    return mapping[type_index];
+}
+
+static inline void craftax_update_mobs_direction_choice(
+    CraftaxThreefryKey key,
+    int32_t count,
+    int32_t direction[2]
+) {
+    int32_t choice = craftax_medium_randint(key, 0, count);
+    direction[0] = 0;
+    direction[1] = 0;
+    if (choice == 0) {
+        direction[1] = -1;
+    } else if (choice == 1) {
+        direction[1] = 1;
+    } else if (choice == 2) {
+        direction[0] = -1;
+    } else if (choice == 3) {
+        direction[0] = 1;
+    }
+}
+
+static inline int32_t craftax_update_mobs_abs_i32(int32_t value) {
+    return value < 0 ? -value : value;
+}
+
+static inline int32_t craftax_update_mobs_sign_i32(int32_t value) {
+    if (value < 0) {
+        return -1;
+    }
+    return value > 0 ? 1 : 0;
+}
+
+static inline int32_t craftax_update_mobs_player_axis_choice(
+    CraftaxThreefryKey key,
+    int32_t distance_row,
+    int32_t distance_col
+) {
+    int32_t max_distance = distance_row > distance_col
+        ? distance_row
+        : distance_col;
+    int32_t total_distance = distance_row + distance_col;
+    if (total_distance == 0) {
+        return 1;
+    }
+
+    float weights[2] = {
+        (distance_row == max_distance) ? 1.0f / (float)total_distance : 0.0f,
+        (distance_col == max_distance) ? 1.0f / (float)total_distance : 0.0f,
+    };
+    return craftax_medium_choice_weighted(key, weights, 2);
+}
+
+static inline bool craftax_update_mobs_valid_position(
+    const CraftaxState* state,
+    int32_t row,
+    int32_t col,
+    const bool collision[3]
+) {
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    bool pos_in_bounds = craftax_update_mobs_in_bounds(row, col);
+    int32_t block = craftax_update_mobs_read_block(state, level, row, col);
+    bool in_solid_block = craftax_step_is_solid_block(block);
+    bool in_mob = craftax_step_is_in_mob(state, row, col);
+    bool in_lava = block == CRAFTAX_BLOCK_LAVA;
+    bool in_water = block == CRAFTAX_BLOCK_WATER;
+    bool on_ground_block = !in_solid_block && !in_water && !in_lava;
+
+    bool valid_move = pos_in_bounds && !in_mob && !in_solid_block;
+    valid_move = valid_move && (!collision[0] || !on_ground_block);
+    valid_move = valid_move && (!collision[1] || !in_water);
+    valid_move = valid_move && (!collision[2] || !in_lava);
+    return valid_move;
+}
+
+static inline int32_t craftax_update_mobs_manhattan_to_player(
+    const CraftaxState* state,
+    int32_t row,
+    int32_t col
+) {
+    return craftax_update_mobs_abs_i32(row - state->player_position[0])
+        + craftax_update_mobs_abs_i32(col - state->player_position[1]);
+}
+
+static inline float craftax_update_mobs_damage_done_to_player(
+    const CraftaxState* state,
+    const float damage_vector[3]
+) {
+    float defense_vector[3] = {0.0f, 0.0f, 0.0f};
+    for (int32_t i = 0; i < 4; i++) {
+        defense_vector[0] += (float)state->inventory.armour[i] * 0.1f;
+        defense_vector[1] +=
+            (float)(int32_t)(state->armour_enchantments[i] == 1) * 0.2f;
+        defense_vector[2] +=
+            (float)(int32_t)(state->armour_enchantments[i] == 2) * 0.2f;
+    }
+
+    float boss_coeff = craftax_step_is_fighting_boss(state)
+        ? 1.0f + CRAFTAX_UPDATE_BOSS_FIGHT_EXTRA_DAMAGE
+        : 1.0f;
+    float damage = 0.0f;
+    for (int32_t i = 0; i < 3; i++) {
+        damage += (1.0f - defense_vector[i]) * damage_vector[i] * boss_coeff;
+    }
+    return damage;
+}
+
+static inline int32_t craftax_update_mobs_count_mob_projectiles(
+    const CraftaxState* state,
+    int32_t level
+) {
+    const bool* mask = state->mob_projectiles.mask[level];
+    return (int32_t)mask[0] + (int32_t)mask[1] + (int32_t)mask[2];
+}
+
+static inline int32_t craftax_update_mobs_first_empty_mob_projectile(
+    const CraftaxState* state,
+    int32_t level
+) {
+    const bool* mask = state->mob_projectiles.mask[level];
+    if (!mask[0]) return 0;
+    if (!mask[1]) return 1;
+    if (!mask[2]) return 2;
+    return 0;
+}
+
+static inline void craftax_update_mobs_spawn_mob_projectile(
+    CraftaxState* state,
+    int32_t level,
+    bool is_spawning_projectile,
+    const int32_t position[2],
+    const int32_t direction[2],
+    int32_t projectile_type
+) {
+    if (!is_spawning_projectile) {
+        return;
+    }
+
+    int32_t index = craftax_update_mobs_first_empty_mob_projectile(
+        state,
+        level
+    );
+    state->mob_projectiles.position[level][index][0] = position[0];
+    state->mob_projectiles.position[level][index][1] = position[1];
+    state->mob_projectiles.mask[level][index] = true;
+    state->mob_projectiles.type_id[level][index] = projectile_type;
+    state->mob_projectile_directions[level][index][0] = direction[0];
+    state->mob_projectile_directions[level][index][1] = direction[1];
+}
+
+static inline void craftax_update_mobs_attack_mob_with_damage(
+    CraftaxState* state,
+    int32_t row,
+    int32_t col,
+    const float damage_vector[3],
+    bool can_eat,
+    bool* did_attack_mob,
+    bool* did_kill_mob
+) {
+    bool did_kill_melee_mob = false;
+    bool is_attacking_melee_mob = false;
+    craftax_do_action_attack_mobs3(
+        state,
+        &state->melee_mobs,
+        row,
+        col,
+        damage_vector,
+        true,
+        CRAFTAX_MOB_MELEE,
+        &did_kill_melee_mob,
+        &is_attacking_melee_mob
+    );
+
+    bool did_kill_passive_mob = false;
+    bool is_attacking_passive_mob = false;
+    craftax_do_action_attack_mobs3(
+        state,
+        &state->passive_mobs,
+        row,
+        col,
+        damage_vector,
+        can_eat,
+        CRAFTAX_MOB_PASSIVE,
+        &did_kill_passive_mob,
+        &is_attacking_passive_mob
+    );
+
+    if (did_kill_passive_mob && can_eat) {
+        state->player_food = craftax_step_mini32(
+            craftax_step_get_max_food(state),
+            state->player_food + 6
+        );
+        state->player_hunger = 0.0f;
+    }
+
+    bool did_kill_ranged_mob = false;
+    bool is_attacking_ranged_mob = false;
+    craftax_do_action_attack_mobs2(
+        state,
+        &state->ranged_mobs,
+        row,
+        col,
+        damage_vector,
+        true,
+        CRAFTAX_MOB_RANGED,
+        &did_kill_ranged_mob,
+        &is_attacking_ranged_mob
+    );
+
+    *did_attack_mob = is_attacking_melee_mob
+        || is_attacking_passive_mob
+        || is_attacking_ranged_mob;
+    bool did_kill_monster = did_kill_melee_mob || did_kill_ranged_mob;
+    *did_kill_mob = did_kill_monster || did_kill_passive_mob;
+
+    craftax_do_action_update_mob_map(state, row, col, *did_kill_mob);
+
+    int32_t level = craftax_step_jax_index(
+        state->player_level,
+        CRAFTAX_NUM_LEVELS
+    );
+    state->monsters_killed[level] += (int32_t)did_kill_monster;
+}
+
+static inline void craftax_update_mobs_player_projectile_damage_vector(
+    const CraftaxState* state,
+    int32_t level,
+    int32_t projectile_index,
+    float damage_vector[3]
+) {
+    int32_t projectile_type =
+        state->player_projectiles.type_id[level][projectile_index];
+    craftax_update_mobs_damage_vector(
+        projectile_type,
+        CRAFTAX_MOB_PROJECTILE,
+        damage_vector
+    );
+
+    float mask = (float)(int32_t)
+        state->player_projectiles.mask[level][projectile_index];
+    for (int32_t i = 0; i < 3; i++) {
+        damage_vector[i] *= mask;
+    }
+
+    bool is_arrow = projectile_type == CRAFTAX_PROJECTILE_ARROW
+        || projectile_type == CRAFTAX_PROJECTILE_ARROW2;
+    if (is_arrow) {
+        float arrow_damage_add[3] = {0.0f, 0.0f, 0.0f};
+        int32_t enchantment_index;
+        if (craftax_update_mobs_scatter_index(
+                state->bow_enchantment,
+                3,
+                &enchantment_index
+            )) {
+            arrow_damage_add[enchantment_index] = damage_vector[0] / 2.0f;
+        }
+        arrow_damage_add[0] = 0.0f;
+        for (int32_t i = 0; i < 3; i++) {
+            damage_vector[i] += arrow_damage_add[i];
+        }
+    }
+
+    if (is_arrow) {
+        float arrow_damage_coeff =
+            1.0f + 0.2f * (float)(state->player_dexterity - 1);
+        for (int32_t i = 0; i < 3; i++) {
+            damage_vector[i] *= arrow_damage_coeff;
+        }
+    }
+
+    bool is_magic_projectile = projectile_type == CRAFTAX_PROJECTILE_FIREBALL
+        || projectile_type == CRAFTAX_PROJECTILE_ICEBALL;
+    if (is_magic_projectile) {
+        float magic_damage_coeff =
+            1.0f + 0.5f * (float)(state->player_intelligence - 1);
+        for (int32_t i = 0; i < 3; i++) {
+            damage_vector[i] *= magic_damage_coeff;
+        }
+    }
+}
+
+static inline void craftax_update_mobs_move_melee(
+    CraftaxState* state,
+    CraftaxThreefryKey* rng,
+    int32_t index
+) {
+    int32_t level = state->player_level;
+    bool old_mask = state->melee_mobs.mask[level][index];
+    // Dead slot early-out: no observable effect on obs/reward/terminal.
+    // Skip body and RNG draws for speed. Breaks per-seed replay against
+    // JAX; define CRAFTAX_JAX_PARITY at build time to restore the
+    // branchless slow path (same pattern in every move_* below).
+#ifndef CRAFTAX_JAX_PARITY
+    if (!old_mask) return;
+#endif
+    int32_t old_row = state->melee_mobs.position[level][index][0];
+    int32_t old_col = state->melee_mobs.position[level][index][1];
+    int32_t old_cooldown = state->melee_mobs.attack_cooldown[level][index];
+    int32_t mob_type = state->melee_mobs.type_id[level][index];
+
+    CraftaxThreefryKey draw_key =
+        craftax_update_mobs_next_random_key(rng);
+    int32_t random_direction[2];
+    craftax_update_mobs_direction_choice(draw_key, 4, random_direction);
+    int32_t random_row = old_row + random_direction[0];
+    int32_t random_col = old_col + random_direction[1];
+
+    int32_t distance_row =
+        craftax_update_mobs_abs_i32(state->player_position[0] - old_row);
+    int32_t distance_col =
+        craftax_update_mobs_abs_i32(state->player_position[1] - old_col);
+    draw_key = craftax_update_mobs_next_random_key(rng);
+    int32_t player_move_axis = craftax_update_mobs_player_axis_choice(
+        draw_key,
+        distance_row,
+        distance_col
+    );
+    int32_t player_direction[2] = {0, 0};
+    if (player_move_axis == 0) {
+        player_direction[0] =
+            craftax_update_mobs_sign_i32(state->player_position[0] - old_row);
+    } else {
+        player_direction[1] =
+            craftax_update_mobs_sign_i32(state->player_position[1] - old_col);
+    }
+    int32_t player_row = old_row + player_direction[0];
+    int32_t player_col = old_col + player_direction[1];
+
+    int32_t distance_to_player = distance_row + distance_col;
+    bool close_to_player = distance_to_player < 10
+        || craftax_step_is_fighting_boss(state);
+    draw_key = craftax_update_mobs_next_random_key(rng);
+    close_to_player = close_to_player
+        && craftax_threefry_uniform_f32(draw_key) < 0.75f;
+
+    int32_t proposed_row = close_to_player ? player_row : random_row;
+    int32_t proposed_col = close_to_player ? player_col : random_col;
+
+    bool is_attacking_player = distance_to_player == 1
+        && old_cooldown <= 0
+        && old_mask;
+    if (is_attacking_player) {
+        proposed_row = old_row;
+        proposed_col = old_col;
+    }
+
+    float base_damage[3];
+    craftax_update_mobs_damage_vector(
+        mob_type,
+        CRAFTAX_MOB_MELEE,
+        base_damage
+    );
+    float sleeping_coeff = 1.0f + 2.5f * (float)(int32_t)state->is_sleeping;
+    for (int32_t i = 0; i < 3; i++) {
+        base_damage[i] *= sleeping_coeff;
+    }
+    float damage = craftax_update_mobs_damage_done_to_player(
+        state,
+        base_damage
+    );
+
+    int32_t new_cooldown = is_attacking_player ? 5 : old_cooldown - 1;
+    bool is_waking_player = state->is_sleeping && is_attacking_player;
+    state->player_health -= damage * (float)(int32_t)is_attacking_player;
+    state->is_sleeping = state->is_sleeping && !is_attacking_player;
+    state->is_resting = state->is_resting && !is_attacking_player;
+    state->achievements[CRAFTAX_ACH_WAKE_UP] =
+        state->achievements[CRAFTAX_ACH_WAKE_UP] || is_waking_player;
+
+    bool collision[3];
+    craftax_update_mobs_collision_map(
+        mob_type,
+        CRAFTAX_MOB_MELEE,
+        collision
+    );
+    bool valid_move = craftax_update_mobs_valid_position(
+        state,
+        proposed_row,
+        proposed_col,
+        collision
+    );
+    int32_t new_row = valid_move ? proposed_row : old_row;
+    int32_t new_col = valid_move ? proposed_col : old_col;
+
+    bool should_not_despawn = distance_to_player < CRAFTAX_MOB_DESPAWN_DISTANCE
+        || craftax_step_is_fighting_boss(state);
+
+    CraftaxThreefryKey unused_left;
+    CraftaxThreefryKey returned_key;
+    craftax_threefry_split(*rng, &unused_left, &returned_key);
+    *rng = returned_key;
+
+    craftax_update_mobs_clear_old_map_entry(
+        state,
+        level,
+        old_row,
+        old_col,
+        old_mask
+    );
+    bool new_mask = old_mask && should_not_despawn;
+    craftax_update_mobs_enter_new_map_entry(
+        state,
+        level,
+        new_row,
+        new_col,
+        new_mask
+    );
+
+    state->melee_mobs.position[level][index][0] = new_row;
+    state->melee_mobs.position[level][index][1] = new_col;
+    state->melee_mobs.attack_cooldown[level][index] = new_cooldown;
+    state->melee_mobs.mask[level][index] = new_mask;
+}
+
+static inline void craftax_update_mobs_move_passive(
+    CraftaxState* state,
+    CraftaxThreefryKey* rng,
+    int32_t index
+) {
+    int32_t level = state->player_level;
+    bool old_mask = state->passive_mobs.mask[level][index];
+#ifndef CRAFTAX_JAX_PARITY
+    if (!old_mask) return;
+#endif
+    int32_t old_row = state->passive_mobs.position[level][index][0];
+    int32_t old_col = state->passive_mobs.position[level][index][1];
+    int32_t mob_type = state->passive_mobs.type_id[level][index];
+
+    CraftaxThreefryKey draw_key =
+        craftax_update_mobs_next_random_key(rng);
+    int32_t direction[2];
+    craftax_update_mobs_direction_choice(draw_key, 8, direction);
+    int32_t proposed_row = old_row + direction[0];
+    int32_t proposed_col = old_col + direction[1];
+
+    bool collision[3];
+    craftax_update_mobs_collision_map(
+        mob_type,
+        CRAFTAX_MOB_PASSIVE,
+        collision
+    );
+    bool valid_move = craftax_update_mobs_valid_position(
+        state,
+        proposed_row,
+        proposed_col,
+        collision
+    );
+    int32_t new_row = valid_move ? proposed_row : old_row;
+    int32_t new_col = valid_move ? proposed_col : old_col;
+
+    int32_t distance_to_player = craftax_update_mobs_manhattan_to_player(
+        state,
+        old_row,
+        old_col
+    );
+    bool should_not_despawn =
+        distance_to_player < CRAFTAX_MOB_DESPAWN_DISTANCE;
+
+    craftax_update_mobs_clear_old_map_entry(
+        state,
+        level,
+        old_row,
+        old_col,
+        old_mask
+    );
+    bool new_mask = old_mask && should_not_despawn;
+    craftax_update_mobs_enter_new_map_entry(
+        state,
+        level,
+        new_row,
+        new_col,
+        new_mask
+    );
+
+    state->passive_mobs.position[level][index][0] = new_row;
+    state->passive_mobs.position[level][index][1] = new_col;
+    state->passive_mobs.mask[level][index] = new_mask;
+}
+
+static inline void craftax_update_mobs_move_ranged(
+    CraftaxState* state,
+    CraftaxThreefryKey* rng,
+    int32_t index
+) {
+    int32_t level = state->player_level;
+    bool old_mask = state->ranged_mobs.mask[level][index];
+#ifndef CRAFTAX_JAX_PARITY
+    if (!old_mask) return;
+#endif
+    int32_t old_row = state->ranged_mobs.position[level][index][0];
+    int32_t old_col = state->ranged_mobs.position[level][index][1];
+    int32_t old_cooldown = state->ranged_mobs.attack_cooldown[level][index];
+    int32_t mob_type = state->ranged_mobs.type_id[level][index];
+
+    CraftaxThreefryKey draw_key =
+        craftax_update_mobs_next_random_key(rng);
+    int32_t random_direction[2];
+    craftax_update_mobs_direction_choice(draw_key, 4, random_direction);
+    int32_t random_row = old_row + random_direction[0];
+    int32_t random_col = old_col + random_direction[1];
+
+    int32_t distance_row =
+        craftax_update_mobs_abs_i32(state->player_position[0] - old_row);
+    int32_t distance_col =
+        craftax_update_mobs_abs_i32(state->player_position[1] - old_col);
+    draw_key = craftax_update_mobs_next_random_key(rng);
+    int32_t player_move_axis = craftax_update_mobs_player_axis_choice(
+        draw_key,
+        distance_row,
+        distance_col
+    );
+    int32_t player_direction[2] = {0, 0};
+    if (player_move_axis == 0) {
+        player_direction[0] =
+            craftax_update_mobs_sign_i32(state->player_position[0] - old_row);
+    } else {
+        player_direction[1] =
+            craftax_update_mobs_sign_i32(state->player_position[1] - old_col);
+    }
+    int32_t towards_row = old_row + player_direction[0];
+    int32_t towards_col = old_col + player_direction[1];
+    int32_t away_row = old_row - player_direction[0];
+    int32_t away_col = old_col - player_direction[1];
+
+    int32_t distance_to_player = distance_row + distance_col;
+    bool far_from_player = distance_to_player >= 6;
+    bool too_close_to_player = distance_to_player <= 3;
+    int32_t proposed_row = far_from_player ? towards_row : random_row;
+    int32_t proposed_col = far_from_player ? towards_col : random_col;
+    if (too_close_to_player) {
+        proposed_row = away_row;
+        proposed_col = away_col;
+    }
+
+    draw_key = craftax_update_mobs_next_random_key(rng);
+    if (!(craftax_threefry_uniform_f32(draw_key) > 0.85f)) {
+        proposed_row = random_row;
+        proposed_col = random_col;
+    }
+
+    bool collision[3];
+    craftax_update_mobs_collision_map(
+        mob_type,
+        CRAFTAX_MOB_RANGED,
+        collision
+    );
+
+    bool is_attacking_player =
+        distance_to_player >= 4 && distance_to_player <= 5;
+    bool proposed_valid = craftax_update_mobs_valid_position(
+        state,
+        proposed_row,
+        proposed_col,
+        collision
+    );
+    is_attacking_player = is_attacking_player
+        || (too_close_to_player && !proposed_valid);
+    is_attacking_player = is_attacking_player
+        && old_cooldown <= 0
+        && old_mask;
+
+    bool can_spawn_projectile =
+        craftax_update_mobs_count_mob_projectiles(state, level)
+            < CRAFTAX_MAX_MOB_PROJECTILES;
+    bool is_spawning_projectile =
+        is_attacking_player && can_spawn_projectile;
+    int32_t projectile_position[2] = {old_row, old_col};
+    int32_t projectile_type =
+        craftax_update_mobs_projectile_type_for_ranged(mob_type);
+    craftax_update_mobs_spawn_mob_projectile(
+        state,
+        level,
+        is_spawning_projectile,
+        projectile_position,
+        player_direction,
+        projectile_type
+    );
+
+    if (is_attacking_player) {
+        proposed_row = old_row;
+        proposed_col = old_col;
+    }
+    int32_t new_cooldown = is_attacking_player ? 4 : old_cooldown - 1;
+
+    bool valid_move = craftax_update_mobs_valid_position(
+        state,
+        proposed_row,
+        proposed_col,
+        collision
+    );
+    int32_t new_row = valid_move ? proposed_row : old_row;
+    int32_t new_col = valid_move ? proposed_col : old_col;
+
+    bool should_not_despawn = distance_to_player < CRAFTAX_MOB_DESPAWN_DISTANCE
+        || craftax_step_is_fighting_boss(state);
+
+    craftax_update_mobs_clear_old_map_entry(
+        state,
+        level,
+        old_row,
+        old_col,
+        old_mask
+    );
+    bool new_mask = old_mask && should_not_despawn;
+    craftax_update_mobs_enter_new_map_entry(
+        state,
+        level,
+        new_row,
+        new_col,
+        new_mask
+    );
+
+    state->ranged_mobs.position[level][index][0] = new_row;
+    state->ranged_mobs.position[level][index][1] = new_col;
+    state->ranged_mobs.attack_cooldown[level][index] = new_cooldown;
+    state->ranged_mobs.mask[level][index] = new_mask;
+}
+
+static inline void craftax_update_mobs_move_mob_projectile(
+    CraftaxState* state,
+    int32_t index
+) {
+    int32_t level = state->player_level;
+    bool old_mask = state->mob_projectiles.mask[level][index];
+#ifndef CRAFTAX_JAX_PARITY
+    if (!old_mask) return;
+#endif
+    int32_t old_row = state->mob_projectiles.position[level][index][0];
+    int32_t old_col = state->mob_projectiles.position[level][index][1];
+    int32_t proposed_row =
+        old_row + state->mob_projectile_directions[level][index][0];
+    int32_t proposed_col =
+        old_col + state->mob_projectile_directions[level][index][1];
+
+    bool proposed_in_player =
+        proposed_row == state->player_position[0]
+        && proposed_col == state->player_position[1];
+    bool proposed_in_bounds = craftax_update_mobs_in_bounds(
+        proposed_row,
+        proposed_col
+    );
+    int32_t proposed_block = craftax_update_mobs_read_block(
+        state,
+        level,
+        proposed_row,
+        proposed_col
+    );
+    bool in_wall = craftax_step_is_solid_block(proposed_block)
+        && proposed_block != CRAFTAX_BLOCK_WATER;
+    bool in_mob = craftax_step_is_in_mob(state, proposed_row, proposed_col);
+    bool continue_move = proposed_in_bounds && !in_wall && !in_mob;
+
+    bool hit_player0 =
+        old_row == state->player_position[0]
+        && old_col == state->player_position[1]
+        && old_mask;
+    bool hit_player1 = proposed_in_player && old_mask;
+    bool hit_player = hit_player0 || hit_player1;
+    continue_move = continue_move && !hit_player;
+
+    bool new_mask = continue_move && old_mask;
+
+    bool hit_bench_or_furnace = proposed_block == CRAFTAX_BLOCK_FURNACE
+        || proposed_block == CRAFTAX_BLOCK_CRAFTING_TABLE;
+    bool removing_block = hit_bench_or_furnace && old_mask;
+    int32_t new_block = removing_block ? CRAFTAX_BLOCK_PATH : proposed_block;
+
+    int32_t projectile_type =
+        state->mob_projectiles.type_id[level][index];
+    float damage_vector[3];
+    craftax_update_mobs_damage_vector(
+        projectile_type,
+        CRAFTAX_MOB_PROJECTILE,
+        damage_vector
+    );
+    float damage = craftax_update_mobs_damage_done_to_player(
+        state,
+        damage_vector
+    );
+
+    state->mob_projectiles.position[level][index][0] = proposed_row;
+    state->mob_projectiles.position[level][index][1] = proposed_col;
+    state->mob_projectiles.mask[level][index] = new_mask;
+    state->player_health -= damage * (float)(int32_t)hit_player;
+    state->is_sleeping = state->is_sleeping && !hit_player;
+    state->is_resting = state->is_resting && !hit_player;
+    craftax_update_mobs_set_block(
+        state,
+        level,
+        proposed_row,
+        proposed_col,
+        new_block
+    );
+}
+
+static inline void craftax_update_mobs_move_player_projectile(
+    CraftaxState* state,
+    int32_t index
+) {
+    int32_t level = state->player_level;
+    bool old_mask = state->player_projectiles.mask[level][index];
+#ifndef CRAFTAX_JAX_PARITY
+    if (!old_mask) return;
+#endif
+    int32_t old_row = state->player_projectiles.position[level][index][0];
+    int32_t old_col = state->player_projectiles.position[level][index][1];
+    int32_t proposed_row =
+        old_row + state->player_projectile_directions[level][index][0];
+    int32_t proposed_col =
+        old_col + state->player_projectile_directions[level][index][1];
+
+    float damage_vector[3];
+    craftax_update_mobs_player_projectile_damage_vector(
+        state,
+        level,
+        index,
+        damage_vector
+    );
+
+    bool proposed_in_bounds = craftax_update_mobs_in_bounds(
+        proposed_row,
+        proposed_col
+    );
+    int32_t proposed_block = craftax_update_mobs_read_block(
+        state,
+        level,
+        proposed_row,
+        proposed_col
+    );
+    bool in_wall = craftax_step_is_solid_block(proposed_block)
+        && proposed_block != CRAFTAX_BLOCK_WATER;
+
+    bool did_attack_mob0 = false;
+    bool did_kill_mob0 = false;
+    craftax_update_mobs_attack_mob_with_damage(
+        state,
+        old_row,
+        old_col,
+        damage_vector,
+        false,
+        &did_attack_mob0,
+        &did_kill_mob0
+    );
+    (void)did_kill_mob0;
+
+    float second_damage_vector[3];
+    for (int32_t i = 0; i < 3; i++) {
+        second_damage_vector[i] =
+            damage_vector[i] * (float)(int32_t)(!did_attack_mob0);
+    }
+
+    bool did_attack_mob1 = false;
+    bool did_kill_mob1 = false;
+    craftax_update_mobs_attack_mob_with_damage(
+        state,
+        proposed_row,
+        proposed_col,
+        second_damage_vector,
+        false,
+        &did_attack_mob1,
+        &did_kill_mob1
+    );
+    (void)did_kill_mob1;
+
+    bool did_attack_mob = did_attack_mob0 || did_attack_mob1;
+    bool continue_move = proposed_in_bounds && !in_wall && !did_attack_mob;
+    bool new_mask = continue_move && old_mask;
+
+    state->player_projectiles.position[level][index][0] = proposed_row;
+    state->player_projectiles.position[level][index][1] = proposed_col;
+    state->player_projectiles.mask[level][index] = new_mask;
+}
+
+static inline void craftax_update_mobs_native(
+    CraftaxState* state,
+    CraftaxThreefryKey rng
+) {
+    CraftaxThreefryKey unused;
+
+    craftax_threefry_split(rng, &rng, &unused);
+    craftax_update_mobs_move_melee(state, &rng, 0);
+    craftax_update_mobs_move_melee(state, &rng, 1);
+    craftax_update_mobs_move_melee(state, &rng, 2);
+
+    craftax_threefry_split(rng, &rng, &unused);
+    craftax_update_mobs_move_passive(state, &rng, 0);
+    craftax_update_mobs_move_passive(state, &rng, 1);
+    craftax_update_mobs_move_passive(state, &rng, 2);
+
+    craftax_threefry_split(rng, &rng, &unused);
+    craftax_update_mobs_move_ranged(state, &rng, 0);
+    craftax_update_mobs_move_ranged(state, &rng, 1);
+
+    craftax_threefry_split(rng, &rng, &unused);
+    craftax_update_mobs_move_mob_projectile(state, 0);
+    craftax_update_mobs_move_mob_projectile(state, 1);
+    craftax_update_mobs_move_mob_projectile(state, 2);
+
+    craftax_threefry_split(rng, &rng, &unused);
+    craftax_update_mobs_move_player_projectile(state, 0);
+    craftax_update_mobs_move_player_projectile(state, 1);
+    craftax_update_mobs_move_player_projectile(state, 2);
+}

--- a/ocean/craftax_moonshot/threefry.h
+++ b/ocean/craftax_moonshot/threefry.h
@@ -1,0 +1,126 @@
+// Fast RNG helpers for Craftax.
+// Replaces JAX Threefry with SplitMix64-based hashing for ~20-50x speedup.
+// NOT cryptographically secure and NOT JAX-compatible.
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+typedef struct CraftaxThreefryKey {
+    uint32_t word[2];
+} CraftaxThreefryKey;
+
+static inline uint64_t craftax_key_to_u64(CraftaxThreefryKey key) {
+    return ((uint64_t)key.word[1] << 32) | key.word[0];
+}
+
+static inline CraftaxThreefryKey craftax_u64_to_key(uint64_t x) {
+    CraftaxThreefryKey key = {{(uint32_t)x, (uint32_t)(x >> 32)}};
+    return key;
+}
+
+static inline uint32_t craftax_rotl32(uint32_t x, uint32_t k) {
+    return (uint32_t)((x << k) | (x >> (32u - k)));
+}
+
+static inline CraftaxThreefryKey craftax_prng_key(uint32_t seed) {
+    CraftaxThreefryKey key = {{seed, seed ^ 0x9E3779B9u}};
+    return key;
+}
+
+// MurmurHash3 64-bit finalizer — fast and good mixing
+static inline uint64_t craftax_mix64(uint64_t x) {
+    x ^= x >> 33;
+    x *= 0xff51afd7ed558ccdULL;
+    x ^= x >> 33;
+    x *= 0xc4ceb9fe1a85ec53ULL;
+    x ^= x >> 33;
+    return x;
+}
+
+// Core hash: mixes key state with counter, returns 64 bits of pseudo-randomness
+static inline uint64_t craftax_fast_hash64(CraftaxThreefryKey key, uint64_t counter) {
+    uint64_t x = craftax_key_to_u64(key);
+    x ^= counter;
+    return craftax_mix64(x);
+}
+
+static inline void craftax_threefry2x32(
+    CraftaxThreefryKey key,
+    uint32_t count0,
+    uint32_t count1,
+    uint32_t out[2]
+) {
+    uint64_t h = craftax_fast_hash64(key, ((uint64_t)count1 << 32) | count0);
+    out[0] = (uint32_t)h;
+    out[1] = (uint32_t)(h >> 32);
+}
+
+static inline CraftaxThreefryKey craftax_threefry_counter_key(
+    CraftaxThreefryKey key,
+    uint32_t count0,
+    uint32_t count1
+) {
+    return craftax_u64_to_key(craftax_fast_hash64(key, ((uint64_t)count1 << 32) | count0));
+}
+
+// Fast split: sequential PCG-style advancement
+static inline void craftax_threefry_split(
+    CraftaxThreefryKey key,
+    CraftaxThreefryKey* left,
+    CraftaxThreefryKey* right
+) {
+    uint64_t state = craftax_key_to_u64(key);
+    uint64_t s1 = state * 6364136223846793005ULL + 1;
+    uint64_t s2 = s1 * 6364136223846793005ULL + 1;
+    *left = craftax_u64_to_key(s1);
+    *right = craftax_u64_to_key(s2);
+}
+
+static inline void craftax_threefry_split_n(
+    CraftaxThreefryKey key,
+    CraftaxThreefryKey* out,
+    size_t count
+) {
+    uint64_t state = craftax_key_to_u64(key);
+    for (size_t i = 0; i < count; i++) {
+        state = state * 6364136223846793005ULL + 1;
+        out[i] = craftax_u64_to_key(state);
+    }
+}
+
+static inline CraftaxThreefryKey craftax_threefry_fold_in(
+    CraftaxThreefryKey key,
+    uint32_t data
+) {
+    return craftax_threefry_counter_key(key, 0u, data);
+}
+
+static inline uint32_t craftax_threefry_uniform_u32_at(
+    CraftaxThreefryKey key,
+    uint64_t index
+) {
+    uint64_t h = craftax_fast_hash64(key, index);
+    return (uint32_t)h ^ (uint32_t)(h >> 32);
+}
+
+static inline uint32_t craftax_threefry_uniform_u32(CraftaxThreefryKey key) {
+    return craftax_threefry_uniform_u32_at(key, 0u);
+}
+
+static inline float craftax_threefry_uniform_f32_at(
+    CraftaxThreefryKey key,
+    uint64_t index
+) {
+    uint32_t bits = craftax_threefry_uniform_u32_at(key, index);
+    uint32_t float_bits = (bits >> 9u) | 0x3F800000u;
+    float value;
+    memcpy(&value, &float_bits, sizeof(value));
+    return value - 1.0f;
+}
+
+static inline float craftax_threefry_uniform_f32(CraftaxThreefryKey key) {
+    return craftax_threefry_uniform_f32_at(key, 0u);
+}

--- a/ocean/craftax_moonshot/worldgen.h
+++ b/ocean/craftax_moonshot/worldgen.h
@@ -1,0 +1,1862 @@
+// Native Craftax reset world generation.
+//
+// This mirrors craftax/craftax/world_gen/world_gen.py for the default
+// EnvParams and StaticEnvParams used by Craftax-Symbolic-v1 reset.
+
+#pragma once
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "noise.h"
+
+#define CRAFTAX_WG_MAP_SIZE 48
+#define CRAFTAX_WG_MAP_CELLS (CRAFTAX_WG_MAP_SIZE * CRAFTAX_WG_MAP_SIZE)
+#define CRAFTAX_WG_NUM_LEVELS 9
+#define CRAFTAX_WG_OBS_ROWS 9
+#define CRAFTAX_WG_OBS_COLS 11
+#define CRAFTAX_WG_NUM_BLOCK_TYPES 37
+#define CRAFTAX_WG_NUM_ITEM_TYPES 5
+#define CRAFTAX_WG_NUM_MOB_CLASSES 5
+#define CRAFTAX_WG_NUM_MOB_TYPES 8
+#define CRAFTAX_WG_INVENTORY_OBS_SIZE 51
+
+// Compact binary observation encoding.
+// Each cell uses binary channels instead of one-hot:
+//   6 bits: block type (0-63, covers 37 block types)
+//   3 bits: item type+1 (0=no item, 1-5=item types)
+//   4 bits per mob class: mob type+1 (0=no mob, 1-8=types) x 5 classes
+//   1 bit : visibility
+// Total: 30 binary channels per cell.
+#define CRAFTAX_WG_BINARY_BLOCK_BITS 6
+#define CRAFTAX_WG_BINARY_ITEM_BITS 3
+#define CRAFTAX_WG_BINARY_MOB_BITS 4
+#define CRAFTAX_WG_BINARY_VISIBILITY_BITS 1
+
+#define CRAFTAX_WG_BINARY_CHANNELS_PER_CELL ( \
+    CRAFTAX_WG_BINARY_BLOCK_BITS + \
+    CRAFTAX_WG_BINARY_ITEM_BITS + \
+    CRAFTAX_WG_NUM_MOB_CLASSES * CRAFTAX_WG_BINARY_MOB_BITS + \
+    CRAFTAX_WG_BINARY_VISIBILITY_BITS \
+)
+
+#define CRAFTAX_WG_BINARY_MAP_OBS_SIZE ( \
+    CRAFTAX_WG_OBS_ROWS * CRAFTAX_WG_OBS_COLS * CRAFTAX_WG_BINARY_CHANNELS_PER_CELL \
+)
+#define CRAFTAX_WG_OBS_WINDOW_CELLS (CRAFTAX_WG_OBS_ROWS * CRAFTAX_WG_OBS_COLS)
+#define CRAFTAX_WG_CELL_TEMPLATE_BYTES ( \
+    CRAFTAX_WG_BINARY_CHANNELS_PER_CELL * sizeof(float) \
+)
+#define CRAFTAX_WG_FULL_OBS_SIZE ( \
+    CRAFTAX_WG_BINARY_MAP_OBS_SIZE + CRAFTAX_WG_INVENTORY_OBS_SIZE \
+)
+
+// Moonshot symbolic observation. Each visible cell stores compact float IDs:
+// block, item+1, visible, and one mob type+1 slot for each mob class.
+// The 51 scalar channels remain exact floats for oracle-expandability.
+#define CRAFTAX_WG_PACKED_CHANNELS_PER_CELL (3 + CRAFTAX_WG_NUM_MOB_CLASSES)
+#define CRAFTAX_WG_PACKED_MAP_OBS_SIZE ( \
+    CRAFTAX_WG_OBS_ROWS * CRAFTAX_WG_OBS_COLS * CRAFTAX_WG_PACKED_CHANNELS_PER_CELL \
+)
+#define CRAFTAX_WG_PACKED_OBS_SIZE ( \
+    CRAFTAX_WG_PACKED_MAP_OBS_SIZE + CRAFTAX_WG_INVENTORY_OBS_SIZE \
+)
+
+// Lookup tables for fast binary bit writing (eliminates loops/branches)
+static const float CRAFTAX_WG_BLOCK_LUT[64][6] = {
+    {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f},{1.0f,0.0f,0.0f,0.0f,0.0f,0.0f},{0.0f,1.0f,0.0f,0.0f,0.0f,0.0f},{1.0f,1.0f,0.0f,0.0f,0.0f,0.0f},
+    {0.0f,0.0f,1.0f,0.0f,0.0f,0.0f},{1.0f,0.0f,1.0f,0.0f,0.0f,0.0f},{0.0f,1.0f,1.0f,0.0f,0.0f,0.0f},{1.0f,1.0f,1.0f,0.0f,0.0f,0.0f},
+    {0.0f,0.0f,0.0f,1.0f,0.0f,0.0f},{1.0f,0.0f,0.0f,1.0f,0.0f,0.0f},{0.0f,1.0f,0.0f,1.0f,0.0f,0.0f},{1.0f,1.0f,0.0f,1.0f,0.0f,0.0f},
+    {0.0f,0.0f,1.0f,1.0f,0.0f,0.0f},{1.0f,0.0f,1.0f,1.0f,0.0f,0.0f},{0.0f,1.0f,1.0f,1.0f,0.0f,0.0f},{1.0f,1.0f,1.0f,1.0f,0.0f,0.0f},
+    {0.0f,0.0f,0.0f,0.0f,1.0f,0.0f},{1.0f,0.0f,0.0f,0.0f,1.0f,0.0f},{0.0f,1.0f,0.0f,0.0f,1.0f,0.0f},{1.0f,1.0f,0.0f,0.0f,1.0f,0.0f},
+    {0.0f,0.0f,1.0f,0.0f,1.0f,0.0f},{1.0f,0.0f,1.0f,0.0f,1.0f,0.0f},{0.0f,1.0f,1.0f,0.0f,1.0f,0.0f},{1.0f,1.0f,1.0f,0.0f,1.0f,0.0f},
+    {0.0f,0.0f,0.0f,1.0f,1.0f,0.0f},{1.0f,0.0f,0.0f,1.0f,1.0f,0.0f},{0.0f,1.0f,0.0f,1.0f,1.0f,0.0f},{1.0f,1.0f,0.0f,1.0f,1.0f,0.0f},
+    {0.0f,0.0f,1.0f,1.0f,1.0f,0.0f},{1.0f,0.0f,1.0f,1.0f,1.0f,0.0f},{0.0f,1.0f,1.0f,1.0f,1.0f,0.0f},{1.0f,1.0f,1.0f,1.0f,1.0f,0.0f},
+    {0.0f,0.0f,0.0f,0.0f,0.0f,1.0f},{1.0f,0.0f,0.0f,0.0f,0.0f,1.0f},{0.0f,1.0f,0.0f,0.0f,0.0f,1.0f},{1.0f,1.0f,0.0f,0.0f,0.0f,1.0f},
+    {0.0f,0.0f,1.0f,0.0f,0.0f,1.0f},{1.0f,0.0f,1.0f,0.0f,0.0f,1.0f},{0.0f,1.0f,1.0f,0.0f,0.0f,1.0f},{1.0f,1.0f,1.0f,0.0f,0.0f,1.0f},
+    {0.0f,0.0f,0.0f,1.0f,0.0f,1.0f},{1.0f,0.0f,0.0f,1.0f,0.0f,1.0f},{0.0f,1.0f,0.0f,1.0f,0.0f,1.0f},{1.0f,1.0f,0.0f,1.0f,0.0f,1.0f},
+    {0.0f,0.0f,1.0f,1.0f,0.0f,1.0f},{1.0f,0.0f,1.0f,1.0f,0.0f,1.0f},{0.0f,1.0f,1.0f,1.0f,0.0f,1.0f},{1.0f,1.0f,1.0f,1.0f,0.0f,1.0f},
+    {0.0f,0.0f,0.0f,0.0f,1.0f,1.0f},{1.0f,0.0f,0.0f,0.0f,1.0f,1.0f},{0.0f,1.0f,0.0f,0.0f,1.0f,1.0f},{1.0f,1.0f,0.0f,0.0f,1.0f,1.0f},
+    {0.0f,0.0f,1.0f,0.0f,1.0f,1.0f},{1.0f,0.0f,1.0f,0.0f,1.0f,1.0f},{0.0f,1.0f,1.0f,0.0f,1.0f,1.0f},{1.0f,1.0f,1.0f,0.0f,1.0f,1.0f},
+    {0.0f,0.0f,0.0f,1.0f,1.0f,1.0f},{1.0f,0.0f,0.0f,1.0f,1.0f,1.0f},{0.0f,1.0f,0.0f,1.0f,1.0f,1.0f},{1.0f,1.0f,0.0f,1.0f,1.0f,1.0f},
+    {0.0f,0.0f,1.0f,1.0f,1.0f,1.0f},{1.0f,0.0f,1.0f,1.0f,1.0f,1.0f},{0.0f,1.0f,1.0f,1.0f,1.0f,1.0f},{1.0f,1.0f,1.0f,1.0f,1.0f,1.0f},
+};
+static const float CRAFTAX_WG_ITEM_LUT[8][3] = {
+    {0.0f,0.0f,0.0f},{1.0f,0.0f,0.0f},{0.0f,1.0f,0.0f},{1.0f,1.0f,0.0f},
+    {0.0f,0.0f,1.0f},{1.0f,0.0f,1.0f},{0.0f,1.0f,1.0f},{1.0f,1.0f,1.0f},
+};
+static const float CRAFTAX_WG_MOB_LUT[16][4] = {
+    {0.0f,0.0f,0.0f,0.0f},{1.0f,0.0f,0.0f,0.0f},{0.0f,1.0f,0.0f,0.0f},{1.0f,1.0f,0.0f,0.0f},
+    {0.0f,0.0f,1.0f,0.0f},{1.0f,0.0f,1.0f,0.0f},{0.0f,1.0f,1.0f,0.0f},{1.0f,1.0f,1.0f,0.0f},
+    {0.0f,0.0f,0.0f,1.0f},{1.0f,0.0f,0.0f,1.0f},{0.0f,1.0f,0.0f,1.0f},{1.0f,1.0f,0.0f,1.0f},
+    {0.0f,0.0f,1.0f,1.0f},{1.0f,0.0f,1.0f,1.0f},{0.0f,1.0f,1.0f,1.0f},{1.0f,1.0f,1.0f,1.0f},
+};
+static float CRAFTAX_WG_VISIBLE_CELL_TEMPLATE_LUT[64][8][CRAFTAX_WG_BINARY_CHANNELS_PER_CELL];
+static float CRAFTAX_WG_EMPTY_CELL_TEMPLATE[CRAFTAX_WG_BINARY_CHANNELS_PER_CELL];
+static bool CRAFTAX_WG_CELL_TEMPLATE_READY = false;
+
+static inline void craftax_wg_init_cell_templates(void) {
+    if (CRAFTAX_WG_CELL_TEMPLATE_READY) {
+        return;
+    }
+
+    for (int block = 0; block < 64; block++) {
+        for (int item = 0; item < 8; item++) {
+            float* cell = CRAFTAX_WG_VISIBLE_CELL_TEMPLATE_LUT[block][item];
+            memcpy(cell, CRAFTAX_WG_BLOCK_LUT[block], 6 * sizeof(float));
+            memcpy(cell + CRAFTAX_WG_BINARY_BLOCK_BITS, CRAFTAX_WG_ITEM_LUT[item], 3 * sizeof(float));
+            cell[CRAFTAX_WG_BINARY_CHANNELS_PER_CELL - 1] = 1.0f;
+        }
+    }
+
+    CRAFTAX_WG_CELL_TEMPLATE_READY = true;
+}
+
+#define CRAFTAX_WG_OBS_SIZE CRAFTAX_WG_PACKED_OBS_SIZE
+#define CRAFTAX_WG_NUM_ACHIEVEMENTS 67
+#define CRAFTAX_WG_MAX_MELEE_MOBS 3
+#define CRAFTAX_WG_MAX_PASSIVE_MOBS 3
+#define CRAFTAX_WG_MAX_RANGED_MOBS 2
+#define CRAFTAX_WG_MAX_MOB_PROJECTILES 3
+#define CRAFTAX_WG_MAX_PLAYER_PROJECTILES 3
+#define CRAFTAX_WG_MAX_GROWING_PLANTS 10
+#define CRAFTAX_WG_MONSTERS_KILLED_TO_CLEAR_LEVEL 8
+
+// Backwards-compatible names used by the phase-1 floor-0 test.
+#define CRAFTAX_OVERWORLD_SIZE CRAFTAX_WG_MAP_SIZE
+#define CRAFTAX_OVERWORLD_CELLS CRAFTAX_WG_MAP_CELLS
+
+#define CRAFTAX_WG_BLOCK_INVALID 0
+#define CRAFTAX_WG_BLOCK_OUT_OF_BOUNDS 1
+#define CRAFTAX_WG_BLOCK_GRASS 2
+#define CRAFTAX_WG_BLOCK_WATER 3
+#define CRAFTAX_WG_BLOCK_STONE 4
+#define CRAFTAX_WG_BLOCK_TREE 5
+#define CRAFTAX_WG_BLOCK_WOOD 6
+#define CRAFTAX_WG_BLOCK_PATH 7
+#define CRAFTAX_WG_BLOCK_COAL 8
+#define CRAFTAX_WG_BLOCK_IRON 9
+#define CRAFTAX_WG_BLOCK_DIAMOND 10
+#define CRAFTAX_WG_BLOCK_CRAFTING_TABLE 11
+#define CRAFTAX_WG_BLOCK_FURNACE 12
+#define CRAFTAX_WG_BLOCK_SAND 13
+#define CRAFTAX_WG_BLOCK_LAVA 14
+#define CRAFTAX_WG_BLOCK_PLANT 15
+#define CRAFTAX_WG_BLOCK_RIPE_PLANT 16
+#define CRAFTAX_WG_BLOCK_WALL 17
+#define CRAFTAX_WG_BLOCK_DARKNESS 18
+#define CRAFTAX_WG_BLOCK_WALL_MOSS 19
+#define CRAFTAX_WG_BLOCK_STALAGMITE 20
+#define CRAFTAX_WG_BLOCK_SAPPHIRE 21
+#define CRAFTAX_WG_BLOCK_RUBY 22
+#define CRAFTAX_WG_BLOCK_CHEST 23
+#define CRAFTAX_WG_BLOCK_FOUNTAIN 24
+#define CRAFTAX_WG_BLOCK_FIRE_GRASS 25
+#define CRAFTAX_WG_BLOCK_ICE_GRASS 26
+#define CRAFTAX_WG_BLOCK_GRAVEL 27
+#define CRAFTAX_WG_BLOCK_FIRE_TREE 28
+#define CRAFTAX_WG_BLOCK_ICE_SHRUB 29
+#define CRAFTAX_WG_BLOCK_ENCHANTMENT_TABLE_FIRE 30
+#define CRAFTAX_WG_BLOCK_ENCHANTMENT_TABLE_ICE 31
+#define CRAFTAX_WG_BLOCK_NECROMANCER 32
+#define CRAFTAX_WG_BLOCK_GRAVE 33
+#define CRAFTAX_WG_BLOCK_GRAVE2 34
+#define CRAFTAX_WG_BLOCK_GRAVE3 35
+#define CRAFTAX_WG_BLOCK_NECROMANCER_VULNERABLE 36
+
+#define CRAFTAX_WG_ITEM_NONE 0
+#define CRAFTAX_WG_ITEM_TORCH 1
+#define CRAFTAX_WG_ITEM_LADDER_DOWN 2
+#define CRAFTAX_WG_ITEM_LADDER_UP 3
+#define CRAFTAX_WG_ITEM_LADDER_DOWN_BLOCKED 4
+
+#define CRAFTAX_WG_ACTION_UP 3
+#define CRAFTAX_WG_BOSS_FIGHT_SPAWN_TURNS 7
+#define CRAFTAX_WG_PI 3.14159265358979323846f
+
+typedef struct CraftaxOverworldFloor {
+    uint8_t map[CRAFTAX_OVERWORLD_SIZE][CRAFTAX_OVERWORLD_SIZE];
+    uint8_t item_map[CRAFTAX_OVERWORLD_SIZE][CRAFTAX_OVERWORLD_SIZE];
+    uint8_t light_map[CRAFTAX_OVERWORLD_SIZE][CRAFTAX_OVERWORLD_SIZE];
+    int32_t ladder_down[2];
+    int32_t ladder_up[2];
+} CraftaxOverworldFloor;
+
+typedef struct CraftaxWGInventory {
+    int32_t wood;
+    int32_t stone;
+    int32_t coal;
+    int32_t iron;
+    int32_t diamond;
+    int32_t sapling;
+    int32_t pickaxe;
+    int32_t sword;
+    int32_t bow;
+    int32_t arrows;
+    int32_t armour[4];
+    int32_t torches;
+    int32_t ruby;
+    int32_t sapphire;
+    int32_t potions[6];
+    int32_t books;
+} CraftaxWGInventory;
+
+typedef struct CraftaxWGMobs3 {
+    int32_t position[CRAFTAX_WG_NUM_LEVELS][3][2];
+    float health[CRAFTAX_WG_NUM_LEVELS][3];
+    bool mask[CRAFTAX_WG_NUM_LEVELS][3];
+    int32_t attack_cooldown[CRAFTAX_WG_NUM_LEVELS][3];
+    int32_t type_id[CRAFTAX_WG_NUM_LEVELS][3];
+} CraftaxWGMobs3;
+
+typedef struct CraftaxWGMobs2 {
+    int32_t position[CRAFTAX_WG_NUM_LEVELS][2][2];
+    float health[CRAFTAX_WG_NUM_LEVELS][2];
+    bool mask[CRAFTAX_WG_NUM_LEVELS][2];
+    int32_t attack_cooldown[CRAFTAX_WG_NUM_LEVELS][2];
+    int32_t type_id[CRAFTAX_WG_NUM_LEVELS][2];
+} CraftaxWGMobs2;
+
+typedef struct CraftaxWorldState {
+    // === Hot data (accessed every step) ===
+    int32_t player_position[2];
+    int32_t player_level;
+    int32_t player_direction;
+
+    float player_health;
+    int32_t player_food;
+    int32_t player_drink;
+    int32_t player_energy;
+    int32_t player_mana;
+    bool is_sleeping;
+    bool is_resting;
+
+    float player_recover;
+    float player_hunger;
+    float player_thirst;
+    float player_fatigue;
+    float player_recover_mana;
+
+    int32_t player_xp;
+    int32_t player_dexterity;
+    int32_t player_strength;
+    int32_t player_intelligence;
+
+    CraftaxWGInventory inventory;
+
+    CraftaxWGMobs3 melee_mobs;
+    CraftaxWGMobs3 passive_mobs;
+    CraftaxWGMobs2 ranged_mobs;
+
+    CraftaxWGMobs3 mob_projectiles;
+    int32_t mob_projectile_directions[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAX_MOB_PROJECTILES][2];
+    CraftaxWGMobs3 player_projectiles;
+    int32_t player_projectile_directions[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAX_PLAYER_PROJECTILES][2];
+
+    int32_t growing_plants_positions[CRAFTAX_WG_MAX_GROWING_PLANTS][2];
+    int32_t growing_plants_age[CRAFTAX_WG_MAX_GROWING_PLANTS];
+    bool growing_plants_mask[CRAFTAX_WG_MAX_GROWING_PLANTS];
+
+    int32_t potion_mapping[6];
+    bool learned_spells[2];
+
+    int32_t sword_enchantment;
+    int32_t bow_enchantment;
+    int32_t armour_enchantments[4];
+
+    int32_t boss_progress;
+    int32_t boss_timesteps_to_spawn_this_round;
+
+    float light_level;
+    bool achievements[CRAFTAX_WG_NUM_ACHIEVEMENTS];
+    uint32_t state_rng[2];
+    int32_t timestep;
+    int32_t fractal_noise_angles[4];
+
+    // === Medium-hot bitmaps ===
+    uint64_t mob_bits[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE];
+    uint64_t spawn_all_bits[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE];
+    uint64_t spawn_grave_bits[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE];
+    uint64_t spawn_water_bits[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE];
+
+    // === Cold data (large maps) ===
+    uint8_t map[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE];
+    uint8_t item_map[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE];
+    uint8_t light_map[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE];
+
+    int32_t down_ladders[CRAFTAX_WG_NUM_LEVELS][2];
+    int32_t up_ladders[CRAFTAX_WG_NUM_LEVELS][2];
+    bool chests_opened[CRAFTAX_WG_NUM_LEVELS];
+    int32_t monsters_killed[CRAFTAX_WG_NUM_LEVELS];
+} CraftaxWorldState;
+
+typedef struct CraftaxSmoothGenConfig {
+    int32_t default_block;
+    int32_t sea_block;
+    int32_t coast_block;
+    int32_t mountain_block;
+    int32_t path_block;
+    int32_t inner_mountain_block;
+    int32_t ore_requirement_blocks[5];
+    int32_t ores[5];
+    float ore_chances[5];
+    int32_t tree_requirement_block;
+    int32_t tree;
+    int32_t lava;
+    int32_t player_spawn;
+    int32_t valid_ladder;
+    bool ladder_up;
+    bool ladder_down;
+    float player_proximity_map_water_strength;
+    float player_proximity_map_water_max;
+    float player_proximity_map_mountain_strength;
+    float player_proximity_map_mountain_max;
+    float default_light;
+    float water_threshold;
+    float sand_threshold;
+    float tree_threshold_uniform;
+    float tree_threshold_perlin;
+} CraftaxSmoothGenConfig;
+
+typedef struct CraftaxDungeonConfig {
+    int32_t special_block;
+    int32_t fountain_block;
+    int32_t rare_path_replacement_block;
+} CraftaxDungeonConfig;
+
+static const CraftaxSmoothGenConfig CRAFTAX_SMOOTHGEN_CONFIGS[6] = {
+    {
+        CRAFTAX_WG_BLOCK_GRASS,
+        CRAFTAX_WG_BLOCK_WATER,
+        CRAFTAX_WG_BLOCK_SAND,
+        CRAFTAX_WG_BLOCK_STONE,
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_PATH,
+        {CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE},
+        {CRAFTAX_WG_BLOCK_COAL, CRAFTAX_WG_BLOCK_IRON, CRAFTAX_WG_BLOCK_DIAMOND, CRAFTAX_WG_BLOCK_OUT_OF_BOUNDS, CRAFTAX_WG_BLOCK_OUT_OF_BOUNDS},
+        {0.03f, 0.02f, 0.001f, 0.0f, 0.0f},
+        CRAFTAX_WG_BLOCK_GRASS,
+        CRAFTAX_WG_BLOCK_TREE,
+        CRAFTAX_WG_BLOCK_LAVA,
+        CRAFTAX_WG_BLOCK_GRASS,
+        CRAFTAX_WG_BLOCK_PATH,
+        false,
+        true,
+        5.0f,
+        1.0f,
+        5.0f,
+        1.0f,
+        1.0f,
+        0.7f,
+        0.6f,
+        0.8f,
+        0.5f,
+    },
+    {
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_WATER,
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_STONE,
+        CRAFTAX_WG_BLOCK_STONE,
+        CRAFTAX_WG_BLOCK_STONE,
+        {CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE},
+        {CRAFTAX_WG_BLOCK_COAL, CRAFTAX_WG_BLOCK_IRON, CRAFTAX_WG_BLOCK_DIAMOND, CRAFTAX_WG_BLOCK_SAPPHIRE, CRAFTAX_WG_BLOCK_RUBY},
+        {0.04f, 0.02f, 0.005f, 0.0025f, 0.0025f},
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_STALAGMITE,
+        CRAFTAX_WG_BLOCK_LAVA,
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_PATH,
+        true,
+        true,
+        5.0f,
+        1.0f,
+        17.0f,
+        1.5f,
+        0.0f,
+        0.7f,
+        0.6f,
+        0.8f,
+        0.5f,
+    },
+    {
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_WATER,
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_STONE,
+        CRAFTAX_WG_BLOCK_STONE,
+        CRAFTAX_WG_BLOCK_STONE,
+        {CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE},
+        {CRAFTAX_WG_BLOCK_COAL, CRAFTAX_WG_BLOCK_IRON, CRAFTAX_WG_BLOCK_DIAMOND, CRAFTAX_WG_BLOCK_SAPPHIRE, CRAFTAX_WG_BLOCK_RUBY},
+        {0.04f, 0.03f, 0.01f, 0.01f, 0.01f},
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_STALAGMITE,
+        CRAFTAX_WG_BLOCK_LAVA,
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_PATH,
+        true,
+        true,
+        5.0f,
+        1.0f,
+        17.0f,
+        1.5f,
+        0.0f,
+        0.7f,
+        0.6f,
+        0.8f,
+        0.5f,
+    },
+    {
+        CRAFTAX_WG_BLOCK_FIRE_GRASS,
+        CRAFTAX_WG_BLOCK_LAVA,
+        CRAFTAX_WG_BLOCK_SAND,
+        CRAFTAX_WG_BLOCK_STONE,
+        CRAFTAX_WG_BLOCK_STONE,
+        CRAFTAX_WG_BLOCK_STONE,
+        {CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE},
+        {CRAFTAX_WG_BLOCK_COAL, CRAFTAX_WG_BLOCK_IRON, CRAFTAX_WG_BLOCK_DIAMOND, CRAFTAX_WG_BLOCK_SAPPHIRE, CRAFTAX_WG_BLOCK_RUBY},
+        {0.05f, 0.0f, 0.0f, 0.0f, 0.025f},
+        CRAFTAX_WG_BLOCK_FIRE_GRASS,
+        CRAFTAX_WG_BLOCK_FIRE_TREE,
+        CRAFTAX_WG_BLOCK_LAVA,
+        CRAFTAX_WG_BLOCK_FIRE_GRASS,
+        CRAFTAX_WG_BLOCK_FIRE_GRASS,
+        true,
+        true,
+        5.0f,
+        1.0f,
+        5.0f,
+        1.0f,
+        1.0f,
+        0.5f,
+        0.6f,
+        0.8f,
+        0.5f,
+    },
+    {
+        CRAFTAX_WG_BLOCK_ICE_GRASS,
+        CRAFTAX_WG_BLOCK_WATER,
+        CRAFTAX_WG_BLOCK_ICE_GRASS,
+        CRAFTAX_WG_BLOCK_STONE,
+        CRAFTAX_WG_BLOCK_STONE,
+        CRAFTAX_WG_BLOCK_STONE,
+        {CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE, CRAFTAX_WG_BLOCK_STONE},
+        {CRAFTAX_WG_BLOCK_COAL, CRAFTAX_WG_BLOCK_IRON, CRAFTAX_WG_BLOCK_DIAMOND, CRAFTAX_WG_BLOCK_SAPPHIRE, CRAFTAX_WG_BLOCK_RUBY},
+        {0.0f, 0.0f, 0.005f, 0.02f, 0.0f},
+        CRAFTAX_WG_BLOCK_ICE_GRASS,
+        CRAFTAX_WG_BLOCK_ICE_SHRUB,
+        CRAFTAX_WG_BLOCK_WATER,
+        CRAFTAX_WG_BLOCK_ICE_GRASS,
+        CRAFTAX_WG_BLOCK_ICE_GRASS,
+        true,
+        true,
+        5.0f,
+        1.0f,
+        17.0f,
+        1.5f,
+        0.0f,
+        0.5f,
+        0.6f,
+        0.4f,
+        0.5f,
+    },
+    {
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_WALL,
+        CRAFTAX_WG_BLOCK_WALL,
+        CRAFTAX_WG_BLOCK_WALL,
+        {CRAFTAX_WG_BLOCK_WALL, CRAFTAX_WG_BLOCK_GRAVE, CRAFTAX_WG_BLOCK_GRAVE, CRAFTAX_WG_BLOCK_WALL, CRAFTAX_WG_BLOCK_WALL},
+        {CRAFTAX_WG_BLOCK_WALL_MOSS, CRAFTAX_WG_BLOCK_GRAVE2, CRAFTAX_WG_BLOCK_GRAVE3, CRAFTAX_WG_BLOCK_SAPPHIRE, CRAFTAX_WG_BLOCK_RUBY},
+        {0.1f, 0.333f, 0.5f, 0.0f, 0.0f},
+        CRAFTAX_WG_BLOCK_PATH,
+        CRAFTAX_WG_BLOCK_GRAVE,
+        CRAFTAX_WG_BLOCK_WALL,
+        CRAFTAX_WG_BLOCK_NECROMANCER,
+        CRAFTAX_WG_BLOCK_PATH,
+        false,
+        false,
+        5.0f,
+        1.0f,
+        10.0f,
+        10.0f,
+        0.0f,
+        0.7f,
+        0.6f,
+        0.95f,
+        -1.0f,
+    },
+};
+
+static const CraftaxDungeonConfig CRAFTAX_DUNGEON_CONFIGS[3] = {
+    {CRAFTAX_WG_BLOCK_PATH, CRAFTAX_WG_BLOCK_FOUNTAIN, CRAFTAX_WG_BLOCK_PATH},
+    {CRAFTAX_WG_BLOCK_ENCHANTMENT_TABLE_ICE, CRAFTAX_WG_BLOCK_WATER, CRAFTAX_WG_BLOCK_WATER},
+    {CRAFTAX_WG_BLOCK_ENCHANTMENT_TABLE_FIRE, CRAFTAX_WG_BLOCK_FOUNTAIN, CRAFTAX_WG_BLOCK_PATH},
+};
+
+static inline float craftax_wg_clampf(float value, float low, float high) {
+    if (value < low) {
+        return low;
+    }
+    if (value > high) {
+        return high;
+    }
+    return value;
+}
+
+static inline int craftax_wg_clampi(int value, int low, int high) {
+    if (value < low) {
+        return low;
+    }
+    if (value > high) {
+        return high;
+    }
+    return value;
+}
+
+static inline size_t craftax_wg_index(int row, int col) {
+    return (size_t)row * (size_t)CRAFTAX_WG_MAP_SIZE + (size_t)col;
+}
+
+static inline void craftax_threefry_split3(
+    CraftaxThreefryKey key,
+    CraftaxThreefryKey* first,
+    CraftaxThreefryKey* second,
+    CraftaxThreefryKey* third
+) {
+    CraftaxThreefryKey keys[3];
+    craftax_threefry_split_n(key, keys, 3);
+    *first = keys[0];
+    *second = keys[1];
+    *third = keys[2];
+}
+
+static inline CraftaxThreefryKey craftax_worldgen_key_from_seed(uint32_t seed) {
+    CraftaxThreefryKey key = craftax_prng_key(seed);
+    CraftaxThreefryKey carry;
+    CraftaxThreefryKey reset_key;
+    craftax_threefry_split(key, &carry, &reset_key);
+
+    CraftaxThreefryKey reset_carry;
+    CraftaxThreefryKey world_key;
+    craftax_threefry_split(reset_key, &reset_carry, &world_key);
+    return world_key;
+}
+
+static inline CraftaxThreefryKey craftax_overworld_rng_from_seed(uint32_t seed) {
+    CraftaxThreefryKey world_key = craftax_worldgen_key_from_seed(seed);
+    CraftaxThreefryKey world_keys[7];
+    craftax_threefry_split_n(world_key, world_keys, 7);
+    return world_keys[1];
+}
+
+static inline uint32_t craftax_randint_u32_at(
+    CraftaxThreefryKey key,
+    uint64_t index,
+    uint32_t minval,
+    uint32_t maxval
+) {
+    uint32_t span = maxval > minval ? maxval - minval : 1u;
+    // Fast path for power-of-2 spans: just mask
+    if ((span & (span - 1)) == 0) {
+        uint32_t bits = craftax_threefry_uniform_u32_at(key, index);
+        return minval + (bits & (span - 1));
+    }
+    // General path: use top-32 of hash, scale to span
+    uint64_t h = craftax_fast_hash64(key, index);
+    return minval + (uint32_t)(((h >> 32) * (uint64_t)span) >> 32);
+}
+
+static inline int32_t craftax_randint_i32_at(
+    CraftaxThreefryKey key,
+    uint64_t index,
+    int32_t minval,
+    int32_t maxval
+) {
+    return (int32_t)craftax_randint_u32_at(
+        key,
+        index,
+        (uint32_t)minval,
+        (uint32_t)maxval
+    );
+}
+
+static inline int craftax_choice_bool_flat(
+    CraftaxThreefryKey key,
+    const bool* valid,
+    int count
+) {
+    int valid_count = 0;
+    int last_valid = 0;
+    for (int i = 0; i < count; i++) {
+        if (valid[i]) {
+            valid_count++;
+            last_valid = i;
+        }
+    }
+    if (valid_count == 0) {
+        return 0;
+    }
+
+    float draw = (float)valid_count * (1.0f - craftax_threefry_uniform_f32(key));
+    float cumulative = 0.0f;
+    for (int i = 0; i < count; i++) {
+        if (valid[i]) {
+            cumulative += 1.0f;
+        }
+        if (cumulative >= draw) {
+            return i;
+        }
+    }
+    return last_valid;
+}
+
+static inline float craftax_torch_light_value(int row, int col, float default_light) {
+    float dr = (float)(row - 4);
+    float dc = (float)(col - 4);
+    float distance = sqrtf(dr * dr + dc * dc);
+    float torch = craftax_wg_clampf(1.0f - distance / 5.0f, 0.0f, 1.0f);
+    return torch * (1.0f - default_light) + default_light;
+}
+
+static inline void craftax_apply_ladder_light(
+    uint8_t light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    const int32_t ladder_up[2],
+    float default_light
+) {
+    int start_row = ladder_up[0] - 4;
+    int start_col = ladder_up[1] - 4;
+    if (start_row < 0) {
+        start_row += CRAFTAX_WG_MAP_SIZE;
+    }
+    if (start_col < 0) {
+        start_col += CRAFTAX_WG_MAP_SIZE;
+    }
+    start_row = craftax_wg_clampi(start_row, 0, CRAFTAX_WG_MAP_SIZE - 9);
+    start_col = craftax_wg_clampi(start_col, 0, CRAFTAX_WG_MAP_SIZE - 9);
+    for (int row = 0; row < 9; row++) {
+        for (int col = 0; col < 9; col++) {
+            light_map[start_row + row][start_col + col] =
+                (uint8_t)(craftax_torch_light_value(row, col, default_light) * 255.0f);
+        }
+    }
+}
+
+static inline void craftax_add_lava_light(
+    uint8_t light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    const bool lava_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    bool lava_emits_light
+) {
+    if (!lava_emits_light) {
+        return;
+    }
+
+    static const float kernel[3][3] = {
+        {0.2f, 0.7f, 0.2f},
+        {0.7f, 1.0f, 0.7f},
+        {0.2f, 0.7f, 0.2f},
+    };
+
+    for (int row = 0; row < CRAFTAX_WG_MAP_SIZE; row++) {
+        for (int col = 0; col < CRAFTAX_WG_MAP_SIZE; col++) {
+            float add = 0.0f;
+            for (int kr = 0; kr < 3; kr++) {
+                int src_row = row + kr - 1;
+                if (src_row < 0 || src_row >= CRAFTAX_WG_MAP_SIZE) {
+                    continue;
+                }
+                for (int kc = 0; kc < 3; kc++) {
+                    int src_col = col + kc - 1;
+                    if (src_col < 0 || src_col >= CRAFTAX_WG_MAP_SIZE) {
+                        continue;
+                    }
+                    add += lava_map[src_row][src_col] ? kernel[kr][kc] : 0.0f;
+                }
+            }
+            float new_light = craftax_wg_clampf(light_map[row][col] / 255.0f + add, 0.0f, 1.0f);
+            light_map[row][col] = (uint8_t)(new_light * 255.0f);
+        }
+    }
+}
+
+static inline int craftax_smooth_config_index_for_floor(int floor_idx) {
+    switch (floor_idx) {
+        case 0:
+            return 0;
+        case 2:
+            return 1;
+        case 5:
+            return 2;
+        case 6:
+            return 3;
+        case 7:
+            return 4;
+        case 8:
+            return 5;
+        default:
+            return -1;
+    }
+}
+
+static inline int craftax_dungeon_config_index_for_floor(int floor_idx) {
+    switch (floor_idx) {
+        case 1:
+            return 0;
+        case 3:
+            return 1;
+        case 4:
+            return 2;
+        default:
+            return -1;
+    }
+}
+
+static inline void craftax_generate_smoothworld_config(
+    CraftaxThreefryKey rng,
+    int config_idx,
+    uint8_t map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t item_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    int32_t ladder_down[2],
+    int32_t ladder_up[2]
+) {
+    const CraftaxSmoothGenConfig* config = &CRAFTAX_SMOOTHGEN_CONFIGS[config_idx];
+    const int size = CRAFTAX_WG_MAP_SIZE;
+    const int player_row = CRAFTAX_WG_MAP_SIZE / 2;
+    const int player_col = CRAFTAX_WG_MAP_SIZE / 2;
+    const size_t cells = CRAFTAX_WG_MAP_CELLS;
+
+    CraftaxThreefryKey subkey;
+    float water[CRAFTAX_WG_MAP_CELLS];
+    float mountain[CRAFTAX_WG_MAP_CELLS];
+    float path_x[CRAFTAX_WG_MAP_CELLS];
+    float tree_noise[CRAFTAX_WG_MAP_CELLS];
+    bool lava_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE];
+
+    craftax_threefry_split(rng, &rng, &subkey);
+    craftax_generate_fractal_noise_2d(subkey, size, size, 3, 3, 1, 0.5f, 2, NULL, water);
+
+    craftax_threefry_split(rng, &rng, &subkey);
+    (void)subkey;
+
+    craftax_threefry_split(rng, &rng, &subkey);
+    craftax_generate_fractal_noise_2d(subkey, size, size, 3, 3, 1, 0.5f, 2, NULL, mountain);
+
+    craftax_threefry_split(rng, &rng, &subkey);
+    craftax_generate_fractal_noise_2d(subkey, size, size, 6, 24, 1, 0.5f, 2, NULL, path_x);
+
+    craftax_threefry_split(rng, &rng, &subkey);
+    (void)subkey;
+
+    craftax_threefry_split(rng, &rng, &subkey);
+    CraftaxThreefryKey tree_uniform_key = rng;
+    craftax_generate_fractal_noise_2d(subkey, size, size, 12, 12, 1, 0.5f, 2, NULL, tree_noise);
+
+    for (int row = 0; row < size; row++) {
+        int dr = row > player_row ? row - player_row : player_row - row;
+        for (int col = 0; col < size; col++) {
+            int dc = col > player_col ? col - player_col : player_col - col;
+            float distance = sqrtf((float)(dr * dr + dc * dc));
+            float proximity_water = craftax_wg_clampf(
+                distance / config->player_proximity_map_water_strength,
+                0.0f,
+                config->player_proximity_map_water_max
+            );
+            float proximity_mountain = craftax_wg_clampf(
+                distance / config->player_proximity_map_mountain_strength,
+                0.0f,
+                config->player_proximity_map_mountain_max
+            );
+            size_t idx = craftax_wg_index(row, col);
+
+            water[idx] = water[idx] + proximity_water - 1.0f;
+            int32_t block = water[idx] > config->water_threshold
+                ? config->sea_block
+                : config->default_block;
+            bool sand = water[idx] > config->sand_threshold && block != config->sea_block;
+            if (sand) {
+                block = config->coast_block;
+            }
+
+            mountain[idx] = mountain[idx] + 0.05f + proximity_mountain - 1.0f;
+            if (mountain[idx] > 0.7f) {
+                block = config->mountain_block;
+            }
+
+            bool path = mountain[idx] > 0.7f && path_x[idx] > 0.8f;
+            if (path) {
+                block = config->path_block;
+            }
+
+            float path_y = path_x[craftax_wg_index(col, row)];
+            path = mountain[idx] > 0.7f && path_y > 0.8f;
+            if (path) {
+                block = config->path_block;
+            }
+
+            bool cave = mountain[idx] > 0.85f && water[idx] > 0.4f;
+            if (cave) {
+                block = config->inner_mountain_block;
+            }
+
+            float tree_draw = craftax_threefry_uniform_f32_at(tree_uniform_key, idx);
+            bool tree = tree_noise[idx] > config->tree_threshold_perlin
+                && tree_draw > config->tree_threshold_uniform;
+            if (tree && block == config->tree_requirement_block) {
+                block = config->tree;
+            }
+
+            map[row][col] = (uint8_t)block;
+            item_map[row][col] = CRAFTAX_WG_ITEM_NONE;
+            light_map[row][col] = (uint8_t)(config->default_light * 255.0f);
+        }
+    }
+
+    CraftaxThreefryKey ore_rng;
+    craftax_threefry_split(rng, &rng, &ore_rng);
+    for (int ore_index = 0; ore_index < 5; ore_index++) {
+        CraftaxThreefryKey ore_key;
+        craftax_threefry_split(ore_rng, &ore_rng, &ore_key);
+        for (int row = 0; row < size; row++) {
+            for (int col = 0; col < size; col++) {
+                size_t idx = craftax_wg_index(row, col);
+                bool is_ore = map[row][col] == config->ore_requirement_blocks[ore_index]
+                    && craftax_threefry_uniform_f32_at(ore_key, idx) < config->ore_chances[ore_index];
+                if (is_ore) {
+                    map[row][col] = (uint8_t)config->ores[ore_index];
+                }
+            }
+        }
+    }
+
+    for (int row = 0; row < size; row++) {
+        for (int col = 0; col < size; col++) {
+            size_t idx = craftax_wg_index(row, col);
+            lava_map[row][col] = mountain[idx] > 0.85f && tree_noise[idx] > 0.7f;
+            if (lava_map[row][col]) {
+                map[row][col] = (uint8_t)config->lava;
+            }
+        }
+    }
+
+    craftax_threefry_split(rng, &rng, &subkey);
+    bool valid_diamond[CRAFTAX_WG_MAP_CELLS];
+    for (int row = 0; row < size; row++) {
+        for (int col = 0; col < size; col++) {
+            valid_diamond[craftax_wg_index(row, col)] = map[row][col] == CRAFTAX_WG_BLOCK_STONE;
+        }
+    }
+    int diamond_index = craftax_choice_bool_flat(subkey, valid_diamond, (int)cells);
+    map[diamond_index / size][diamond_index % size] = (uint8_t)CRAFTAX_WG_BLOCK_STONE;
+
+    map[player_row][player_col] = (uint8_t)config->player_spawn;
+
+    bool valid_ladder[CRAFTAX_WG_MAP_CELLS];
+    for (int row = 0; row < size; row++) {
+        for (int col = 0; col < size; col++) {
+            valid_ladder[craftax_wg_index(row, col)] = map[row][col] == config->valid_ladder;
+        }
+    }
+
+    craftax_threefry_split(rng, &rng, &subkey);
+    int ladder_down_index = craftax_choice_bool_flat(subkey, valid_ladder, (int)cells);
+    ladder_down[0] = ladder_down_index / size;
+    ladder_down[1] = ladder_down_index % size;
+    if (config->ladder_down) {
+        item_map[ladder_down[0]][ladder_down[1]] = CRAFTAX_WG_ITEM_LADDER_DOWN;
+    }
+
+    craftax_threefry_split(rng, &rng, &subkey);
+    int ladder_up_index = craftax_choice_bool_flat(subkey, valid_ladder, (int)cells);
+    ladder_up[0] = ladder_up_index / size;
+    ladder_up[1] = ladder_up_index % size;
+
+    craftax_apply_ladder_light(light_map, ladder_up, config->default_light);
+    craftax_add_lava_light(light_map, lava_map, config->lava == CRAFTAX_WG_BLOCK_LAVA);
+
+    if (config->ladder_up) {
+        item_map[ladder_up[0]][ladder_up[1]] = CRAFTAX_WG_ITEM_LADDER_UP;
+    }
+}
+
+static inline void craftax_generate_smoothworld_floor(
+    CraftaxThreefryKey seed_key,
+    int floor_idx,
+    uint8_t map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t item_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    int32_t ladder_down[2],
+    int32_t ladder_up[2]
+) {
+    int config_idx = craftax_smooth_config_index_for_floor(floor_idx);
+    if (config_idx < 0) {
+        memset(map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(uint8_t));
+        memset(item_map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(uint8_t));
+        memset(light_map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(uint8_t));
+        ladder_down[0] = 0;
+        ladder_down[1] = 0;
+        ladder_up[0] = 0;
+        ladder_up[1] = 0;
+        return;
+    }
+    craftax_generate_smoothworld_config(
+        seed_key,
+        config_idx,
+        map,
+        item_map,
+        light_map,
+        ladder_down,
+        ladder_up
+    );
+}
+
+static inline void craftax_generate_dungeon_config(
+    CraftaxThreefryKey rng,
+    int config_idx,
+    uint8_t map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t item_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    int32_t ladder_down[2],
+    int32_t ladder_up[2]
+) {
+    const CraftaxDungeonConfig* config = &CRAFTAX_DUNGEON_CONFIGS[config_idx];
+    const int chunk_size = 16;
+    const int world_chunk_height = CRAFTAX_WG_MAP_SIZE / chunk_size;
+    const int num_rooms = 8;
+    const int min_room_size = 5;
+    const int max_room_size = 10;
+    const int padded_size = CRAFTAX_WG_MAP_SIZE + 2 * max_room_size;
+
+    uint8_t padded_map[68][68];
+    uint8_t padded_item_map[68][68];
+    bool room_occupancy_chunks[9];
+    int32_t room_sizes[8][2];
+    int32_t room_positions[8][2];
+
+    for (int row = 0; row < padded_size; row++) {
+        for (int col = 0; col < padded_size; col++) {
+            bool inner = row >= max_room_size
+                && row < max_room_size + CRAFTAX_WG_MAP_SIZE
+                && col >= max_room_size
+                && col < max_room_size + CRAFTAX_WG_MAP_SIZE;
+            padded_map[row][col] = inner ? CRAFTAX_WG_BLOCK_WALL : 0;
+            padded_item_map[row][col] = CRAFTAX_WG_ITEM_NONE;
+        }
+    }
+    for (int i = 0; i < 9; i++) {
+        room_occupancy_chunks[i] = true;
+    }
+
+    CraftaxThreefryKey room_scan_ignored_key;
+    CraftaxThreefryKey room_size_key;
+    craftax_threefry_split3(rng, &rng, &room_scan_ignored_key, &room_size_key);
+    (void)room_scan_ignored_key;
+    for (int room = 0; room < num_rooms; room++) {
+        room_sizes[room][0] = craftax_randint_i32_at(room_size_key, (uint64_t)room * 2u, min_room_size, max_room_size);
+        room_sizes[room][1] = craftax_randint_i32_at(room_size_key, (uint64_t)room * 2u + 1u, min_room_size, max_room_size);
+    }
+
+    CraftaxThreefryKey room_rng;
+    craftax_threefry_split(rng, &rng, &room_rng);
+
+    for (int room_index = 0; room_index < num_rooms; room_index++) {
+        CraftaxThreefryKey choice_key;
+        craftax_threefry_split(room_rng, &room_rng, &choice_key);
+        int room_chunk = craftax_choice_bool_flat(choice_key, room_occupancy_chunks, 9);
+        room_occupancy_chunks[room_chunk] = false;
+
+        int room_row = (room_chunk % world_chunk_height) * chunk_size + max_room_size;
+        int room_col = (room_chunk / world_chunk_height) * chunk_size + max_room_size;
+        CraftaxThreefryKey position_key;
+        craftax_threefry_split(room_rng, &room_rng, &position_key);
+        room_row += craftax_randint_i32_at(position_key, 0, 0, chunk_size - min_room_size);
+        room_col += craftax_randint_i32_at(position_key, 1, 0, chunk_size - min_room_size);
+        room_positions[room_index][0] = room_row;
+        room_positions[room_index][1] = room_col;
+
+        for (int row = 0; row < max_room_size; row++) {
+            for (int col = 0; col < max_room_size; col++) {
+                if (row < room_sizes[room_index][0] && col < room_sizes[room_index][1]) {
+                    padded_map[room_row + row][room_col + col] = CRAFTAX_WG_BLOCK_PATH;
+                }
+            }
+        }
+
+        padded_item_map[room_row][room_col] = CRAFTAX_WG_ITEM_TORCH;
+        padded_item_map[room_row + room_sizes[room_index][0] - 1][room_col] = CRAFTAX_WG_ITEM_TORCH;
+        padded_item_map[room_row][room_col + room_sizes[room_index][1] - 1] = CRAFTAX_WG_ITEM_TORCH;
+        padded_item_map[room_row + room_sizes[room_index][0] - 1][room_col + room_sizes[room_index][1] - 1] = CRAFTAX_WG_ITEM_TORCH;
+
+        CraftaxThreefryKey chest_key;
+        craftax_threefry_split(room_rng, &room_rng, &chest_key);
+        int chest_row = craftax_randint_i32_at(chest_key, 0, 1, room_sizes[room_index][0] - 1);
+        int chest_col = craftax_randint_i32_at(chest_key, 1, 1, room_sizes[room_index][1] - 1);
+        padded_map[room_row + chest_row][room_col + chest_col] = CRAFTAX_WG_BLOCK_CHEST;
+
+        CraftaxThreefryKey fountain_key;
+        CraftaxThreefryKey fountain_uniform_key;
+        craftax_threefry_split3(room_rng, &room_rng, &fountain_key, &fountain_uniform_key);
+        int fountain_row = craftax_randint_i32_at(fountain_key, 0, 1, room_sizes[room_index][0] - 1);
+        int fountain_col = craftax_randint_i32_at(fountain_key, 1, 1, room_sizes[room_index][1] - 1);
+        bool room_has_fountain = craftax_threefry_uniform_f32(fountain_uniform_key) > 0.5f;
+        if (room_has_fountain) {
+            padded_map[room_row + fountain_row][room_col + fountain_col] = config->fountain_block;
+        }
+    }
+
+    CraftaxThreefryKey path_rng;
+    craftax_threefry_split(rng, &rng, &path_rng);
+    bool included_rooms_mask[8] = {false, false, false, false, false, false, false, true};
+
+    for (int path_index = 0; path_index < num_rooms; path_index++) {
+        int source_row = room_positions[path_index][0];
+        int source_col = room_positions[path_index][1];
+
+        CraftaxThreefryKey sink_key;
+        craftax_threefry_split(path_rng, &path_rng, &sink_key);
+        int sink_index = craftax_choice_bool_flat(sink_key, included_rooms_mask, num_rooms);
+        int sink_row = room_positions[sink_index][0];
+        int sink_col = room_positions[sink_index][1];
+
+        int horizontal_distance = sink_col - source_col;
+        int horizontal_sign = (horizontal_distance > 0) - (horizontal_distance < 0);
+        if (horizontal_sign != 0) {
+            int abs_distance = horizontal_distance > 0 ? horizontal_distance : -horizontal_distance;
+            for (int col = 0; col < padded_size; col++) {
+                int path_index_col = (col - source_col) * horizontal_sign;
+                bool horizontal_mask = path_index_col >= 0
+                    && path_index_col <= abs_distance
+                    && padded_map[source_row][col] == CRAFTAX_WG_BLOCK_WALL;
+                if (horizontal_mask) {
+                    padded_map[source_row][col] = CRAFTAX_WG_BLOCK_PATH;
+                }
+            }
+        }
+
+        int vertical_distance = sink_row - source_row;
+        int vertical_sign = (vertical_distance > 0) - (vertical_distance < 0);
+        if (vertical_sign != 0) {
+            int abs_distance = vertical_distance > 0 ? vertical_distance : -vertical_distance;
+            for (int row = 0; row < padded_size; row++) {
+                int path_index_row = (row - source_row) * vertical_sign;
+                bool vertical_mask = path_index_row >= 0
+                    && path_index_row <= abs_distance
+                    && padded_map[row][sink_col] == CRAFTAX_WG_BLOCK_WALL;
+                if (vertical_mask) {
+                    padded_map[row][sink_col] = CRAFTAX_WG_BLOCK_PATH;
+                }
+            }
+        }
+
+        CraftaxThreefryKey unused_left;
+        CraftaxThreefryKey next_path_rng;
+        craftax_threefry_split(path_rng, &unused_left, &next_path_rng);
+        path_rng = next_path_rng;
+        included_rooms_mask[path_index] = true;
+    }
+
+    int special_row = room_positions[0][0] + 2;
+    int special_col = room_positions[0][1] + 2;
+    padded_map[special_row][special_col] = config->special_block;
+
+    for (int row = 0; row < CRAFTAX_WG_MAP_SIZE; row++) {
+        for (int col = 0; col < CRAFTAX_WG_MAP_SIZE; col++) {
+            map[row][col] = padded_map[row + max_room_size][col + max_room_size];
+            item_map[row][col] = padded_item_map[row + max_room_size][col + max_room_size];
+        }
+    }
+
+    bool adjacent_path[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE];
+    for (int row = 0; row < CRAFTAX_WG_MAP_SIZE; row++) {
+        for (int col = 0; col < CRAFTAX_WG_MAP_SIZE; col++) {
+            bool adjacent = map[row][col] != CRAFTAX_WG_BLOCK_WALL;
+            adjacent = adjacent || (row > 0 && map[row - 1][col] != CRAFTAX_WG_BLOCK_WALL);
+            adjacent = adjacent || (row + 1 < CRAFTAX_WG_MAP_SIZE && map[row + 1][col] != CRAFTAX_WG_BLOCK_WALL);
+            adjacent = adjacent || (col > 0 && map[row][col - 1] != CRAFTAX_WG_BLOCK_WALL);
+            adjacent = adjacent || (col + 1 < CRAFTAX_WG_MAP_SIZE && map[row][col + 1] != CRAFTAX_WG_BLOCK_WALL);
+            adjacent_path[row][col] = adjacent;
+        }
+    }
+
+    CraftaxThreefryKey rare_key;
+    craftax_threefry_split(rng, &rng, &rare_key);
+    for (int row = 0; row < CRAFTAX_WG_MAP_SIZE; row++) {
+        for (int col = 0; col < CRAFTAX_WG_MAP_SIZE; col++) {
+            size_t idx = craftax_wg_index(row, col);
+            bool rare = (1.0f - craftax_threefry_uniform_f32_at(rare_key, idx)) > 0.9f;
+            int32_t wall_map = rare ? CRAFTAX_WG_BLOCK_WALL_MOSS : CRAFTAX_WG_BLOCK_WALL;
+            bool rare_path = rare && map[row][col] == CRAFTAX_WG_BLOCK_PATH && item_map[row][col] == CRAFTAX_WG_ITEM_NONE;
+            int32_t path_map = rare_path ? config->rare_path_replacement_block : map[row][col];
+            bool is_wall_map = map[row][col] == CRAFTAX_WG_BLOCK_WALL && adjacent_path[row][col];
+            bool is_darkness_map = !adjacent_path[row][col];
+
+            if (is_darkness_map) {
+                map[row][col] = CRAFTAX_WG_BLOCK_DARKNESS;
+            } else if (is_wall_map) {
+                map[row][col] = wall_map;
+            } else {
+                map[row][col] = path_map;
+            }
+            light_map[row][col] = 255;
+        }
+    }
+
+    bool valid_ladder[CRAFTAX_WG_MAP_CELLS];
+    for (int row = 0; row < CRAFTAX_WG_MAP_SIZE; row++) {
+        for (int col = 0; col < CRAFTAX_WG_MAP_SIZE; col++) {
+            valid_ladder[craftax_wg_index(row, col)] = map[row][col] == CRAFTAX_WG_BLOCK_PATH;
+        }
+    }
+
+    CraftaxThreefryKey ladder_down_key;
+    craftax_threefry_split(rng, &rng, &ladder_down_key);
+    int ladder_down_index = craftax_choice_bool_flat(ladder_down_key, valid_ladder, CRAFTAX_WG_MAP_CELLS);
+    ladder_down[0] = ladder_down_index / CRAFTAX_WG_MAP_SIZE;
+    ladder_down[1] = ladder_down_index % CRAFTAX_WG_MAP_SIZE;
+    item_map[ladder_down[0]][ladder_down[1]] = CRAFTAX_WG_ITEM_LADDER_DOWN;
+
+    CraftaxThreefryKey ladder_up_key;
+    craftax_threefry_split(rng, &rng, &ladder_up_key);
+    int ladder_up_index = craftax_choice_bool_flat(ladder_up_key, valid_ladder, CRAFTAX_WG_MAP_CELLS);
+    ladder_up[0] = ladder_up_index / CRAFTAX_WG_MAP_SIZE;
+    ladder_up[1] = ladder_up_index % CRAFTAX_WG_MAP_SIZE;
+    item_map[ladder_up[0]][ladder_up[1]] = CRAFTAX_WG_ITEM_LADDER_UP;
+}
+
+static inline void craftax_generate_dungeon_floor(
+    CraftaxThreefryKey seed_key,
+    int floor_idx,
+    uint8_t map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t item_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    int32_t ladder_down[2],
+    int32_t ladder_up[2]
+) {
+    int config_idx = craftax_dungeon_config_index_for_floor(floor_idx);
+    if (config_idx < 0) {
+        memset(map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(uint8_t));
+        memset(item_map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(uint8_t));
+        memset(light_map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(uint8_t));
+        ladder_down[0] = 0;
+        ladder_down[1] = 0;
+        ladder_up[0] = 0;
+        ladder_up[1] = 0;
+        return;
+    }
+    craftax_generate_dungeon_config(
+        seed_key,
+        config_idx,
+        map,
+        item_map,
+        light_map,
+        ladder_down,
+        ladder_up
+    );
+}
+
+static inline void craftax_permutation_6(CraftaxThreefryKey key, int32_t out[6]) {
+    CraftaxThreefryKey carry;
+    CraftaxThreefryKey sort_key;
+    craftax_threefry_split(key, &carry, &sort_key);
+    (void)carry;
+
+    uint32_t keys[6];
+    for (int i = 0; i < 6; i++) {
+        keys[i] = craftax_threefry_uniform_u32_at(sort_key, (uint64_t)i);
+        out[i] = i;
+    }
+
+    for (int i = 1; i < 6; i++) {
+        uint32_t key_value = keys[i];
+        int32_t value = out[i];
+        int j = i - 1;
+        while (j >= 0 && keys[j] > key_value) {
+            keys[j + 1] = keys[j];
+            out[j + 1] = out[j];
+            j--;
+        }
+        keys[j + 1] = key_value;
+        out[j + 1] = value;
+    }
+}
+
+static inline float craftax_calculate_initial_light_level(void) {
+    float progress = 0.3f;
+    float c = cosf(CRAFTAX_WG_PI * progress);
+    return 1.0f - powf(fabsf(c), 3.0f);
+}
+
+static inline void craftax_init_empty_mobs3(CraftaxWGMobs3* mobs) {
+    for (int level = 0; level < CRAFTAX_WG_NUM_LEVELS; level++) {
+        for (int mob = 0; mob < 3; mob++) {
+            mobs->health[level][mob] = 1.0f;
+        }
+    }
+}
+
+static inline void craftax_init_empty_mobs2(CraftaxWGMobs2* mobs) {
+    for (int level = 0; level < CRAFTAX_WG_NUM_LEVELS; level++) {
+        for (int mob = 0; mob < 2; mob++) {
+            mobs->health[level][mob] = 1.0f;
+        }
+    }
+}
+
+static inline void craftax_generate_world_from_key(
+    CraftaxThreefryKey rng,
+    CraftaxWorldState* out
+) {
+    memset(out, 0, sizeof(*out));
+
+    CraftaxThreefryKey smooth_split[7];
+    craftax_threefry_split_n(rng, smooth_split, 7);
+    rng = smooth_split[0];
+
+    static const int smooth_floor_order[6] = {0, 2, 5, 6, 7, 8};
+    for (int i = 0; i < 6; i++) {
+        int level = smooth_floor_order[i];
+        craftax_generate_smoothworld_config(
+            smooth_split[i + 1],
+            i,
+            out->map[level],
+            out->item_map[level],
+            out->light_map[level],
+            out->down_ladders[level],
+            out->up_ladders[level]
+        );
+    }
+
+    CraftaxThreefryKey dungeon_split[4];
+    craftax_threefry_split_n(rng, dungeon_split, 4);
+    rng = dungeon_split[0];
+
+    static const int dungeon_floor_order[3] = {1, 3, 4};
+    for (int i = 0; i < 3; i++) {
+        int level = dungeon_floor_order[i];
+        craftax_generate_dungeon_config(
+            dungeon_split[i + 1],
+            i,
+            out->map[level],
+            out->item_map[level],
+            out->light_map[level],
+            out->down_ladders[level],
+            out->up_ladders[level]
+        );
+    }
+
+    craftax_init_empty_mobs3(&out->melee_mobs);
+    craftax_init_empty_mobs3(&out->passive_mobs);
+    craftax_init_empty_mobs2(&out->ranged_mobs);
+    craftax_init_empty_mobs3(&out->mob_projectiles);
+    craftax_init_empty_mobs3(&out->player_projectiles);
+    for (int level = 0; level < CRAFTAX_WG_NUM_LEVELS; level++) {
+        for (int projectile = 0; projectile < CRAFTAX_WG_MAX_MOB_PROJECTILES; projectile++) {
+            out->mob_projectile_directions[level][projectile][0] = 1;
+            out->mob_projectile_directions[level][projectile][1] = 1;
+        }
+        for (int projectile = 0; projectile < CRAFTAX_WG_MAX_PLAYER_PROJECTILES; projectile++) {
+            out->player_projectile_directions[level][projectile][0] = 1;
+            out->player_projectile_directions[level][projectile][1] = 1;
+        }
+    }
+
+    CraftaxThreefryKey potion_key;
+    craftax_threefry_split(rng, &rng, &potion_key);
+    craftax_permutation_6(potion_key, out->potion_mapping);
+
+    CraftaxThreefryKey state_key;
+    craftax_threefry_split(rng, &rng, &state_key);
+    (void)rng;
+    out->state_rng[0] = state_key.word[0];
+    out->state_rng[1] = state_key.word[1];
+
+    out->monsters_killed[0] = 10;
+    out->player_position[0] = CRAFTAX_WG_MAP_SIZE / 2;
+    out->player_position[1] = CRAFTAX_WG_MAP_SIZE / 2;
+    out->player_level = 0;
+    out->player_direction = CRAFTAX_WG_ACTION_UP;
+    out->player_health = 9.0f;
+    out->player_food = 9;
+    out->player_drink = 9;
+    out->player_energy = 9;
+    out->player_mana = 9;
+    out->player_dexterity = 1;
+    out->player_strength = 1;
+    out->player_intelligence = 1;
+    out->boss_timesteps_to_spawn_this_round = CRAFTAX_WG_BOSS_FIGHT_SPAWN_TURNS;
+    out->light_level = craftax_calculate_initial_light_level();
+}
+
+static inline void craftax_generate_world_from_seed(
+    uint32_t seed,
+    CraftaxWorldState* out
+) {
+    craftax_generate_world_from_key(craftax_worldgen_key_from_seed(seed), out);
+}
+
+static inline void craftax_generate_overworld_from_rng(
+    CraftaxThreefryKey rng,
+    CraftaxOverworldFloor* out
+) {
+    craftax_generate_smoothworld_config(
+        rng,
+        0,
+        out->map,
+        out->item_map,
+        out->light_map,
+        out->ladder_down,
+        out->ladder_up
+    );
+}
+
+static inline void craftax_generate_overworld_from_seed(
+    uint32_t seed,
+    CraftaxOverworldFloor* out
+) {
+    craftax_generate_overworld_from_rng(craftax_overworld_rng_from_seed(seed), out);
+}
+
+static inline int craftax_wg_jax_index(int32_t index, int32_t size) {
+    if (index < 0) {
+        index += size;
+    }
+    if (index < 0) {
+        return 0;
+    }
+    if (index >= size) {
+        return size - 1;
+    }
+    return index;
+}
+
+static inline bool craftax_wg_scatter_index(
+    int32_t index,
+    int32_t size,
+    int* mapped_index
+) {
+    if (index < -size || index >= size) {
+        return false;
+    }
+    *mapped_index = index < 0 ? index + size : index;
+    return true;
+}
+
+static inline bool craftax_wg_is_boss_vulnerable(
+    const CraftaxWorldState* state
+) {
+    int level = craftax_wg_jax_index(state->player_level, CRAFTAX_WG_NUM_LEVELS);
+    bool has_melee = false;
+    bool has_ranged = false;
+    for (int i = 0; i < CRAFTAX_WG_MAX_MELEE_MOBS; i++) {
+        has_melee = has_melee || state->melee_mobs.mask[level][i];
+    }
+    for (int i = 0; i < CRAFTAX_WG_MAX_RANGED_MOBS; i++) {
+        has_ranged = has_ranged || state->ranged_mobs.mask[level][i];
+    }
+    return !has_melee
+        && !has_ranged
+        && state->boss_timesteps_to_spawn_this_round <= 0;
+}
+
+static inline void craftax_encode_mobs3_observation(
+    const CraftaxWorldState* state,
+    const CraftaxWGMobs3* mobs,
+    int mob_class_index,
+    int channels,
+    int mob_channels_offset,
+    float* obs
+) {
+    int level = craftax_wg_jax_index(state->player_level, CRAFTAX_WG_NUM_LEVELS);
+    for (int i = 0; i < 3; i++) {
+        int local_row = mobs->position[level][i][0]
+            - state->player_position[0]
+            + CRAFTAX_WG_OBS_ROWS / 2;
+        int local_col = mobs->position[level][i][1]
+            - state->player_position[1]
+            + CRAFTAX_WG_OBS_COLS / 2;
+        int type_id = mobs->type_id[level][i];
+        int scatter_row;
+        int scatter_col;
+        if (!craftax_wg_scatter_index(
+                local_row,
+                CRAFTAX_WG_OBS_ROWS,
+                &scatter_row
+            )
+            || !craftax_wg_scatter_index(
+                local_col,
+                CRAFTAX_WG_OBS_COLS,
+                &scatter_col
+            )
+            || type_id < 0
+            || type_id >= CRAFTAX_WG_NUM_MOB_TYPES) {
+            continue;
+        }
+
+        bool on_screen = local_row >= 0
+            && local_row < CRAFTAX_WG_OBS_ROWS
+            && local_col >= 0
+            && local_col < CRAFTAX_WG_OBS_COLS;
+        int world_row = mobs->position[level][i][0];
+        int world_col = mobs->position[level][i][1];
+        bool in_bounds = world_row >= 0
+            && world_row < CRAFTAX_WG_MAP_SIZE
+            && world_col >= 0
+            && world_col < CRAFTAX_WG_MAP_SIZE;
+        bool visible = in_bounds && state->light_map[level][world_row][world_col] > 12;
+        int obs_base = (scatter_row * CRAFTAX_WG_OBS_COLS + scatter_col) * channels;
+        int channel = mob_channels_offset
+            + mob_class_index * CRAFTAX_WG_NUM_MOB_TYPES
+            + type_id;
+        obs[obs_base + channel] =
+            mobs->mask[level][i] && on_screen && visible ? 1.0f : 0.0f;
+    }
+}
+
+static inline void craftax_encode_mobs2_observation(
+    const CraftaxWorldState* state,
+    const CraftaxWGMobs2* mobs,
+    int mob_class_index,
+    int channels,
+    int mob_channels_offset,
+    float* obs
+) {
+    int level = craftax_wg_jax_index(state->player_level, CRAFTAX_WG_NUM_LEVELS);
+    for (int i = 0; i < 2; i++) {
+        int local_row = mobs->position[level][i][0]
+            - state->player_position[0]
+            + CRAFTAX_WG_OBS_ROWS / 2;
+        int local_col = mobs->position[level][i][1]
+            - state->player_position[1]
+            + CRAFTAX_WG_OBS_COLS / 2;
+        int type_id = mobs->type_id[level][i];
+        int scatter_row;
+        int scatter_col;
+        if (!craftax_wg_scatter_index(
+                local_row,
+                CRAFTAX_WG_OBS_ROWS,
+                &scatter_row
+            )
+            || !craftax_wg_scatter_index(
+                local_col,
+                CRAFTAX_WG_OBS_COLS,
+                &scatter_col
+            )
+            || type_id < 0
+            || type_id >= CRAFTAX_WG_NUM_MOB_TYPES) {
+            continue;
+        }
+
+        bool on_screen = local_row >= 0
+            && local_row < CRAFTAX_WG_OBS_ROWS
+            && local_col >= 0
+            && local_col < CRAFTAX_WG_OBS_COLS;
+        int world_row = mobs->position[level][i][0];
+        int world_col = mobs->position[level][i][1];
+        bool in_bounds = world_row >= 0
+            && world_row < CRAFTAX_WG_MAP_SIZE
+            && world_col >= 0
+            && world_col < CRAFTAX_WG_MAP_SIZE;
+        bool visible = in_bounds && state->light_map[level][world_row][world_col] > 12;
+        int obs_base = (scatter_row * CRAFTAX_WG_OBS_COLS + scatter_col) * channels;
+        int channel = mob_channels_offset
+            + mob_class_index * CRAFTAX_WG_NUM_MOB_TYPES
+            + type_id;
+        obs[obs_base + channel] =
+            mobs->mask[level][i] && on_screen && visible ? 1.0f : 0.0f;
+    }
+}
+
+static inline void craftax_write_binary_bits(
+    float* obs,
+    int base,
+    int value,
+    int num_bits
+) {
+    if (num_bits == 6) {
+        memcpy(obs + base, CRAFTAX_WG_BLOCK_LUT[value], 6 * sizeof(float));
+    } else if (num_bits == 3) {
+        memcpy(obs + base, CRAFTAX_WG_ITEM_LUT[value], 3 * sizeof(float));
+    } else if (num_bits == 4) {
+        memcpy(obs + base, CRAFTAX_WG_MOB_LUT[value], 4 * sizeof(float));
+    } else {
+        for (int i = 0; i < num_bits; i++) {
+            obs[base + i] = (value & (1 << i)) ? 1.0f : 0.0f;
+        }
+    }
+}
+
+static inline void craftax_encode_mobs3_binary(
+    const CraftaxWorldState* state,
+    const CraftaxWGMobs3* mobs,
+    int mob_class_index,
+    int channels_per_cell,
+    int mob_bits_offset,
+    float* obs
+) {
+    int level = craftax_wg_jax_index(state->player_level, CRAFTAX_WG_NUM_LEVELS);
+    for (int i = 0; i < 3; i++) {
+        int type_id = mobs->type_id[level][i];
+        if (type_id < 0 || type_id >= CRAFTAX_WG_NUM_MOB_TYPES
+            || !mobs->mask[level][i]) {
+            continue;
+        }
+
+        int local_row = mobs->position[level][i][0]
+            - state->player_position[0]
+            + CRAFTAX_WG_OBS_ROWS / 2;
+        int local_col = mobs->position[level][i][1]
+            - state->player_position[1]
+            + CRAFTAX_WG_OBS_COLS / 2;
+        if (local_row < 0 || local_row >= CRAFTAX_WG_OBS_ROWS
+            || local_col < 0 || local_col >= CRAFTAX_WG_OBS_COLS) {
+            continue;
+        }
+
+        int world_row = mobs->position[level][i][0];
+        int world_col = mobs->position[level][i][1];
+        if (world_row < 0 || world_row >= CRAFTAX_WG_MAP_SIZE
+            || world_col < 0 || world_col >= CRAFTAX_WG_MAP_SIZE
+            || state->light_map[level][world_row][world_col] <= 12) {
+            continue;
+        }
+
+        int obs_base = (local_row * CRAFTAX_WG_OBS_COLS + local_col)
+            * channels_per_cell;
+        int class_offset = mob_bits_offset
+            + mob_class_index * CRAFTAX_WG_BINARY_MOB_BITS;
+        memcpy(obs + obs_base + class_offset,
+               CRAFTAX_WG_MOB_LUT[type_id + 1],
+               CRAFTAX_WG_BINARY_MOB_BITS * sizeof(float));
+    }
+}
+
+static inline void craftax_encode_mobs2_binary(
+    const CraftaxWorldState* state,
+    const CraftaxWGMobs2* mobs,
+    int mob_class_index,
+    int channels_per_cell,
+    int mob_bits_offset,
+    float* obs
+) {
+    int level = craftax_wg_jax_index(state->player_level, CRAFTAX_WG_NUM_LEVELS);
+    for (int i = 0; i < 2; i++) {
+        int type_id = mobs->type_id[level][i];
+        if (type_id < 0 || type_id >= CRAFTAX_WG_NUM_MOB_TYPES
+            || !mobs->mask[level][i]) {
+            continue;
+        }
+
+        int local_row = mobs->position[level][i][0]
+            - state->player_position[0]
+            + CRAFTAX_WG_OBS_ROWS / 2;
+        int local_col = mobs->position[level][i][1]
+            - state->player_position[1]
+            + CRAFTAX_WG_OBS_COLS / 2;
+        if (local_row < 0 || local_row >= CRAFTAX_WG_OBS_ROWS
+            || local_col < 0 || local_col >= CRAFTAX_WG_OBS_COLS) {
+            continue;
+        }
+
+        int world_row = mobs->position[level][i][0];
+        int world_col = mobs->position[level][i][1];
+        if (world_row < 0 || world_row >= CRAFTAX_WG_MAP_SIZE
+            || world_col < 0 || world_col >= CRAFTAX_WG_MAP_SIZE
+            || state->light_map[level][world_row][world_col] <= 12) {
+            continue;
+        }
+
+        int obs_base = (local_row * CRAFTAX_WG_OBS_COLS + local_col)
+            * channels_per_cell;
+        int class_offset = mob_bits_offset
+            + mob_class_index * CRAFTAX_WG_BINARY_MOB_BITS;
+        memcpy(obs + obs_base + class_offset,
+               CRAFTAX_WG_MOB_LUT[type_id + 1],
+               CRAFTAX_WG_BINARY_MOB_BITS * sizeof(float));
+    }
+}
+
+static inline void craftax_encode_map_base_observation(
+    const CraftaxWorldState* state,
+    float* obs
+) {
+    const int channels = CRAFTAX_WG_BINARY_CHANNELS_PER_CELL;
+    const int top = state->player_position[0] - CRAFTAX_WG_OBS_ROWS / 2;
+    const int left = state->player_position[1] - CRAFTAX_WG_OBS_COLS / 2;
+    const int level = state->player_level;
+    const float* empty_cell = CRAFTAX_WG_EMPTY_CELL_TEMPLATE;
+
+    for (int row = 0; row < CRAFTAX_WG_OBS_ROWS; row++) {
+        int world_row = top + row;
+        bool row_in_bounds = world_row >= 0 && world_row < CRAFTAX_WG_MAP_SIZE;
+        for (int col = 0; col < CRAFTAX_WG_OBS_COLS; col++) {
+            int world_col = left + col;
+            int obs_base = (row * CRAFTAX_WG_OBS_COLS + col) * channels;
+            const float* cell = empty_cell;
+
+            if (row_in_bounds && world_col >= 0 && world_col < CRAFTAX_WG_MAP_SIZE
+                && state->light_map[level][world_row][world_col] > 12) {
+                uint8_t block = state->map[level][world_row][world_col];
+                uint8_t item = state->item_map[level][world_row][world_col];
+                cell = CRAFTAX_WG_VISIBLE_CELL_TEMPLATE_LUT[block][item + 1];
+            }
+
+            memcpy(obs + obs_base, cell, CRAFTAX_WG_CELL_TEMPLATE_BYTES);
+        }
+    }
+}
+
+static inline void craftax_encode_packed_map_base_observation(
+    const CraftaxWorldState* state,
+    float* obs
+) {
+    const int channels = CRAFTAX_WG_PACKED_CHANNELS_PER_CELL;
+    const int top = state->player_position[0] - CRAFTAX_WG_OBS_ROWS / 2;
+    const int left = state->player_position[1] - CRAFTAX_WG_OBS_COLS / 2;
+    const int level = state->player_level;
+
+    memset(obs, 0, CRAFTAX_WG_PACKED_MAP_OBS_SIZE * sizeof(float));
+    for (int row = 0; row < CRAFTAX_WG_OBS_ROWS; row++) {
+        int world_row = top + row;
+        bool row_in_bounds = world_row >= 0 && world_row < CRAFTAX_WG_MAP_SIZE;
+        for (int col = 0; col < CRAFTAX_WG_OBS_COLS; col++) {
+            int world_col = left + col;
+            int obs_base = (row * CRAFTAX_WG_OBS_COLS + col) * channels;
+            if (row_in_bounds && world_col >= 0 && world_col < CRAFTAX_WG_MAP_SIZE
+                && state->light_map[level][world_row][world_col] > 12) {
+                obs[obs_base + 0] = (float)state->map[level][world_row][world_col];
+                obs[obs_base + 1] = (float)state->item_map[level][world_row][world_col] + 1.0f;
+                obs[obs_base + 2] = 1.0f;
+            }
+        }
+    }
+}
+
+static inline void craftax_clear_mob_channels_observation(float* obs) {
+    const int channels = CRAFTAX_WG_BINARY_CHANNELS_PER_CELL;
+    const int mob_bits_offset = CRAFTAX_WG_BINARY_BLOCK_BITS + CRAFTAX_WG_BINARY_ITEM_BITS;
+    const size_t mob_channel_bytes =
+        CRAFTAX_WG_NUM_MOB_CLASSES * CRAFTAX_WG_BINARY_MOB_BITS * sizeof(float);
+
+    for (int cell = 0; cell < CRAFTAX_WG_OBS_WINDOW_CELLS; cell++) {
+        memset(obs + cell * channels + mob_bits_offset, 0, mob_channel_bytes);
+    }
+}
+
+static inline void craftax_encode_mobs3_packed(
+    const CraftaxWorldState* state,
+    const CraftaxWGMobs3* mobs,
+    int mob_class_index,
+    float* obs
+) {
+    const int level = craftax_wg_jax_index(state->player_level, CRAFTAX_WG_NUM_LEVELS);
+    const int mob_slot_offset = 3 + mob_class_index;
+    for (int i = 0; i < 3; i++) {
+        int type_id = mobs->type_id[level][i];
+        if (type_id < 0 || type_id >= CRAFTAX_WG_NUM_MOB_TYPES
+            || !mobs->mask[level][i]) {
+            continue;
+        }
+
+        int local_row = mobs->position[level][i][0]
+            - state->player_position[0]
+            + CRAFTAX_WG_OBS_ROWS / 2;
+        int local_col = mobs->position[level][i][1]
+            - state->player_position[1]
+            + CRAFTAX_WG_OBS_COLS / 2;
+        if (local_row < 0 || local_row >= CRAFTAX_WG_OBS_ROWS
+            || local_col < 0 || local_col >= CRAFTAX_WG_OBS_COLS) {
+            continue;
+        }
+
+        int world_row = mobs->position[level][i][0];
+        int world_col = mobs->position[level][i][1];
+        if (world_row < 0 || world_row >= CRAFTAX_WG_MAP_SIZE
+            || world_col < 0 || world_col >= CRAFTAX_WG_MAP_SIZE
+            || state->light_map[level][world_row][world_col] <= 12) {
+            continue;
+        }
+
+        int obs_base = (local_row * CRAFTAX_WG_OBS_COLS + local_col)
+            * CRAFTAX_WG_PACKED_CHANNELS_PER_CELL;
+        obs[obs_base + mob_slot_offset] = (float)(type_id + 1);
+    }
+}
+
+static inline void craftax_encode_mobs2_packed(
+    const CraftaxWorldState* state,
+    const CraftaxWGMobs2* mobs,
+    int mob_class_index,
+    float* obs
+) {
+    const int level = craftax_wg_jax_index(state->player_level, CRAFTAX_WG_NUM_LEVELS);
+    const int mob_slot_offset = 3 + mob_class_index;
+    for (int i = 0; i < 2; i++) {
+        int type_id = mobs->type_id[level][i];
+        if (type_id < 0 || type_id >= CRAFTAX_WG_NUM_MOB_TYPES
+            || !mobs->mask[level][i]) {
+            continue;
+        }
+
+        int local_row = mobs->position[level][i][0]
+            - state->player_position[0]
+            + CRAFTAX_WG_OBS_ROWS / 2;
+        int local_col = mobs->position[level][i][1]
+            - state->player_position[1]
+            + CRAFTAX_WG_OBS_COLS / 2;
+        if (local_row < 0 || local_row >= CRAFTAX_WG_OBS_ROWS
+            || local_col < 0 || local_col >= CRAFTAX_WG_OBS_COLS) {
+            continue;
+        }
+
+        int world_row = mobs->position[level][i][0];
+        int world_col = mobs->position[level][i][1];
+        if (world_row < 0 || world_row >= CRAFTAX_WG_MAP_SIZE
+            || world_col < 0 || world_col >= CRAFTAX_WG_MAP_SIZE
+            || state->light_map[level][world_row][world_col] <= 12) {
+            continue;
+        }
+
+        int obs_base = (local_row * CRAFTAX_WG_OBS_COLS + local_col)
+            * CRAFTAX_WG_PACKED_CHANNELS_PER_CELL;
+        obs[obs_base + mob_slot_offset] = (float)(type_id + 1);
+    }
+}
+
+static inline void craftax_encode_packed_mobs_observation(
+    const CraftaxWorldState* state,
+    float* obs
+) {
+    craftax_encode_mobs3_packed(state, &state->melee_mobs, 0, obs);
+    craftax_encode_mobs3_packed(state, &state->passive_mobs, 1, obs);
+    craftax_encode_mobs2_packed(state, &state->ranged_mobs, 2, obs);
+    craftax_encode_mobs3_packed(state, &state->mob_projectiles, 3, obs);
+    craftax_encode_mobs3_packed(state, &state->player_projectiles, 4, obs);
+}
+
+static inline void craftax_encode_mobs_observation(
+    const CraftaxWorldState* state,
+    float* obs
+) {
+    const int channels = CRAFTAX_WG_BINARY_CHANNELS_PER_CELL;
+    const int mob_bits_offset = CRAFTAX_WG_BINARY_BLOCK_BITS + CRAFTAX_WG_BINARY_ITEM_BITS;
+
+    craftax_encode_mobs3_binary(
+        state,
+        &state->melee_mobs,
+        0,
+        channels,
+        mob_bits_offset,
+        obs
+    );
+    craftax_encode_mobs3_binary(
+        state,
+        &state->passive_mobs,
+        1,
+        channels,
+        mob_bits_offset,
+        obs
+    );
+    craftax_encode_mobs2_binary(
+        state,
+        &state->ranged_mobs,
+        2,
+        channels,
+        mob_bits_offset,
+        obs
+    );
+    craftax_encode_mobs3_binary(
+        state,
+        &state->mob_projectiles,
+        3,
+        channels,
+        mob_bits_offset,
+        obs
+    );
+    craftax_encode_mobs3_binary(
+        state,
+        &state->player_projectiles,
+        4,
+        channels,
+        mob_bits_offset,
+        obs
+    );
+}
+
+static inline void craftax_encode_scalar_observation_tail_at(
+    const CraftaxWorldState* state,
+    float* obs,
+    int index
+) {
+    const int level = state->player_level;
+    obs[index++] = sqrtf((float)state->inventory.wood) / 10.0f;
+    obs[index++] = sqrtf((float)state->inventory.stone) / 10.0f;
+    obs[index++] = sqrtf((float)state->inventory.coal) / 10.0f;
+    obs[index++] = sqrtf((float)state->inventory.iron) / 10.0f;
+    obs[index++] = sqrtf((float)state->inventory.diamond) / 10.0f;
+    obs[index++] = sqrtf((float)state->inventory.sapphire) / 10.0f;
+    obs[index++] = sqrtf((float)state->inventory.ruby) / 10.0f;
+    obs[index++] = sqrtf((float)state->inventory.sapling) / 10.0f;
+    obs[index++] = sqrtf((float)state->inventory.torches) / 10.0f;
+    obs[index++] = sqrtf((float)state->inventory.arrows) / 10.0f;
+    obs[index++] = (float)state->inventory.books / 2.0f;
+    obs[index++] = (float)state->inventory.pickaxe / 4.0f;
+    obs[index++] = (float)state->inventory.sword / 4.0f;
+    obs[index++] = (float)state->sword_enchantment;
+    obs[index++] = (float)state->bow_enchantment;
+    obs[index++] = (float)state->inventory.bow;
+
+    for (int i = 0; i < 6; i++) {
+        obs[index++] = sqrtf((float)state->inventory.potions[i]) / 10.0f;
+    }
+
+    obs[index++] = state->player_health / 10.0f;
+    obs[index++] = (float)state->player_food / 10.0f;
+    obs[index++] = (float)state->player_drink / 10.0f;
+    obs[index++] = (float)state->player_energy / 10.0f;
+    obs[index++] = (float)state->player_mana / 10.0f;
+    obs[index++] = (float)state->player_xp / 10.0f;
+    obs[index++] = (float)state->player_dexterity / 10.0f;
+    obs[index++] = (float)state->player_strength / 10.0f;
+    obs[index++] = (float)state->player_intelligence / 10.0f;
+
+    int direction_index = state->player_direction - 1;
+    for (int i = 0; i < 4; i++) {
+        obs[index++] = i == direction_index ? 1.0f : 0.0f;
+    }
+
+    for (int i = 0; i < 4; i++) {
+        obs[index++] = (float)state->inventory.armour[i] / 2.0f;
+    }
+    for (int i = 0; i < 4; i++) {
+        obs[index++] = (float)state->armour_enchantments[i];
+    }
+
+    obs[index++] = state->light_level;
+    obs[index++] = state->is_sleeping ? 1.0f : 0.0f;
+    obs[index++] = state->is_resting ? 1.0f : 0.0f;
+    obs[index++] = state->learned_spells[0] ? 1.0f : 0.0f;
+    obs[index++] = state->learned_spells[1] ? 1.0f : 0.0f;
+    obs[index++] = (float)state->player_level / 10.0f;
+    obs[index++] = state->monsters_killed[level] >= CRAFTAX_WG_MONSTERS_KILLED_TO_CLEAR_LEVEL ? 1.0f : 0.0f;
+    obs[index++] = craftax_wg_is_boss_vulnerable(state) ? 1.0f : 0.0f;
+}
+
+static inline void craftax_encode_scalar_observation_tail(
+    const CraftaxWorldState* state,
+    float* obs
+) {
+    craftax_encode_scalar_observation_tail_at(state, obs, CRAFTAX_WG_BINARY_MAP_OBS_SIZE);
+}
+
+static inline void craftax_encode_reset_observation(
+    const CraftaxWorldState* state,
+    float* obs
+) {
+    craftax_encode_packed_map_base_observation(state, obs);
+    craftax_encode_packed_mobs_observation(state, obs);
+    craftax_encode_scalar_observation_tail_at(state, obs, CRAFTAX_WG_PACKED_MAP_OBS_SIZE);
+}

--- a/src/vecenv.h
+++ b/src/vecenv.h
@@ -603,6 +603,12 @@ int get_num_act_sizes(void) { return (int)(sizeof(_act_sizes) / sizeof(_act_size
 const char* get_obs_dtype(void) { return dtype_symbol; }
 size_t get_obs_elem_size(void) { return obs_element_size(); }
 
+#ifdef MY_VEC_STEP
+void MY_VEC_STEP(StaticVec* vec);
+static inline void _static_vec_env_step(StaticVec* vec) {
+    MY_VEC_STEP(vec);
+}
+#else
 static inline void _static_vec_env_step(StaticVec* vec) {
     memset(vec->rewards, 0, vec->total_agents * sizeof(float));
     memset(vec->terminals, 0, vec->total_agents * sizeof(float));
@@ -612,6 +618,7 @@ static inline void _static_vec_env_step(StaticVec* vec) {
         c_step(&envs[i]);
     }
 }
+#endif
 
 void gpu_vec_step(StaticVec* vec) {
     assert(vec->buffers == 1);

--- a/src/vecenv.h
+++ b/src/vecenv.h
@@ -192,6 +192,9 @@ extern const char* cudaGetErrorString(cudaError_t);
 void my_init(Env* env, Dict* kwargs);
 void my_log(Log* log, Dict* out);
 
+#ifdef MY_VEC_STEP_RANGE
+void MY_VEC_STEP_RANGE(StaticVec* vec, int env_start, int env_count, int num_workers);
+#endif
 
 struct StaticThreading {
     atomic_int* buffer_states;
@@ -234,8 +237,6 @@ static void* static_omp_threadmanager(void* arg) {
     int num_workers = threading->num_threads / vec->buffers;
     if (num_workers < 1) num_workers = 1;
 
-    Env* envs = (Env*)vec->envs;
-
     printf("Num workers: %d\n", num_workers);
     while (true) {
         while (atomic_load(&buffer_states[buf]) != OMP_RUNNING) {
@@ -264,10 +265,15 @@ static void* static_omp_threadmanager(void* arg) {
             memset(&vec->rewards[agent_start], 0, agents_per_buffer * sizeof(float));
             memset(&vec->terminals[agent_start], 0, agents_per_buffer * sizeof(float));
             clock_gettime(CLOCK_MONOTONIC, &t0);
+            #ifdef MY_VEC_STEP_RANGE
+            MY_VEC_STEP_RANGE(vec, env_start, env_count, num_workers);
+            #else
+            Env* envs = (Env*)vec->envs;
             #pragma omp parallel for schedule(static) num_threads(num_workers)
             for (int i = env_start; i < env_start + env_count; i++) {
                 c_step(&envs[i]);
             }
+            #endif
             clock_gettime(CLOCK_MONOTONIC, &t1);
             my_accum[EVAL_ENV_STEP] += (t1.tv_sec - t0.tv_sec) * 1000.0f + (t1.tv_nsec - t0.tv_nsec) / 1e6f;
 

--- a/tests/craftax_diff.py
+++ b/tests/craftax_diff.py
@@ -1,0 +1,595 @@
+import argparse
+import ctypes
+import subprocess
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+
+FULL_BLOCK_CHANNELS = 37
+FULL_ITEM_CHANNELS = 5
+FULL_MOB_TYPES = 8
+NUM_MOB_CLASSES = 5
+OBS_ROWS = 9
+OBS_COLS = 11
+INVENTORY_OBS_SIZE = 51
+NUM_TILE_CHANNELS = (
+    FULL_BLOCK_CHANNELS
+    + FULL_ITEM_CHANNELS
+    + NUM_MOB_CLASSES * FULL_MOB_TYPES
+    + 1
+)
+MAP_OBS_SIZE = OBS_ROWS * OBS_COLS * NUM_TILE_CHANNELS
+PACKED_TILE_CHANNELS = 3 + NUM_MOB_CLASSES
+PACKED_MAP_OBS_SIZE = OBS_ROWS * OBS_COLS * PACKED_TILE_CHANNELS
+PACKED_OBS_SIZE = PACKED_MAP_OBS_SIZE + INVENTORY_OBS_SIZE
+
+
+WRAPPER_SOURCE = r"""
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+#include "raylib.h"
+#include "vecenv.h"
+
+typedef int cudaError_t;
+typedef int cudaMemcpyKind;
+cudaError_t cudaHostAlloc(void**, size_t, unsigned int) { return 0; }
+cudaError_t cudaMalloc(void**, size_t) { return 0; }
+cudaError_t cudaMemcpy(void*, const void*, size_t, cudaMemcpyKind) { return 0; }
+cudaError_t cudaMemcpyAsync(void*, const void*, size_t, cudaMemcpyKind, cudaStream_t) { return 0; }
+cudaError_t cudaMemset(void*, int, size_t) { return 0; }
+cudaError_t cudaFree(void*) { return 0; }
+cudaError_t cudaFreeHost(void*) { return 0; }
+cudaError_t cudaSetDevice(int) { return 0; }
+cudaError_t cudaDeviceSynchronize(void) { return 0; }
+cudaError_t cudaStreamSynchronize(cudaStream_t) { return 0; }
+cudaError_t cudaStreamCreateWithFlags(cudaStream_t*, unsigned int) { return 0; }
+cudaError_t cudaStreamQuery(cudaStream_t) { return 0; }
+const char* cudaGetErrorString(cudaError_t) { return "stub"; }
+
+Image LoadImageFromMemory(const char* fileType, const unsigned char* fileData, int dataSize) {
+    Image img = {0};
+    return img;
+}
+Texture2D LoadTextureFromImage(Image image) {
+    Texture2D tex = {0};
+    return tex;
+}
+void SetTextureFilter(Texture2D texture, int filter) { (void)texture; (void)filter; }
+void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2 origin, float rotation, Color tint) {
+    (void)texture; (void)source; (void)dest; (void)origin; (void)rotation; (void)tint;
+}
+void InitWindow(int width, int height, const char* title) {
+    (void)width; (void)height; (void)title;
+}
+void SetTargetFPS(int fps) { (void)fps; }
+void BeginDrawing(void) {}
+void ClearBackground(Color color) { (void)color; }
+void DrawText(const char* text, int posX, int posY, int fontSize, Color color) {
+    (void)text; (void)posX; (void)posY; (void)fontSize; (void)color;
+}
+void DrawRectangle(int posX, int posY, int width, int height, Color color) {
+    (void)posX; (void)posY; (void)width; (void)height; (void)color;
+}
+void EndDrawing(void) {}
+bool IsWindowReady(void) { return false; }
+bool IsKeyDown(int key) { (void)key; return false; }
+const char* TextFormat(const char* text, ...) { return text; }
+
+StaticVec* craftax_diff_create_vec(
+    int total_agents,
+    int num_buffers,
+    uint64_t seed_offset,
+    int reset_pool_size
+) {
+    Dict* vec_kwargs = create_dict(3);
+    dict_set(vec_kwargs, "total_agents", (double)total_agents);
+    dict_set(vec_kwargs, "num_buffers", (double)num_buffers);
+    dict_set(vec_kwargs, "num_threads", 1.0);
+
+    Dict* env_kwargs = create_dict(2);
+    dict_set(env_kwargs, "seed_offset", (double)seed_offset);
+    dict_set(env_kwargs, "reset_pool_size", (double)reset_pool_size);
+
+    StaticVec* vec = create_static_vec(
+        total_agents,
+        num_buffers,
+        0,
+        vec_kwargs,
+        env_kwargs
+    );
+    static_vec_reset(vec);
+
+    free(vec_kwargs->items);
+    free(vec_kwargs);
+    free(env_kwargs->items);
+    free(env_kwargs);
+    return vec;
+}
+
+void craftax_diff_step_vec(StaticVec* vec, const int32_t* actions) {
+    for (int i = 0; i < vec->total_agents; i++) {
+        vec->actions[i] = (float)actions[i];
+    }
+    cpu_vec_step(vec);
+}
+
+float* craftax_diff_obs_ptr(StaticVec* vec) {
+    return (float*)vec->observations;
+}
+
+float* craftax_diff_rewards_ptr(StaticVec* vec) {
+    return vec->rewards;
+}
+
+float* craftax_diff_terminals_ptr(StaticVec* vec) {
+    return vec->terminals;
+}
+
+int craftax_diff_obs_size(void) {
+    return get_obs_size();
+}
+
+int craftax_diff_num_actions(void) {
+    int* act_sizes = get_act_sizes();
+    int n = get_num_act_sizes();
+    int total = 0;
+    for (int i = 0; i < n; i++) {
+        total += act_sizes[i];
+    }
+    return total;
+}
+
+void craftax_diff_close_vec(StaticVec* vec) {
+    static_vec_close(vec);
+}
+"""
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _resolve_root(path: str | None) -> Path:
+    if path is None:
+        return repo_root()
+    resolved = Path(path)
+    if not resolved.is_absolute():
+        resolved = (repo_root() / resolved).resolve()
+    return resolved
+
+
+def _resolve_craftax_dir(root: Path, craftax_dir: str) -> Path:
+    path = Path(craftax_dir)
+    if not path.is_absolute():
+        path = (root / path).resolve()
+    return path
+
+
+def _describe_obs_index(index: int) -> str:
+    if index < MAP_OBS_SIZE:
+        tile = index // NUM_TILE_CHANNELS
+        channel = index % NUM_TILE_CHANNELS
+        row = tile // OBS_COLS
+        col = tile % OBS_COLS
+        if channel < FULL_BLOCK_CHANNELS:
+            return f"map.block_onehot[{row},{col},{channel}]"
+        channel -= FULL_BLOCK_CHANNELS
+        if channel < FULL_ITEM_CHANNELS:
+            return f"map.item_onehot[{row},{col},{channel}]"
+        channel -= FULL_ITEM_CHANNELS
+        if channel < NUM_MOB_CLASSES * FULL_MOB_TYPES:
+            mob_class = channel // FULL_MOB_TYPES
+            mob_type = channel % FULL_MOB_TYPES
+            return f"map.mob_onehot[{row},{col},class={mob_class},type={mob_type}]"
+        return f"map.visible[{row},{col}]"
+
+    inventory_index = index - MAP_OBS_SIZE
+    if 0 <= inventory_index < INVENTORY_OBS_SIZE:
+        return f"inventory[{inventory_index}]"
+    return f"obs[{index}]"
+
+
+def _first_bitwise_float_diff(ref: np.ndarray, got: np.ndarray):
+    ref_u32 = np.ascontiguousarray(ref).view(np.uint32).reshape(-1)
+    got_u32 = np.ascontiguousarray(got).view(np.uint32).reshape(-1)
+    mismatch = np.flatnonzero(ref_u32 != got_u32)
+    if mismatch.size == 0:
+        return None
+    idx = int(mismatch[0])
+    return idx, ref_u32[idx], got_u32[idx], float(ref.reshape(-1)[idx]), float(got.reshape(-1)[idx])
+
+
+def _expand_packed_craftax_obs(packed: np.ndarray) -> np.ndarray:
+    if packed.shape[1] != PACKED_OBS_SIZE:
+        raise ValueError(f"packed obs has size {packed.shape[1]}, expected {PACKED_OBS_SIZE}")
+
+    full = np.zeros((packed.shape[0], MAP_OBS_SIZE + INVENTORY_OBS_SIZE), dtype=np.float32)
+    for env_i in range(packed.shape[0]):
+        for cell in range(OBS_ROWS * OBS_COLS):
+            packed_base = cell * PACKED_TILE_CHANNELS
+            full_base = cell * NUM_TILE_CHANNELS
+            block = int(packed[env_i, packed_base + 0])
+            item = int(packed[env_i, packed_base + 1])
+            visible = int(packed[env_i, packed_base + 2])
+            if visible:
+                if 0 <= block < FULL_BLOCK_CHANNELS:
+                    full[env_i, full_base + block] = 1.0
+                item_id = item - 1
+                if 0 <= item_id < FULL_ITEM_CHANNELS:
+                    full[env_i, full_base + FULL_BLOCK_CHANNELS + item_id] = 1.0
+                full[env_i, full_base + NUM_TILE_CHANNELS - 1] = 1.0
+
+            mob_offset = full_base + FULL_BLOCK_CHANNELS + FULL_ITEM_CHANNELS
+            for mob_class in range(NUM_MOB_CLASSES):
+                mob_value = int(packed[env_i, packed_base + 3 + mob_class])
+                if mob_value:
+                    mob_type = mob_value - 1
+                    if 0 <= mob_type < FULL_MOB_TYPES:
+                        full[
+                            env_i,
+                            mob_offset + mob_class * FULL_MOB_TYPES + mob_type,
+                        ] = 1.0
+
+    full[:, MAP_OBS_SIZE:] = packed[:, PACKED_MAP_OBS_SIZE:]
+    return full
+
+
+def _candidate_obs_for_compare(candidate: "DiffVec", candidate_obs_format: str) -> np.ndarray:
+    if candidate_obs_format == "full":
+        return candidate.obs
+    if candidate_obs_format == "packed_float":
+        return _expand_packed_craftax_obs(candidate.obs)
+    raise ValueError(f"unknown candidate obs format {candidate_obs_format!r}")
+
+
+class DiffLib:
+    def __init__(self, root: Path, craftax_dir: Path, label: str):
+        self.root = root
+        self.craftax_dir = craftax_dir
+        self.label = label
+        self._tmp = tempfile.TemporaryDirectory(prefix=f"craftax_diff_{label}_")
+        tmp = Path(self._tmp.name)
+        src = tmp / "craftax_diff_wrapper.c"
+        so = tmp / f"craftax_diff_{label}.so"
+        src.write_text(WRAPPER_SOURCE)
+
+        raylib_include = root / "raylib-5.5_linux_amd64/include"
+        compile_cmd = [
+            "cc",
+            "-std=c99",
+            "-O2",
+            "-shared",
+            "-fPIC",
+            "-ffunction-sections",
+            "-fdata-sections",
+            "-fopenmp",
+            str(src),
+            str(craftax_dir / "binding.c"),
+            "-I",
+            str(root / "src"),
+            "-I",
+            str(root),
+            "-I",
+            str(root / "vendor"),
+            "-I",
+            str(craftax_dir),
+            "-I",
+            str(raylib_include),
+            "-lm",
+            "-lpthread",
+            "-Wl,--gc-sections",
+            "-o",
+            str(so),
+        ]
+        subprocess.run(compile_cmd, check=True, cwd=root)
+        self.lib = ctypes.CDLL(str(so))
+
+        self.lib.craftax_diff_create_vec.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_uint64,
+            ctypes.c_int,
+        ]
+        self.lib.craftax_diff_create_vec.restype = ctypes.c_void_p
+        self.lib.craftax_diff_step_vec.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int32)]
+        self.lib.craftax_diff_step_vec.restype = None
+        self.lib.craftax_diff_obs_ptr.argtypes = [ctypes.c_void_p]
+        self.lib.craftax_diff_obs_ptr.restype = ctypes.c_void_p
+        self.lib.craftax_diff_rewards_ptr.argtypes = [ctypes.c_void_p]
+        self.lib.craftax_diff_rewards_ptr.restype = ctypes.c_void_p
+        self.lib.craftax_diff_terminals_ptr.argtypes = [ctypes.c_void_p]
+        self.lib.craftax_diff_terminals_ptr.restype = ctypes.c_void_p
+        self.lib.craftax_diff_obs_size.argtypes = []
+        self.lib.craftax_diff_obs_size.restype = ctypes.c_int
+        self.lib.craftax_diff_num_actions.argtypes = []
+        self.lib.craftax_diff_num_actions.restype = ctypes.c_int
+        self.lib.craftax_diff_close_vec.argtypes = [ctypes.c_void_p]
+        self.lib.craftax_diff_close_vec.restype = None
+
+
+class DiffVec:
+    def __init__(
+        self,
+        lib: DiffLib,
+        total_agents: int,
+        num_buffers: int,
+        seed_offset: int,
+        reset_pool_size: int,
+    ):
+        self.lib = lib
+        self.total_agents = total_agents
+        self.ptr = lib.lib.craftax_diff_create_vec(
+            total_agents,
+            num_buffers,
+            ctypes.c_uint64(seed_offset),
+            reset_pool_size,
+        )
+        if not self.ptr:
+            raise RuntimeError(f"{lib.label}: failed to create vec")
+
+        self.obs_size = int(lib.lib.craftax_diff_obs_size())
+        self.num_actions = int(lib.lib.craftax_diff_num_actions())
+
+        obs_ptr = int(lib.lib.craftax_diff_obs_ptr(self.ptr))
+        rewards_ptr = int(lib.lib.craftax_diff_rewards_ptr(self.ptr))
+        terminals_ptr = int(lib.lib.craftax_diff_terminals_ptr(self.ptr))
+
+        obs_t = ctypes.c_float * (total_agents * self.obs_size)
+        rewards_t = ctypes.c_float * total_agents
+        terminals_t = ctypes.c_float * total_agents
+
+        self.obs = np.ctypeslib.as_array(obs_t.from_address(obs_ptr)).reshape(total_agents, self.obs_size)
+        self.rewards = np.ctypeslib.as_array(rewards_t.from_address(rewards_ptr))
+        self.terminals = np.ctypeslib.as_array(terminals_t.from_address(terminals_ptr))
+
+    def step(self, actions: np.ndarray) -> None:
+        if actions.dtype != np.int32:
+            actions = actions.astype(np.int32, copy=False)
+        self.lib.lib.craftax_diff_step_vec(
+            self.ptr,
+            actions.ctypes.data_as(ctypes.POINTER(ctypes.c_int32)),
+        )
+
+    def close(self) -> None:
+        if self.ptr:
+            self.lib.lib.craftax_diff_close_vec(self.ptr)
+            self.ptr = None
+
+
+def _save_trace(path: Path, actions: np.ndarray) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.save(path, actions)
+
+
+def _load_or_generate_actions(
+    num_steps: int,
+    num_envs: int,
+    num_actions: int,
+    action_seed: int,
+    trace_in: str | None,
+) -> np.ndarray:
+    if trace_in is not None:
+        trace = np.load(trace_in)
+        trace = np.asarray(trace, dtype=np.int32)
+        expected = (num_steps, num_envs)
+        if trace.shape != expected:
+            raise ValueError(f"--trace-in has shape {trace.shape}, expected {expected}")
+        return trace
+    rng = np.random.default_rng(action_seed)
+    return rng.integers(0, num_actions, size=(num_steps, num_envs), dtype=np.int32)
+
+
+def run_diff(args) -> int:
+    baseline_root = _resolve_root(args.baseline_root)
+    candidate_root = _resolve_root(args.candidate_root) if args.candidate_root else baseline_root
+    baseline_dir = _resolve_craftax_dir(baseline_root, args.baseline_craftax_dir)
+    candidate_dir = _resolve_craftax_dir(candidate_root, args.candidate_craftax_dir)
+
+    baseline_lib = DiffLib(baseline_root, baseline_dir, "baseline")
+    candidate_lib = DiffLib(candidate_root, candidate_dir, "candidate")
+
+    baseline = DiffVec(
+        baseline_lib,
+        args.seeds,
+        args.num_buffers,
+        args.seed_start,
+        args.reset_pool_size,
+    )
+    candidate = DiffVec(
+        candidate_lib,
+        args.seeds,
+        args.num_buffers,
+        args.seed_start,
+        args.reset_pool_size,
+    )
+
+    try:
+        candidate_obs_format = getattr(args, "candidate_obs_format", "full")
+        if candidate_obs_format == "full" and baseline.obs_size != candidate.obs_size:
+            raise RuntimeError(
+                f"obs_size mismatch: baseline={baseline.obs_size} candidate={candidate.obs_size}"
+            )
+        if baseline.num_actions != candidate.num_actions:
+            raise RuntimeError(
+                f"num_actions mismatch: baseline={baseline.num_actions} candidate={candidate.num_actions}"
+            )
+
+        actions = _load_or_generate_actions(
+            num_steps=args.steps,
+            num_envs=args.seeds,
+            num_actions=baseline.num_actions,
+            action_seed=args.action_seed,
+            trace_in=args.trace_in,
+        )
+        if args.trace_out is not None:
+            _save_trace(Path(args.trace_out), actions)
+
+        candidate_obs = _candidate_obs_for_compare(candidate, candidate_obs_format)
+        if baseline.obs_size != candidate_obs.shape[1]:
+            raise RuntimeError(
+                "expanded obs_size mismatch: "
+                f"baseline={baseline.obs_size} candidate={candidate_obs.shape[1]}"
+            )
+
+        init_obs_diff = _first_bitwise_float_diff(baseline.obs, candidate_obs)
+        if init_obs_diff is not None:
+            idx, ref_bits, got_bits, ref_value, got_value = init_obs_diff
+            env_i = idx // baseline.obs_size
+            obs_i = idx % baseline.obs_size
+            print(
+                "RESET DIVERGENCE "
+                f"env={env_i} seed={args.seed_start + env_i} "
+                f"obs_index={obs_i} section={_describe_obs_index(obs_i)} "
+                f"baseline_bits=0x{ref_bits:08x} candidate_bits=0x{got_bits:08x} "
+                f"baseline={ref_value:.8g} candidate={got_value:.8g}"
+            )
+            return 1
+
+        for step in range(args.steps):
+            step_actions = actions[step]
+            baseline.step(step_actions)
+            candidate.step(step_actions)
+
+            reward_diff = _first_bitwise_float_diff(baseline.rewards, candidate.rewards)
+            if reward_diff is not None:
+                env_i, ref_bits, got_bits, ref_value, got_value = reward_diff
+                print(
+                    "REWARD DIVERGENCE "
+                    f"step={step} env={env_i} seed={args.seed_start + env_i} "
+                    f"action={int(step_actions[env_i])} "
+                    f"baseline_bits=0x{ref_bits:08x} candidate_bits=0x{got_bits:08x} "
+                    f"baseline={ref_value:.8g} candidate={got_value:.8g}"
+                )
+                if args.divergence_trace is not None:
+                    _save_trace(Path(args.divergence_trace), actions[: step + 1])
+                return 1
+
+            done_diff = _first_bitwise_float_diff(baseline.terminals, candidate.terminals)
+            if done_diff is not None:
+                env_i, ref_bits, got_bits, ref_value, got_value = done_diff
+                print(
+                    "TERMINAL DIVERGENCE "
+                    f"step={step} env={env_i} seed={args.seed_start + env_i} "
+                    f"action={int(step_actions[env_i])} "
+                    f"baseline_bits=0x{ref_bits:08x} candidate_bits=0x{got_bits:08x} "
+                    f"baseline={ref_value:.8g} candidate={got_value:.8g}"
+                )
+                if args.divergence_trace is not None:
+                    _save_trace(Path(args.divergence_trace), actions[: step + 1])
+                return 1
+
+            candidate_obs = _candidate_obs_for_compare(candidate, candidate_obs_format)
+            obs_diff = _first_bitwise_float_diff(baseline.obs, candidate_obs)
+            if obs_diff is not None:
+                idx, ref_bits, got_bits, ref_value, got_value = obs_diff
+                env_i = idx // baseline.obs_size
+                obs_i = idx % baseline.obs_size
+                print(
+                    "OBS DIVERGENCE "
+                    f"step={step} env={env_i} seed={args.seed_start + env_i} "
+                    f"action={int(step_actions[env_i])} "
+                    f"obs_index={obs_i} section={_describe_obs_index(obs_i)} "
+                    f"baseline_bits=0x{ref_bits:08x} candidate_bits=0x{got_bits:08x} "
+                    f"baseline={ref_value:.8g} candidate={got_value:.8g}"
+                )
+                if args.divergence_trace is not None:
+                    _save_trace(Path(args.divergence_trace), actions[: step + 1])
+                return 1
+
+        print(
+            "PASS craftax diff "
+            f"seeds={args.seeds} steps={args.steps} action_seed={args.action_seed} "
+            f"reset_pool_size={args.reset_pool_size} "
+            f"baseline={baseline_dir} candidate={candidate_dir}"
+        )
+        return 0
+    finally:
+        baseline.close()
+        candidate.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seeds", type=int, default=16)
+    parser.add_argument("--seed-start", type=int, default=0)
+    parser.add_argument("--steps", type=int, default=1000)
+    parser.add_argument("--action-seed", type=int, default=0)
+    parser.add_argument("--reset-pool-size", type=int, default=1024)
+    parser.add_argument("--num-buffers", type=int, default=1)
+    parser.add_argument("--baseline-root", type=str, default=None)
+    parser.add_argument("--candidate-root", type=str, default=None)
+    parser.add_argument("--baseline-craftax-dir", type=str, default="ocean/craftax")
+    parser.add_argument("--candidate-craftax-dir", type=str, default="ocean/craftax")
+    parser.add_argument(
+        "--candidate-obs-format",
+        choices=["full", "packed_float"],
+        default="full",
+    )
+    parser.add_argument("--trace-in", type=str, default=None)
+    parser.add_argument("--trace-out", type=str, default=None)
+    parser.add_argument(
+        "--divergence-trace",
+        type=str,
+        default="build/craftax_diff_divergence.npy",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.seeds <= 0:
+        raise ValueError("--seeds must be positive")
+    if args.steps < 0:
+        raise ValueError("--steps must be non-negative")
+    if args.num_buffers <= 0:
+        raise ValueError("--num-buffers must be positive")
+    return run_diff(args)
+
+
+def test_craftax_diff_self() -> None:
+    args = argparse.Namespace(
+        seeds=4,
+        seed_start=0,
+        steps=64,
+        action_seed=7,
+        reset_pool_size=1024,
+        num_buffers=1,
+        baseline_root=None,
+        candidate_root=None,
+        baseline_craftax_dir="ocean/craftax",
+        candidate_craftax_dir="ocean/craftax",
+        candidate_obs_format="full",
+        trace_in=None,
+        trace_out=None,
+        divergence_trace="build/test_craftax_diff_divergence.npy",
+    )
+    assert run_diff(args) == 0
+
+
+def test_craftax_diff_moonshot_self() -> None:
+    args = argparse.Namespace(
+        seeds=4,
+        seed_start=0,
+        steps=64,
+        action_seed=13,
+        reset_pool_size=1024,
+        num_buffers=1,
+        baseline_root=None,
+        candidate_root=None,
+        baseline_craftax_dir="ocean/craftax_moonshot",
+        candidate_craftax_dir="ocean/craftax_moonshot",
+        candidate_obs_format="full",
+        trace_in=None,
+        trace_out=None,
+        divergence_trace="build/test_craftax_moonshot_diff_divergence.npy",
+    )
+    assert run_diff(args) == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a side-by-side `craftax_moonshot` implementation for the 4.0 branch. This keeps the existing Craftax implementation intact while adding a CPU-oriented version with a smaller packed float observation path, reset-state caching, tiled stepping, and a per-buffer VecEnv rollout hook used only by environments that opt in.

The `src/vecenv.h` change is intentionally narrow: default environments keep the existing `c_step` rollout loop, while `craftax_moonshot` defines `MY_VEC_STEP_RANGE` to avoid the scalar fallback during Puffer rollouts.

## Measured throughput

On a Ryzen 9 9950X3D + RTX PRO 6000 Blackwell workstation, pinned to the V-Cache cores:

```bash
env OMP_NUM_THREADS=1 taskset -c 0-7,16-23 \
  uv run puffer train craftax_moonshot \
  --train.total-timesteps 200000000 \
  --vec.total-agents 16384 \
  --vec.num-buffers 16 \
  --vec.num-threads 16 \
  --policy.hidden-size 32 \
  --policy.num-layers 1 \
  --policy.expansion-factor 1 \
  --train.horizon 128 \
  --train.minibatch-size 32768
```

Short-run dashboard measurement: about 4.0M training SPS with env around 47% of wall time.

Raw random-action env-only measurement on 4096 agents: about 16.8M env SPS.

## Verification

```bash
uv run --with pybind11 --with rich_argparse --with nvidia-cudnn-cu12 --with nvidia-nccl-cu12 ./build.sh craftax_moonshot
uv run --with pytest pytest tests/craftax_diff.py -q
uv run --with ruff ruff check tests/craftax_diff.py --fix
```

Results:

```text
Built: pufferlib/_C.cpython-313-x86_64-linux-gnu.so
2 passed in 15.07s
All checks passed!
```

Repo-wide pytest/ruff are currently blocked by pre-existing upstream dependency/lint issues unrelated to this PR.
