### PR TITLE
Optimize Craftax CPU rollout

### DIFF
--- a/config/craftax.ini
+++ b/config/craftax.ini
@@ -2,8 +2,8 @@
 env_name = craftax
 
 [vec]
-total_agents = 8192
-num_buffers = 4
+total_agents = 16384
+num_buffers = 16
 num_threads = 16
 
 [env]
@@ -17,3 +17,14 @@ reset_pool_size = 1024
 
 [train]
 total_timesteps = 200_000_000
+learning_rate = 0.008
+ent_coef = 0.02
+gamma = 0.997
+gae_lambda = 0.95
+horizon = 128
+minibatch_size = 32768
+
+[policy]
+hidden_size = 32
+num_layers = 1
+expansion_factor = 1

--- a/ocean/craftax/binding.c
+++ b/ocean/craftax/binding.c
@@ -9,8 +9,109 @@
 #define ACT_SIZES {CRAFTAX_NUM_ACTIONS}
 #define OBS_TENSOR_T FloatTensor
 
+#define CRAFTAX_VEC_TILE_SIZE 128
+#define MY_VEC_INIT
+#define MY_VEC_CLOSE
+#define MY_VEC_STEP craftax_vec_step
+#define MY_VEC_STEP_RANGE craftax_vec_step_range
 #define Env Craftax
 #include "vecenv.h"
+
+// Tiled vector step: process agents in tiles that fit comfortably in cache.
+// Each thread processes a contiguous block of lightweight env handles while
+// the heavier CraftaxState storage lives in a separate arena.
+void craftax_vec_step(StaticVec* vec) {
+    memset(vec->rewards, 0, vec->total_agents * sizeof(float));
+    memset(vec->terminals, 0, vec->total_agents * sizeof(float));
+    Craftax* envs = (Craftax*)vec->envs;
+    int size = vec->size;
+    #pragma omp parallel for schedule(static)
+    for (int tile = 0; tile < size; tile += CRAFTAX_VEC_TILE_SIZE) {
+        int end = tile + CRAFTAX_VEC_TILE_SIZE;
+        if (end > size) end = size;
+        for (int i = tile; i < end; i++) {
+            c_step_gameplay(&envs[i]);
+            c_step_encode(&envs[i]);
+        }
+    }
+}
+
+void craftax_vec_step_range(StaticVec* vec, int env_start, int env_count, int num_workers) {
+    (void)num_workers;
+    Craftax* envs = (Craftax*)vec->envs;
+    int env_end = env_start + env_count;
+    for (int tile = env_start; tile < env_end; tile += CRAFTAX_VEC_TILE_SIZE) {
+        int end = tile + CRAFTAX_VEC_TILE_SIZE;
+        if (end > env_end) end = env_end;
+        for (int i = tile; i < end; i++) {
+            c_step_gameplay(&envs[i]);
+            c_step_encode(&envs[i]);
+        }
+    }
+}
+
+static CraftaxState* craftax_alloc_state_arena(int num_envs) {
+    return (CraftaxState*)calloc((size_t)num_envs, sizeof(CraftaxState));
+}
+
+Env* my_vec_init(
+    int* num_envs_out,
+    int* buffer_env_starts,
+    int* buffer_env_counts,
+    Dict* vec_kwargs,
+    Dict* env_kwargs
+) {
+    int total_agents = (int)dict_get(vec_kwargs, "total_agents")->value;
+    int num_buffers = (int)dict_get(vec_kwargs, "num_buffers")->value;
+    int agents_per_buffer = total_agents / num_buffers;
+    int num_envs = total_agents;
+
+    Env* envs = (Env*)calloc((size_t)num_envs, sizeof(Env));
+    CraftaxArena* arena = (CraftaxArena*)calloc(1, sizeof(CraftaxArena));
+    arena->states = craftax_alloc_state_arena(num_envs);
+    arena->num_envs = num_envs;
+    arena->packet_size = CRAFTAX_ARENA_PACKET_SIZE;
+    arena->num_packets = (num_envs + CRAFTAX_ARENA_PACKET_SIZE - 1)
+        / CRAFTAX_ARENA_PACKET_SIZE;
+
+    int buf = 0;
+    int buf_agents = 0;
+    buffer_env_starts[0] = 0;
+    buffer_env_counts[0] = 0;
+
+    for (int i = 0; i < num_envs; i++) {
+        Env* env = &envs[i];
+        env->rng = (unsigned int)i;
+        env->arena = arena;
+        env->state = &arena->states[i];
+        env->packet_id = i / arena->packet_size;
+        env->lane_id = i % arena->packet_size;
+        env->owns_state_storage = false;
+        my_init(env, env_kwargs);
+
+        buf_agents += env->num_agents;
+        buffer_env_counts[buf]++;
+        if (buf_agents >= agents_per_buffer && buf < num_buffers - 1) {
+            buf++;
+            buffer_env_starts[buf] = i + 1;
+            buffer_env_counts[buf] = 0;
+            buf_agents = 0;
+        }
+    }
+
+    *num_envs_out = num_envs;
+    return envs;
+}
+
+void my_vec_close(Env* envs) {
+    if (envs == NULL || envs[0].arena == NULL) {
+        return;
+    }
+
+    CraftaxArena* arena = envs[0].arena;
+    free(arena->states);
+    free(arena);
+}
 
 void my_init(Env* env, Dict* kwargs) {
     env->num_agents = 1;

--- a/ocean/craftax/craftax.h
+++ b/ocean/craftax/craftax.h
@@ -11,6 +11,85 @@
 #include "raylib.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
+
+// ============================================================
+// Optional step profiling (compile with -DCRAFTAX_PROFILE)
+// ============================================================
+#ifdef CRAFTAX_PROFILE
+
+#define CRAFTAX_NUM_PROFILE_ZONES 18
+
+typedef struct {
+    const char* name;
+    uint64_t total_ns;
+    uint64_t count;
+} CraftaxProfileZone;
+
+static CraftaxProfileZone craftax_profile_zones[CRAFTAX_NUM_PROFILE_ZONES] = {
+    {"change_floor", 0, 0},
+    {"crafting", 0, 0},
+    {"do_action", 0, 0},
+    {"place+shoot+spell+potion", 0, 0},
+    {"read_book", 0, 0},
+    {"enchant", 0, 0},
+    {"boss+attr+move", 0, 0},
+    {"update_mobs", 0, 0},
+    {"spawn_mobs", 0, 0},
+    {"plants+intrinsics+achieve", 0, 0},
+    {"reward+bookkeeping", 0, 0},
+    {"encode_obs", 0, 0},
+    {"rng_split", 0, 0},
+    {"is_game_over", 0, 0},
+    {"reset_on_done", 0, 0},
+    {"copy_achievements", 0, 0},
+    {"reward_bookkeeping", 0, 0},
+    {"unprofiled", 0, 0},
+};
+
+static inline uint64_t craftax_profile_now(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+static inline void craftax_profile_record(int zone, uint64_t start) {
+    craftax_profile_zones[zone].total_ns += craftax_profile_now() - start;
+    craftax_profile_zones[zone].count++;
+}
+
+static inline void craftax_profile_report(void) {
+    fprintf(stderr, "\n=== Craftax Step Profile ===\n");
+    uint64_t total = 0;
+    for (int i = 0; i < CRAFTAX_NUM_PROFILE_ZONES; i++) {
+        total += craftax_profile_zones[i].total_ns;
+    }
+    for (int i = 0; i < CRAFTAX_NUM_PROFILE_ZONES; i++) {
+        CraftaxProfileZone* z = &craftax_profile_zones[i];
+        if (z->count == 0) continue;
+        double pct = total > 0 ? (100.0 * (double)z->total_ns / (double)total) : 0.0;
+        double avg_us = (double)z->total_ns / (double)z->count / 1000.0;
+        fprintf(stderr, "%-28s %8.3f%%  %10.2f us/step  (%lu calls)\n",
+                z->name, pct, avg_us, (unsigned long)z->count);
+    }
+    fprintf(stderr, "%-28s %8.3f%%  %10.2f us/step\n",
+            "TOTAL", 100.0, (double)total / (double)craftax_profile_zones[0].count / 1000.0);
+}
+
+#define CRAFTAX_PROFILE_START() uint64_t _prof_start = craftax_profile_now(); uint64_t _prof_zone_start;
+#define CRAFTAX_PROFILE_ZONE(n) do { _prof_zone_start = craftax_profile_now(); } while(0)
+#define CRAFTAX_PROFILE_END(n) craftax_profile_record((n), _prof_zone_start)
+#define CRAFTAX_PROFILE_FINAL(n) craftax_profile_record((n), _prof_start)
+
+#else
+
+#define CRAFTAX_PROFILE_START() ((void)0)
+#define CRAFTAX_PROFILE_ZONE(n) ((void)0)
+#define CRAFTAX_PROFILE_END(n) ((void)0)
+#define CRAFTAX_PROFILE_FINAL(n) ((void)0)
+#define craftax_profile_report() ((void)0)
+
+#endif // CRAFTAX_PROFILE
 
 // ============================================================
 // Constants
@@ -25,7 +104,7 @@
 #define CRAFTAX_NUM_MOB_CLASSES 5
 #define CRAFTAX_NUM_MOB_TYPES 8
 #define CRAFTAX_INVENTORY_OBS_SIZE 51
-#define CRAFTAX_OBS_SIZE 8268
+#define CRAFTAX_OBS_SIZE CRAFTAX_WG_OBS_SIZE
 
 #define CRAFTAX_NUM_ACTIONS 43
 #define CRAFTAX_NUM_ACHIEVEMENTS 67
@@ -267,15 +346,7 @@ typedef struct CraftaxMobs2 {
 } CraftaxMobs2;
 
 typedef struct CraftaxState {
-    int32_t map[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE][CRAFTAX_MAP_SIZE];
-    int32_t item_map[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE][CRAFTAX_MAP_SIZE];
-    bool mob_map[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE][CRAFTAX_MAP_SIZE];
-    float light_map[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE][CRAFTAX_MAP_SIZE];
-    int32_t down_ladders[CRAFTAX_NUM_LEVELS][2];
-    int32_t up_ladders[CRAFTAX_NUM_LEVELS][2];
-    bool chests_opened[CRAFTAX_NUM_LEVELS];
-    int32_t monsters_killed[CRAFTAX_NUM_LEVELS];
-
+    // === Hot data (accessed every step) ===
     int32_t player_position[2];
     int32_t player_level;
     int32_t player_direction;
@@ -329,11 +400,108 @@ typedef struct CraftaxState {
     uint32_t state_rng[2];
     int32_t timestep;
     int32_t fractal_noise_angles[4];
+
+    // === Medium-hot bitmaps, read during mob updates, spawn scans, encode_obs ===
+    uint64_t mob_bits[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE];
+    uint64_t spawn_all_bits[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE];
+    uint64_t spawn_grave_bits[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE];
+    uint64_t spawn_water_bits[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE];
+
+    // === Cold data (large maps, scattered access) ===
+    uint8_t map[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE][CRAFTAX_MAP_SIZE];
+    uint8_t item_map[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE][CRAFTAX_MAP_SIZE];
+    uint8_t light_map[CRAFTAX_NUM_LEVELS][CRAFTAX_MAP_SIZE][CRAFTAX_MAP_SIZE];
+
+    int32_t down_ladders[CRAFTAX_NUM_LEVELS][2];
+    int32_t up_ladders[CRAFTAX_NUM_LEVELS][2];
+    bool chests_opened[CRAFTAX_NUM_LEVELS];
+    int32_t monsters_killed[CRAFTAX_NUM_LEVELS];
 } CraftaxState;
 
 typedef char CraftaxStateMatchesWorldState[
     (sizeof(CraftaxState) == sizeof(CraftaxWorldState)) ? 1 : -1
 ];
+
+static inline uint64_t craftax_spawn_all_bit(uint8_t block) {
+    return (uint64_t)(
+        block == CRAFTAX_BLOCK_GRASS
+        || block == CRAFTAX_BLOCK_PATH
+        || block == CRAFTAX_BLOCK_FIRE_GRASS
+        || block == CRAFTAX_BLOCK_ICE_GRASS
+    );
+}
+
+static inline uint64_t craftax_spawn_grave_bit(uint8_t block) {
+    return (uint64_t)(
+        block == CRAFTAX_BLOCK_GRAVE
+        || block == CRAFTAX_BLOCK_GRAVE2
+        || block == CRAFTAX_BLOCK_GRAVE3
+    );
+}
+
+static inline uint64_t craftax_spawn_water_bit(uint8_t block) {
+    return (uint64_t)(block == CRAFTAX_BLOCK_WATER);
+}
+
+static inline void craftax_refresh_spawn_bits_cell(
+    CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    int32_t col
+) {
+    uint64_t bit = 1ULL << col;
+    uint8_t block = state->map[level][row][col];
+
+    state->spawn_all_bits[level][row] =
+        (state->spawn_all_bits[level][row] & ~bit)
+        | ((0ULL - craftax_spawn_all_bit(block)) & bit);
+    state->spawn_grave_bits[level][row] =
+        (state->spawn_grave_bits[level][row] & ~bit)
+        | ((0ULL - craftax_spawn_grave_bit(block)) & bit);
+    state->spawn_water_bits[level][row] =
+        (state->spawn_water_bits[level][row] & ~bit)
+        | ((0ULL - craftax_spawn_water_bit(block)) & bit);
+}
+
+static inline void craftax_set_map_block(
+    CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    int32_t col,
+    int32_t block
+) {
+    state->map[level][row][col] = (uint8_t)block;
+    craftax_refresh_spawn_bits_cell(state, level, row, col);
+}
+
+static inline void craftax_refresh_spawn_bits_all(CraftaxState* state) {
+    for (int32_t level = 0; level < CRAFTAX_NUM_LEVELS; level++) {
+        for (int32_t row = 0; row < CRAFTAX_MAP_SIZE; row++) {
+            uint64_t all_bits = 0;
+            uint64_t grave_bits = 0;
+            uint64_t water_bits = 0;
+            for (int32_t col = 0; col < CRAFTAX_MAP_SIZE; col++) {
+                uint8_t block = state->map[level][row][col];
+                uint64_t bit = 1ULL << col;
+                all_bits |= (0ULL - craftax_spawn_all_bit(block)) & bit;
+                grave_bits |= (0ULL - craftax_spawn_grave_bit(block)) & bit;
+                water_bits |= (0ULL - craftax_spawn_water_bit(block)) & bit;
+            }
+            state->spawn_all_bits[level][row] = all_bits;
+            state->spawn_grave_bits[level][row] = grave_bits;
+            state->spawn_water_bits[level][row] = water_bits;
+        }
+    }
+}
+
+#define CRAFTAX_ARENA_PACKET_SIZE 64
+
+typedef struct CraftaxArena {
+    CraftaxState* states;
+    int num_envs;
+    int packet_size;
+    int num_packets;
+} CraftaxArena;
 
 #ifdef CRAFTAX_ENABLE_ENV_IMPL
 static inline void craftax_change_floor_native(CraftaxState* state, int32_t action);
@@ -419,7 +587,11 @@ typedef struct Craftax {
     unsigned int rng;
     uint64_t seed;
     CraftaxThreefryKey rng_key;
-    CraftaxState state;
+    CraftaxArena* arena;
+    CraftaxState* state;
+    int32_t packet_id;
+    int32_t lane_id;
+    bool owns_state_storage;
 
     float achievements[CRAFTAX_NUM_ACHIEVEMENTS];
     float episode_return_accum;
@@ -465,6 +637,7 @@ static inline void craftax_generate_state_from_world_key(
     CraftaxWorldState world_state;
     craftax_generate_world_from_key(world_key, &world_state);
     craftax_copy_world_state_to_state(out, &world_state);
+    craftax_refresh_spawn_bits_all(out);
 }
 
 static inline void craftax_reset_state_from_reset_key(
@@ -505,18 +678,37 @@ static inline void craftax_set_reset_pool_size(int n) {
     g_craftax_reset_pool_ready = 1;
 }
 
+static inline void craftax_ensure_state_storage(Craftax* env) {
+    if (env->state != NULL) {
+        return;
+    }
+
+    CraftaxArena* arena = (CraftaxArena*)calloc(1, sizeof(CraftaxArena));
+    arena->states = (CraftaxState*)calloc(1, sizeof(CraftaxState));
+    arena->num_envs = 1;
+    arena->packet_size = 1;
+    arena->num_packets = 1;
+
+    env->arena = arena;
+    env->state = arena->states;
+    env->packet_id = 0;
+    env->lane_id = 0;
+    env->owns_state_storage = true;
+}
+
 static inline void craftax_reset_state_from_seed(Craftax* env) {
+    craftax_ensure_state_storage(env);
     CraftaxThreefryKey initial_key = craftax_prng_key((uint32_t)env->seed);
     if (g_craftax_reset_pool_size > 0) {
         CraftaxThreefryKey discard;
         craftax_threefry_split(initial_key, &env->rng_key, &discard);
         int idx = (int)(env->seed % (uint64_t)g_craftax_reset_pool_size);
-        memcpy(&env->state, &g_craftax_reset_pool[idx], sizeof(CraftaxState));
+        memcpy(env->state, &g_craftax_reset_pool[idx], sizeof(CraftaxState));
         return;
     }
     CraftaxThreefryKey reset_key;
     craftax_threefry_split(initial_key, &env->rng_key, &reset_key);
-    craftax_reset_state_from_reset_key(&env->state, reset_key);
+    craftax_reset_state_from_reset_key(env->state, reset_key);
 }
 
 // Hot-path reset used by c_step on episode-done. Consults the reset pool
@@ -590,6 +782,7 @@ static float craftax_gameplay_step_native(
     int32_t action,
     CraftaxThreefryKey rng
 ) {
+    CRAFTAX_PROFILE_START();
     bool init_achievements[CRAFTAX_NUM_ACHIEVEMENTS];
     memcpy(init_achievements, state->achievements, sizeof(init_achievements));
     float init_health = state->player_health;
@@ -597,38 +790,57 @@ static float craftax_gameplay_step_native(
     action = state->is_sleeping ? CRAFTAX_ACTION_NOOP : action;
     action = state->is_resting ? CRAFTAX_ACTION_NOOP : action;
 
+    CRAFTAX_PROFILE_ZONE(0);
     craftax_change_floor_native(state, action);
     craftax_do_crafting_native(state, action);
+    CRAFTAX_PROFILE_END(0);
 
     CraftaxThreefryKey subkey = craftax_step_native_next_key(&rng);
+    CRAFTAX_PROFILE_ZONE(2);
     craftax_do_action_native(state, action, subkey);
+    CRAFTAX_PROFILE_END(2);
 
+    CRAFTAX_PROFILE_ZONE(3);
     craftax_place_block_native(state, action);
     craftax_shoot_projectile_native(state, action);
     craftax_cast_spell_native(state, action);
     craftax_drink_potion_native(state, action);
+    CRAFTAX_PROFILE_END(3);
 
     subkey = craftax_step_native_next_key(&rng);
+    CRAFTAX_PROFILE_ZONE(4);
     craftax_read_book_native(state, subkey.word, action);
+    CRAFTAX_PROFILE_END(4);
 
     subkey = craftax_step_native_next_key(&rng);
+    CRAFTAX_PROFILE_ZONE(5);
     craftax_enchant_native(state, action, subkey);
+    CRAFTAX_PROFILE_END(5);
 
+    CRAFTAX_PROFILE_ZONE(6);
     craftax_boss_logic_native(state);
     craftax_level_up_attributes_native(state, action, CRAFTAX_MAX_ATTRIBUTE);
     craftax_move_player_native(state, action, false);
+    CRAFTAX_PROFILE_END(6);
 
     subkey = craftax_step_native_next_key(&rng);
+    CRAFTAX_PROFILE_ZONE(7);
     craftax_update_mobs_native(state, subkey);
+    CRAFTAX_PROFILE_END(7);
 
     subkey = craftax_step_native_next_key(&rng);
+    CRAFTAX_PROFILE_ZONE(8);
     craftax_spawn_mobs_native(state, subkey);
+    CRAFTAX_PROFILE_END(8);
 
+    CRAFTAX_PROFILE_ZONE(9);
     craftax_update_plants_native(state);
     craftax_update_player_intrinsics_native(state, action);
     craftax_clip_inventory_and_intrinsics_native(state, false);
     craftax_calculate_inventory_achievements_native(state);
+    CRAFTAX_PROFILE_END(9);
 
+    CRAFTAX_PROFILE_ZONE(10);
     float reward = 0.0f;
     for (int i = 0; i < CRAFTAX_NUM_ACHIEVEMENTS; i++) {
         int32_t delta = (int32_t)state->achievements[i]
@@ -642,6 +854,7 @@ static float craftax_gameplay_step_native(
     state->light_level = craftax_calculate_light_level_native(state->timestep);
     state->state_rng[0] = subkey.word[0];
     state->state_rng[1] = subkey.word[1];
+    CRAFTAX_PROFILE_END(10);
 
     return reward;
 }
@@ -652,10 +865,12 @@ static float craftax_gameplay_step_native(
 static void c_init(Craftax* env) {
     env->client = NULL;
     env->num_agents = 1;
+    craftax_ensure_state_storage(env);
     env->episode_return_accum = 0.0f;
     env->episode_length_accum = 0;
     memset(env->achievements, 0, sizeof(env->achievements));
     memset(&env->log, 0, sizeof(env->log));
+    craftax_wg_init_cell_templates();
     craftax_reset_state_from_seed(env);
 }
 
@@ -671,10 +886,12 @@ static void c_reset(Craftax* env) {
     memset(env->achievements, 0, sizeof(env->achievements));
 
     craftax_reset_state_from_seed(env);
-    craftax_encode_native_observation(&env->state, env->observations);
+    craftax_encode_native_observation(env->state, env->observations);
 }
 
+#ifdef CRAFTAX_PROFILE
 static void c_step_native(Craftax* env) {
+    CRAFTAX_PROFILE_START();
     env->rewards[0] = 0.0f;
     env->terminals[0] = 0.0f;
 
@@ -686,17 +903,80 @@ static void c_step_native(Craftax* env) {
         action = CRAFTAX_NUM_ACTIONS - 1;
     }
 
+    CRAFTAX_PROFILE_ZONE(12);
     CraftaxThreefryKey step_key;
     craftax_threefry_split(env->rng_key, &env->rng_key, &step_key);
 
     CraftaxThreefryKey step_rng;
     CraftaxThreefryKey reset_key;
     craftax_threefry_split(step_key, &step_rng, &reset_key);
+    CRAFTAX_PROFILE_END(12);
 
-    float reward = craftax_gameplay_step_native(&env->state, action, step_rng);
-    bool done = craftax_is_game_over_native(&env->state);
+    float reward = craftax_gameplay_step_native(env->state, action, step_rng);
 
-    craftax_copy_achievements_to_env(env, &env->state);
+    CRAFTAX_PROFILE_ZONE(13);
+    bool done = craftax_is_game_over_native(env->state);
+    CRAFTAX_PROFILE_END(13);
+
+    CRAFTAX_PROFILE_ZONE(15);
+    craftax_copy_achievements_to_env(env, env->state);
+    CRAFTAX_PROFILE_END(15);
+
+    CRAFTAX_PROFILE_ZONE(16);
+    env->rewards[0] = reward;
+    env->terminals[0] = done ? 1.0f : 0.0f;
+    env->episode_return_accum += reward;
+    env->episode_length_accum += 1;
+    CRAFTAX_PROFILE_END(16);
+
+    if (done) {
+        add_log(env);
+        env->episode_return_accum = 0.0f;
+        env->episode_length_accum = 0;
+        memset(env->achievements, 0, sizeof(env->achievements));
+        CRAFTAX_PROFILE_ZONE(14);
+        craftax_reset_state_on_done(env->state, reset_key);
+        CRAFTAX_PROFILE_END(14);
+    }
+
+    CRAFTAX_PROFILE_ZONE(11);
+    craftax_encode_native_observation(env->state, env->observations);
+    CRAFTAX_PROFILE_END(11);
+
+    // Record unprofiled time
+    CRAFTAX_PROFILE_ZONE(17);
+    CRAFTAX_PROFILE_END(17);
+
+#ifdef CRAFTAX_PROFILE
+    static int profile_step_count = 0;
+    profile_step_count++;
+    if (profile_step_count >= 100000) {
+        craftax_profile_report();
+        profile_step_count = 0;
+    }
+
+#endif
+}
+
+#endif
+
+static void c_step_gameplay(Craftax* env) {
+    env->rewards[0] = 0.0f;
+    env->terminals[0] = 0.0f;
+
+    int action = (int)env->actions[0];
+    if (action < 0) action = CRAFTAX_ACTION_NOOP;
+    if (action >= CRAFTAX_NUM_ACTIONS) action = CRAFTAX_NUM_ACTIONS - 1;
+
+    CraftaxThreefryKey step_key;
+    craftax_threefry_split(env->rng_key, &env->rng_key, &step_key);
+    CraftaxThreefryKey step_rng;
+    CraftaxThreefryKey reset_key;
+    craftax_threefry_split(step_key, &step_rng, &reset_key);
+
+    float reward = craftax_gameplay_step_native(env->state, action, step_rng);
+    bool done = craftax_is_game_over_native(env->state);
+    craftax_copy_achievements_to_env(env, env->state);
 
     env->rewards[0] = reward;
     env->terminals[0] = done ? 1.0f : 0.0f;
@@ -708,18 +988,28 @@ static void c_step_native(Craftax* env) {
         env->episode_return_accum = 0.0f;
         env->episode_length_accum = 0;
         memset(env->achievements, 0, sizeof(env->achievements));
-        craftax_reset_state_on_done(&env->state, reset_key);
+        craftax_reset_state_on_done(env->state, reset_key);
     }
+}
 
-    craftax_encode_native_observation(&env->state, env->observations);
+static void c_step_encode(Craftax* env) {
+    craftax_encode_native_observation(env->state, env->observations);
 }
 
 static void c_step(Craftax* env) {
-    c_step_native(env);
+    c_step_gameplay(env);
+    c_step_encode(env);
 }
 
 static void c_close(Craftax* env) {
-    (void)env;
+    if (!env->owns_state_storage || env->arena == NULL) {
+        return;
+    }
+    free(env->arena->states);
+    free(env->arena);
+    env->arena = NULL;
+    env->state = NULL;
+    env->owns_state_storage = false;
 }
 
 // ------------------------------------------------------------
@@ -818,7 +1108,7 @@ static void c_render(Craftax* env) {
     if (!craftax_textures_loaded) craftax_load_textures();
     if (IsKeyDown(KEY_ESCAPE)) exit(0);
 
-    CraftaxState* s = &env->state;
+    CraftaxState* s = env->state;
     int lvl = s->player_level;
     int pr = s->player_position[0];
     int pc = s->player_position[1];
@@ -836,11 +1126,9 @@ static void c_render(Craftax* env) {
             int dst_y = vr * CRAFTAX_TEX_DRAW_PX;
 
             int blk = CRAFTAX_BLOCK_OUT_OF_BOUNDS;
-            float light = 1.0f;
             if (wr >= 0 && wr < CRAFTAX_MAP_SIZE && wc >= 0 && wc < CRAFTAX_MAP_SIZE) {
                 blk = s->map[lvl][wr][wc];
-                light = s->light_map[lvl][wr][wc];
-                if (light < 0.05f) blk = CRAFTAX_BLOCK_DARKNESS;
+                if (s->light_map[lvl][wr][wc] <= 12) blk = CRAFTAX_BLOCK_DARKNESS;
             }
             if (blk < 0 || blk >= CRAFTAX_NUM_BLOCK_TYPES) blk = 0;
             craftax_draw_tile(blk, dst_x, dst_y, 1.0f);

--- a/ocean/craftax/pack_textures.py
+++ b/ocean/craftax/pack_textures.py
@@ -109,8 +109,10 @@ def main() -> None:
         tiles.append(load_tile(f))
 
     # manual overrides to match upstream renderer
-    tiles[1] = np.full((TILE, TILE, 4), 128, dtype=np.uint8); tiles[1][..., 3] = 255  # out of bounds
-    tiles[18] = np.zeros((TILE, TILE, 4), dtype=np.uint8); tiles[18][..., 3] = 255    # darkness
+    tiles[1] = np.full((TILE, TILE, 4), 128, dtype=np.uint8)
+    tiles[1][..., 3] = 255  # out of bounds
+    tiles[18] = np.zeros((TILE, TILE, 4), dtype=np.uint8)
+    tiles[18][..., 3] = 255  # darkness
 
     for f in PLAYER_FILES:
         tiles.append(load_tile(f))

--- a/ocean/craftax/step_crafting.h
+++ b/ocean/craftax/step_crafting.h
@@ -286,10 +286,10 @@ static inline void craftax_crafting_add_torch_light(
             if (map_col < 0 || map_col >= CRAFTAX_MAP_SIZE) {
                 continue;
             }
-            float light = state->light_map[level][map_row][map_col]
+            float light = state->light_map[level][map_row][map_col] / 255.0f
                 + craftax_crafting_torch_light(dr + 4, dc + 4);
             state->light_map[level][map_row][map_col] =
-                craftax_step_minf32(craftax_step_maxf32(light, 0.0f), 1.0f);
+                (uint8_t)(craftax_step_minf32(craftax_step_maxf32(light, 0.0f), 1.0f) * 255.0f);
         }
     }
 }
@@ -353,7 +353,7 @@ static inline void craftax_place_block_native(
         && !is_placement_on_solid_block_or_item
         && inventory->wood >= 2;
     if (is_placing_crafting_table) {
-        state->map[level][row][col] = CRAFTAX_BLOCK_CRAFTING_TABLE;
+        craftax_set_map_block(state, level, row, col, CRAFTAX_BLOCK_CRAFTING_TABLE);
     }
     inventory->wood -= 2 * (int32_t)is_placing_crafting_table;
     state->achievements[CRAFTAX_ACH_PLACE_TABLE] =
@@ -365,7 +365,7 @@ static inline void craftax_place_block_native(
         && !is_placement_on_solid_block_or_item
         && inventory->stone > 0;
     if (is_placing_furnace) {
-        state->map[level][row][col] = CRAFTAX_BLOCK_FURNACE;
+        craftax_set_map_block(state, level, row, col, CRAFTAX_BLOCK_FURNACE);
     }
     inventory->stone -= 1 * (int32_t)is_placing_furnace;
     state->achievements[CRAFTAX_ACH_PLACE_FURNACE] =
@@ -380,7 +380,7 @@ static inline void craftax_place_block_native(
         && is_placing_on_valid_stone_block
         && inventory->stone > 0;
     if (is_placing_stone) {
-        state->map[level][row][col] = CRAFTAX_BLOCK_STONE;
+        craftax_set_map_block(state, level, row, col, CRAFTAX_BLOCK_STONE);
     }
     inventory->stone -= 1 * (int32_t)is_placing_stone;
     state->achievements[CRAFTAX_ACH_PLACE_STONE] =
@@ -410,7 +410,7 @@ static inline void craftax_place_block_native(
         && state->item_map[level][row][col] == CRAFTAX_ITEM_NONE;
     if (is_placing_sapling) {
         int32_t position[2] = {row, col};
-        state->map[level][row][col] = CRAFTAX_BLOCK_PLANT;
+        craftax_set_map_block(state, level, row, col, CRAFTAX_BLOCK_PLANT);
         craftax_add_new_growing_plant_native(
             state,
             position,

--- a/ocean/craftax/step_do_action.h
+++ b/ocean/craftax/step_do_action.h
@@ -304,8 +304,13 @@ static inline void craftax_do_action_update_mob_map(
     );
     int32_t read_row = craftax_step_jax_index(row, CRAFTAX_MAP_SIZE);
     int32_t read_col = craftax_step_jax_index(col, CRAFTAX_MAP_SIZE);
-    state->mob_map[level][update_row][update_col] =
-        state->mob_map[level][read_row][read_col] && !did_kill_mob;
+    bool old_value = (state->mob_bits[level][read_row] >> read_col) & 1ULL;
+    bool new_value = old_value && !did_kill_mob;
+    if (new_value) {
+        state->mob_bits[level][update_row] |= (1ULL << update_col);
+    } else {
+        state->mob_bits[level][update_row] &= ~(1ULL << update_col);
+    }
 }
 
 static inline void craftax_do_action_attack_mob(
@@ -486,57 +491,57 @@ static inline void craftax_do_action_native(
                 : (is_block_fire_tree
                     ? CRAFTAX_BLOCK_FIRE_GRASS
                     : CRAFTAX_BLOCK_ICE_GRASS);
-            state->map[level][target_row][target_col] = replacement;
+            craftax_set_map_block(state, level, target_row, target_col, replacement);
             state->inventory.wood += 1;
         }
 
         bool is_mining_stone = target_block == CRAFTAX_BLOCK_STONE
             && state->inventory.pickaxe >= 1;
         if (is_mining_stone) {
-            state->map[level][target_row][target_col] = CRAFTAX_BLOCK_PATH;
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
             state->inventory.stone += 1;
         }
 
         if (target_block == CRAFTAX_BLOCK_FURNACE) {
-            state->map[level][target_row][target_col] = CRAFTAX_BLOCK_PATH;
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
         }
 
         if (target_block == CRAFTAX_BLOCK_CRAFTING_TABLE) {
-            state->map[level][target_row][target_col] = CRAFTAX_BLOCK_PATH;
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
         }
 
         bool is_mining_coal = target_block == CRAFTAX_BLOCK_COAL
             && state->inventory.pickaxe >= 1;
         if (is_mining_coal) {
-            state->map[level][target_row][target_col] = CRAFTAX_BLOCK_PATH;
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
             state->inventory.coal += 1;
         }
 
         bool is_mining_iron = target_block == CRAFTAX_BLOCK_IRON
             && state->inventory.pickaxe >= 2;
         if (is_mining_iron) {
-            state->map[level][target_row][target_col] = CRAFTAX_BLOCK_PATH;
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
             state->inventory.iron += 1;
         }
 
         bool is_mining_diamond = target_block == CRAFTAX_BLOCK_DIAMOND
             && state->inventory.pickaxe >= 3;
         if (is_mining_diamond) {
-            state->map[level][target_row][target_col] = CRAFTAX_BLOCK_PATH;
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
             state->inventory.diamond += 1;
         }
 
         bool is_mining_sapphire = target_block == CRAFTAX_BLOCK_SAPPHIRE
             && state->inventory.pickaxe >= 4;
         if (is_mining_sapphire) {
-            state->map[level][target_row][target_col] = CRAFTAX_BLOCK_PATH;
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
             state->inventory.sapphire += 1;
         }
 
         bool is_mining_ruby = target_block == CRAFTAX_BLOCK_RUBY
             && state->inventory.pickaxe >= 4;
         if (is_mining_ruby) {
-            state->map[level][target_row][target_col] = CRAFTAX_BLOCK_PATH;
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
             state->inventory.ruby += 1;
         }
 
@@ -557,7 +562,7 @@ static inline void craftax_do_action_native(
 
         bool is_eating_plant = target_block == CRAFTAX_BLOCK_RIPE_PLANT;
         if (is_eating_plant) {
-            state->map[level][target_row][target_col] = CRAFTAX_BLOCK_PLANT;
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PLANT);
             state->player_food = craftax_step_mini32(
                 craftax_step_get_max_food(state),
                 state->player_food + 4
@@ -574,12 +579,12 @@ static inline void craftax_do_action_native(
         bool is_mining_stalagmite = target_block == CRAFTAX_BLOCK_STALAGMITE
             && state->inventory.pickaxe >= 1;
         if (is_mining_stalagmite) {
-            state->map[level][target_row][target_col] = CRAFTAX_BLOCK_PATH;
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
             state->inventory.stone += 1;
         }
 
         if (is_opening_chest) {
-            state->map[level][target_row][target_col] = CRAFTAX_BLOCK_PATH;
+            craftax_set_map_block(state, level, target_row, target_col, CRAFTAX_BLOCK_PATH);
             craftax_add_items_from_chest_native(
                 state,
                 &state->inventory,

--- a/ocean/craftax/step_simple.h
+++ b/ocean/craftax/step_simple.h
@@ -127,7 +127,7 @@ static inline bool craftax_step_is_in_mob(
     int32_t map_col = craftax_step_jax_index(col, CRAFTAX_MAP_SIZE);
     bool player_here = state->player_position[0] == row
         && state->player_position[1] == col;
-    return state->mob_map[level][map_row][map_col] || player_here;
+    return ((state->mob_bits[level][map_row] >> map_col) & 1ULL) || player_here;
 }
 
 static inline bool craftax_step_valid_land_position(
@@ -201,7 +201,7 @@ static inline void craftax_update_plants_native(CraftaxState* state) {
         int32_t new_block = finished_growing_plants[plant]
             ? CRAFTAX_BLOCK_RIPE_PLANT
             : state->map[0][row][col];
-        state->map[0][row][col] = new_block;
+        craftax_set_map_block(state, 0, row, col, new_block);
     }
 }
 

--- a/ocean/craftax/step_spawn_mobs.h
+++ b/ocean/craftax/step_spawn_mobs.h
@@ -17,6 +17,142 @@
 
 #define CRAFTAX_SPAWN_MAP_CELLS (CRAFTAX_MAP_SIZE * CRAFTAX_MAP_SIZE)
 #define CRAFTAX_SPAWN_BBOX_MAX_CELLS 729  // (2*DESPAWN-1)^2 at 14 = 27*27
+#define CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK ( \
+    (1ULL << CRAFTAX_BLOCK_GRASS) \
+    | (1ULL << CRAFTAX_BLOCK_PATH) \
+    | (1ULL << CRAFTAX_BLOCK_FIRE_GRASS) \
+    | (1ULL << CRAFTAX_BLOCK_ICE_GRASS))
+#define CRAFTAX_SPAWN_GRAVE_BLOCK_MASK ( \
+    (1ULL << CRAFTAX_BLOCK_GRAVE) \
+    | (1ULL << CRAFTAX_BLOCK_GRAVE2) \
+    | (1ULL << CRAFTAX_BLOCK_GRAVE3))
+#define CRAFTAX_SPAWN_WATER_BLOCK_MASK (1ULL << CRAFTAX_BLOCK_WATER)
+
+typedef struct { int8_t dr, dc0, dc1; } CraftaxSpawnOffsetSpan;
+
+static CraftaxSpawnOffsetSpan craftax_spawn_passive_spans[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+static CraftaxSpawnOffsetSpan craftax_spawn_hostile_spans[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+static CraftaxSpawnOffsetSpan craftax_spawn_boss_spans[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+static int32_t craftax_spawn_passive_span_count = 0;
+static int32_t craftax_spawn_hostile_span_count = 0;
+static int32_t craftax_spawn_boss_span_count = 0;
+static int32_t craftax_spawn_offsets_initialized = 0;
+
+static inline void craftax_spawn_append_span(
+    CraftaxSpawnOffsetSpan* spans,
+    int32_t* count,
+    int32_t dr,
+    int32_t dc0,
+    int32_t dc1
+) {
+    spans[*count] = (CraftaxSpawnOffsetSpan){
+        (int8_t)dr, (int8_t)dc0, (int8_t)dc1
+    };
+    *count += 1;
+}
+
+static inline void craftax_spawn_build_spans_for_row(
+    CraftaxSpawnOffsetSpan* spans,
+    int32_t* count,
+    int32_t dr,
+    int32_t limit,
+    int32_t min_exclusive,
+    int32_t max_exclusive
+) {
+    bool active = false;
+    int32_t start = 0;
+    for (int32_t dc = -limit; dc <= limit; dc++) {
+        int32_t distance2 = dr * dr + dc * dc;
+        bool valid = distance2 > min_exclusive && distance2 < max_exclusive;
+        if (valid && !active) {
+            active = true;
+            start = dc;
+        } else if (!valid && active) {
+            craftax_spawn_append_span(spans, count, dr, start, dc - 1);
+            active = false;
+        }
+    }
+    if (active) {
+        craftax_spawn_append_span(spans, count, dr, start, limit);
+    }
+}
+
+static inline void craftax_spawn_init_offsets_once(void) {
+    if (__atomic_load_n(
+            &craftax_spawn_offsets_initialized, __ATOMIC_ACQUIRE
+    )) return;
+
+    #pragma omp critical(craftax_spawn_offsets_init)
+    {
+        if (!__atomic_load_n(
+                &craftax_spawn_offsets_initialized, __ATOMIC_RELAXED
+        )) {
+            int32_t passive_count = 0;
+            int32_t hostile_count = 0;
+            int32_t boss_count = 0;
+            int32_t limit = CRAFTAX_MOB_DESPAWN_DISTANCE - 1;
+            int32_t limit2 = CRAFTAX_MOB_DESPAWN_DISTANCE
+                           * CRAFTAX_MOB_DESPAWN_DISTANCE;
+            for (int32_t dr = -limit; dr <= limit; dr++) {
+                craftax_spawn_build_spans_for_row(
+                    craftax_spawn_passive_spans,
+                    &passive_count,
+                    dr,
+                    limit,
+                    9,
+                    limit2
+                );
+                craftax_spawn_build_spans_for_row(
+                    craftax_spawn_hostile_spans,
+                    &hostile_count,
+                    dr,
+                    limit,
+                    81,
+                    limit2
+                );
+                craftax_spawn_build_spans_for_row(
+                    craftax_spawn_boss_spans,
+                    &boss_count,
+                    dr,
+                    limit,
+                    -1,
+                    37
+                );
+            }
+            craftax_spawn_passive_span_count = passive_count;
+            craftax_spawn_hostile_span_count = hostile_count;
+            craftax_spawn_boss_span_count = boss_count;
+            __atomic_store_n(
+                &craftax_spawn_offsets_initialized, 1, __ATOMIC_RELEASE
+            );
+        }
+    }
+}
+
+static inline bool craftax_spawn_block_matches(uint8_t block, uint64_t mask) {
+    return ((mask >> block) & 1ULL) != 0;
+}
+
+static inline uint64_t craftax_spawn_row_bits_for_mask(
+    const CraftaxState* state,
+    int32_t level,
+    int32_t row,
+    uint64_t terrain_mask
+) {
+    if (terrain_mask == CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK) {
+        return state->spawn_all_bits[level][row];
+    }
+    if (terrain_mask == CRAFTAX_SPAWN_GRAVE_BLOCK_MASK) {
+        return state->spawn_grave_bits[level][row];
+    }
+    return state->spawn_water_bits[level][row];
+}
+
+static inline uint64_t craftax_spawn_col_mask(int32_t col0, int32_t col1) {
+    uint64_t hi = (1ULL << (col1 + 1)) - 1ULL;
+    uint64_t lo = col0 <= 0 ? 0ULL : ((1ULL << col0) - 1ULL);
+    return hi & ~lo;
+}
 
 static inline CraftaxThreefryKey craftax_spawn_next_random_key(
     CraftaxThreefryKey* rng
@@ -72,16 +208,32 @@ static inline float craftax_spawn_mob_type_health(
 }
 
 static inline bool craftax_spawn_is_all_valid_block(int32_t block) {
-    return block == CRAFTAX_BLOCK_GRASS
-        || block == CRAFTAX_BLOCK_PATH
-        || block == CRAFTAX_BLOCK_FIRE_GRASS
-        || block == CRAFTAX_BLOCK_ICE_GRASS;
+    static const uint8_t flags[CRAFTAX_NUM_BLOCK_TYPES] = {
+        [CRAFTAX_BLOCK_GRASS] = 1,
+        [CRAFTAX_BLOCK_PATH] = 1,
+        [CRAFTAX_BLOCK_FIRE_GRASS] = 1,
+        [CRAFTAX_BLOCK_ICE_GRASS] = 1,
+    };
+    int32_t idx = craftax_step_jax_index(block, CRAFTAX_NUM_BLOCK_TYPES);
+    return flags[idx] != 0;
 }
 
 static inline bool craftax_spawn_is_grave_block(int32_t block) {
-    return block == CRAFTAX_BLOCK_GRAVE
-        || block == CRAFTAX_BLOCK_GRAVE2
-        || block == CRAFTAX_BLOCK_GRAVE3;
+    static const uint8_t flags[CRAFTAX_NUM_BLOCK_TYPES] = {
+        [CRAFTAX_BLOCK_GRAVE] = 1,
+        [CRAFTAX_BLOCK_GRAVE2] = 1,
+        [CRAFTAX_BLOCK_GRAVE3] = 1,
+    };
+    int32_t idx = craftax_step_jax_index(block, CRAFTAX_NUM_BLOCK_TYPES);
+    return flags[idx] != 0;
+}
+
+static inline bool craftax_spawn_is_water_block(int32_t block) {
+    static const uint8_t flags[CRAFTAX_NUM_BLOCK_TYPES] = {
+        [CRAFTAX_BLOCK_WATER] = 1,
+    };
+    int32_t idx = craftax_step_jax_index(block, CRAFTAX_NUM_BLOCK_TYPES);
+    return flags[idx] != 0;
 }
 
 static inline int32_t craftax_spawn_player_distance_squared(
@@ -174,44 +326,63 @@ static inline int32_t craftax_spawn_pick_kth(
 
 typedef struct { int16_t row, col; } CraftaxSpawnCoord;
 
-static inline bool craftax_spawn_scan_passive(
-    const CraftaxState* state, int32_t level, CraftaxThreefryKey pos_key,
-    int32_t* out_row, int32_t* out_col
+typedef struct {
+    CraftaxSpawnCoord passive[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+    CraftaxSpawnCoord melee[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+    CraftaxSpawnCoord ranged[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+    int32_t passive_count;
+    int32_t melee_count;
+    int32_t ranged_count;
+} CraftaxSpawnLists;
+
+static inline int32_t craftax_spawn_collect_spans(
+    const CraftaxState* state,
+    int32_t level,
+    const CraftaxSpawnOffsetSpan* spans,
+    int32_t span_count,
+    uint64_t terrain_mask,
+    CraftaxSpawnCoord* coords
 ) {
     int32_t pr = state->player_position[0];
     int32_t pc = state->player_position[1];
-    int32_t r0 = pr - (CRAFTAX_MOB_DESPAWN_DISTANCE - 1);
-    int32_t r1 = pr + (CRAFTAX_MOB_DESPAWN_DISTANCE - 1);
-    int32_t c0 = pc - (CRAFTAX_MOB_DESPAWN_DISTANCE - 1);
-    int32_t c1 = pc + (CRAFTAX_MOB_DESPAWN_DISTANCE - 1);
-    if (r0 < 0) r0 = 0;
-    if (c0 < 0) c0 = 0;
-    if (r1 > CRAFTAX_MAP_SIZE - 1) r1 = CRAFTAX_MAP_SIZE - 1;
-    if (c1 > CRAFTAX_MAP_SIZE - 1) c1 = CRAFTAX_MAP_SIZE - 1;
-
-    const int32_t limit2 = CRAFTAX_MOB_DESPAWN_DISTANCE
-                         * CRAFTAX_MOB_DESPAWN_DISTANCE;
-    CraftaxSpawnCoord coords[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
     int32_t n = 0;
-    for (int32_t row = r0; row <= r1; row++) {
-        int32_t dr = row - pr; if (dr < 0) dr = -dr;
-        int32_t dr2 = dr * dr;
-        const int32_t* map_row = state->map[level][row];
-        const bool*    mob_row = state->mob_map[level][row];
-        for (int32_t col = c0; col <= c1; col++) {
-            int32_t dc = col - pc; if (dc < 0) dc = -dc;
-            int32_t distance2 = dr2 + dc * dc;
-            if (distance2 <= 9 || distance2 >= limit2) continue;
-            if (mob_row[col]) continue;
-            int32_t block = map_row[col];
-            if (block != CRAFTAX_BLOCK_GRASS && block != CRAFTAX_BLOCK_PATH
-                && block != CRAFTAX_BLOCK_FIRE_GRASS
-                && block != CRAFTAX_BLOCK_ICE_GRASS) continue;
+    for (int32_t i = 0; i < span_count; i++) {
+        int32_t row = pr + spans[i].dr;
+        if ((uint32_t)row >= CRAFTAX_MAP_SIZE) continue;
+        int32_t col0 = pc + spans[i].dc0;
+        int32_t col1 = pc + spans[i].dc1;
+        if (col0 < 0) col0 = 0;
+        if (col1 >= CRAFTAX_MAP_SIZE) col1 = CRAFTAX_MAP_SIZE - 1;
+        if (col0 > col1) continue;
+        uint64_t candidates =
+            craftax_spawn_row_bits_for_mask(state, level, row, terrain_mask)
+            & ~state->mob_bits[level][row]
+            & craftax_spawn_col_mask(col0, col1);
+        while (candidates != 0) {
+            int32_t col = __builtin_ctzll(candidates);
             coords[n].row = (int16_t)row;
             coords[n].col = (int16_t)col;
             n++;
+            candidates &= candidates - 1;
         }
     }
+    return n;
+}
+
+static inline bool craftax_spawn_scan_spans(
+    const CraftaxState* state,
+    int32_t level,
+    const CraftaxSpawnOffsetSpan* spans,
+    int32_t span_count,
+    uint64_t terrain_mask,
+    CraftaxThreefryKey pos_key,
+    int32_t* out_row,
+    int32_t* out_col
+) {
+    CraftaxSpawnCoord coords[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
+    int32_t n = craftax_spawn_collect_spans(
+        state, level, spans, span_count, terrain_mask, coords
+    );
     if (n == 0) return false;
     int32_t k = craftax_spawn_pick_kth(n, pos_key);
     *out_row = coords[k].row;
@@ -219,60 +390,170 @@ static inline bool craftax_spawn_scan_passive(
     return true;
 }
 
+static inline bool craftax_spawn_coord_matches(
+    CraftaxSpawnCoord coord, bool exclude, int32_t row, int32_t col
+) {
+    return exclude && coord.row == row && coord.col == col;
+}
+
+static inline bool craftax_spawn_pick_excluding(
+    const CraftaxSpawnCoord* coords, int32_t count, CraftaxThreefryKey key,
+    bool exclude_a, int32_t row_a, int32_t col_a,
+    bool exclude_b, int32_t row_b, int32_t col_b,
+    int32_t* out_row, int32_t* out_col
+) {
+    int32_t valid_count = 0;
+    for (int32_t i = 0; i < count; i++) {
+        bool excluded = craftax_spawn_coord_matches(
+            coords[i], exclude_a, row_a, col_a
+        ) || craftax_spawn_coord_matches(coords[i], exclude_b, row_b, col_b);
+        valid_count += excluded ? 0 : 1;
+    }
+    if (valid_count == 0) return false;
+
+    int32_t k = craftax_spawn_pick_kth(valid_count, key);
+    for (int32_t i = 0; i < count; i++) {
+        bool excluded = craftax_spawn_coord_matches(
+            coords[i], exclude_a, row_a, col_a
+        ) || craftax_spawn_coord_matches(coords[i], exclude_b, row_b, col_b);
+        if (excluded) continue;
+        if (k == 0) {
+            *out_row = coords[i].row;
+            *out_col = coords[i].col;
+            return true;
+        }
+        k--;
+    }
+    return false;
+}
+
+static inline void craftax_spawn_scan_all(
+    const CraftaxState* state,
+    int32_t level,
+    int32_t ranged_type,
+    bool fighting_boss,
+    bool need_passive,
+    bool need_melee,
+    bool need_ranged,
+    CraftaxSpawnLists* out
+) {
+    out->passive_count = 0;
+    out->melee_count = 0;
+    out->ranged_count = 0;
+
+    craftax_spawn_init_offsets_once();
+
+    if (need_passive) {
+        out->passive_count = craftax_spawn_collect_spans(
+            state,
+            level,
+            craftax_spawn_passive_spans,
+            craftax_spawn_passive_span_count,
+            CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK,
+            out->passive
+        );
+    }
+
+    if (!need_melee && !need_ranged) return;
+
+    int32_t pr = state->player_position[0];
+    int32_t pc = state->player_position[1];
+    const CraftaxSpawnOffsetSpan* spans = fighting_boss
+        ? craftax_spawn_boss_spans
+        : craftax_spawn_hostile_spans;
+    int32_t span_count = fighting_boss
+        ? craftax_spawn_boss_span_count
+        : craftax_spawn_hostile_span_count;
+    bool ranged_water_type = (ranged_type == 5);
+
+    uint64_t melee_terrain_mask = fighting_boss
+        ? CRAFTAX_SPAWN_GRAVE_BLOCK_MASK
+        : CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK;
+    uint64_t ranged_terrain_mask;
+    if (fighting_boss) {
+        ranged_terrain_mask = CRAFTAX_SPAWN_GRAVE_BLOCK_MASK;
+    } else if (ranged_water_type) {
+        ranged_terrain_mask = CRAFTAX_SPAWN_WATER_BLOCK_MASK;
+    } else {
+        ranged_terrain_mask = CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK;
+    }
+
+    for (int32_t i = 0; i < span_count; i++) {
+        int32_t row = pr + spans[i].dr;
+        if ((uint32_t)row >= CRAFTAX_MAP_SIZE) continue;
+        int32_t col0 = pc + spans[i].dc0;
+        int32_t col1 = pc + spans[i].dc1;
+        if (col0 < 0) col0 = 0;
+        if (col1 >= CRAFTAX_MAP_SIZE) col1 = CRAFTAX_MAP_SIZE - 1;
+        if (col0 > col1) continue;
+        uint64_t open_bits =
+            ~state->mob_bits[level][row] & craftax_spawn_col_mask(col0, col1);
+
+        if (need_melee) {
+            uint64_t melee_candidates =
+                craftax_spawn_row_bits_for_mask(
+                    state, level, row, melee_terrain_mask
+                ) & open_bits;
+            while (melee_candidates != 0) {
+                int32_t col = __builtin_ctzll(melee_candidates);
+                int32_t n = out->melee_count++;
+                out->melee[n].row = (int16_t)row;
+                out->melee[n].col = (int16_t)col;
+                melee_candidates &= melee_candidates - 1;
+            }
+        }
+
+        if (need_ranged) {
+            uint64_t ranged_candidates =
+                craftax_spawn_row_bits_for_mask(
+                    state, level, row, ranged_terrain_mask
+                ) & open_bits;
+            while (ranged_candidates != 0) {
+                int32_t col = __builtin_ctzll(ranged_candidates);
+                int32_t n = out->ranged_count++;
+                out->ranged[n].row = (int16_t)row;
+                out->ranged[n].col = (int16_t)col;
+                ranged_candidates &= ranged_candidates - 1;
+            }
+        }
+    }
+}
+
+static inline bool craftax_spawn_scan_passive(
+    const CraftaxState* state, int32_t level, CraftaxThreefryKey pos_key,
+    int32_t* out_row, int32_t* out_col
+) {
+    craftax_spawn_init_offsets_once();
+    return craftax_spawn_scan_spans(
+        state,
+        level,
+        craftax_spawn_passive_spans,
+        craftax_spawn_passive_span_count,
+        CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK,
+        pos_key,
+        out_row,
+        out_col
+    );
+}
+
 static inline bool craftax_spawn_scan_melee(
     const CraftaxState* state, int32_t level, bool fighting_boss,
     CraftaxThreefryKey pos_key, int32_t* out_row, int32_t* out_col
 ) {
-    int32_t pr = state->player_position[0];
-    int32_t pc = state->player_position[1];
-    int32_t r0 = pr - (CRAFTAX_MOB_DESPAWN_DISTANCE - 1);
-    int32_t r1 = pr + (CRAFTAX_MOB_DESPAWN_DISTANCE - 1);
-    int32_t c0 = pc - (CRAFTAX_MOB_DESPAWN_DISTANCE - 1);
-    int32_t c1 = pc + (CRAFTAX_MOB_DESPAWN_DISTANCE - 1);
-    if (r0 < 0) r0 = 0;
-    if (c0 < 0) c0 = 0;
-    if (r1 > CRAFTAX_MAP_SIZE - 1) r1 = CRAFTAX_MAP_SIZE - 1;
-    if (c1 > CRAFTAX_MAP_SIZE - 1) c1 = CRAFTAX_MAP_SIZE - 1;
-
-    const int32_t limit2 = CRAFTAX_MOB_DESPAWN_DISTANCE
-                         * CRAFTAX_MOB_DESPAWN_DISTANCE;
-    CraftaxSpawnCoord coords[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
-    int32_t n = 0;
-    for (int32_t row = r0; row <= r1; row++) {
-        int32_t dr = row - pr; if (dr < 0) dr = -dr;
-        int32_t dr2 = dr * dr;
-        const int32_t* map_row = state->map[level][row];
-        const bool*    mob_row = state->mob_map[level][row];
-        for (int32_t col = c0; col <= c1; col++) {
-            int32_t dc = col - pc; if (dc < 0) dc = -dc;
-            int32_t distance2 = dr2 + dc * dc;
-            if (distance2 >= limit2) continue;
-            bool range_ok = fighting_boss ? (distance2 <= 36) : (distance2 > 81);
-            if (!range_ok) continue;
-            if (mob_row[col]) continue;
-            int32_t block = map_row[col];
-            bool terrain_ok;
-            if (fighting_boss) {
-                terrain_ok = (block == CRAFTAX_BLOCK_GRAVE
-                           || block == CRAFTAX_BLOCK_GRAVE2
-                           || block == CRAFTAX_BLOCK_GRAVE3);
-            } else {
-                terrain_ok = (block == CRAFTAX_BLOCK_GRASS
-                           || block == CRAFTAX_BLOCK_PATH
-                           || block == CRAFTAX_BLOCK_FIRE_GRASS
-                           || block == CRAFTAX_BLOCK_ICE_GRASS);
-            }
-            if (!terrain_ok) continue;
-            coords[n].row = (int16_t)row;
-            coords[n].col = (int16_t)col;
-            n++;
-        }
-    }
-    if (n == 0) return false;
-    int32_t k = craftax_spawn_pick_kth(n, pos_key);
-    *out_row = coords[k].row;
-    *out_col = coords[k].col;
-    return true;
+    craftax_spawn_init_offsets_once();
+    const CraftaxSpawnOffsetSpan* spans = fighting_boss
+        ? craftax_spawn_boss_spans
+        : craftax_spawn_hostile_spans;
+    int32_t span_count = fighting_boss
+        ? craftax_spawn_boss_span_count
+        : craftax_spawn_hostile_span_count;
+    uint64_t terrain_mask = fighting_boss
+        ? CRAFTAX_SPAWN_GRAVE_BLOCK_MASK
+        : CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK;
+    return craftax_spawn_scan_spans(
+        state, level, spans, span_count, terrain_mask, pos_key,
+        out_row, out_col
+    );
 }
 
 static inline bool craftax_spawn_scan_ranged(
@@ -280,59 +561,25 @@ static inline bool craftax_spawn_scan_ranged(
     bool fighting_boss, CraftaxThreefryKey pos_key,
     int32_t* out_row, int32_t* out_col
 ) {
-    int32_t pr = state->player_position[0];
-    int32_t pc = state->player_position[1];
-    int32_t r0 = pr - (CRAFTAX_MOB_DESPAWN_DISTANCE - 1);
-    int32_t r1 = pr + (CRAFTAX_MOB_DESPAWN_DISTANCE - 1);
-    int32_t c0 = pc - (CRAFTAX_MOB_DESPAWN_DISTANCE - 1);
-    int32_t c1 = pc + (CRAFTAX_MOB_DESPAWN_DISTANCE - 1);
-    if (r0 < 0) r0 = 0;
-    if (c0 < 0) c0 = 0;
-    if (r1 > CRAFTAX_MAP_SIZE - 1) r1 = CRAFTAX_MAP_SIZE - 1;
-    if (c1 > CRAFTAX_MAP_SIZE - 1) c1 = CRAFTAX_MAP_SIZE - 1;
-
-    const int32_t limit2 = CRAFTAX_MOB_DESPAWN_DISTANCE
-                         * CRAFTAX_MOB_DESPAWN_DISTANCE;
-    CraftaxSpawnCoord coords[CRAFTAX_SPAWN_BBOX_MAX_CELLS];
-    int32_t n = 0;
-    bool water_type = (new_type == 5);
-    for (int32_t row = r0; row <= r1; row++) {
-        int32_t dr = row - pr; if (dr < 0) dr = -dr;
-        int32_t dr2 = dr * dr;
-        const int32_t* map_row = state->map[level][row];
-        const bool*    mob_row = state->mob_map[level][row];
-        for (int32_t col = c0; col <= c1; col++) {
-            int32_t dc = col - pc; if (dc < 0) dc = -dc;
-            int32_t distance2 = dr2 + dc * dc;
-            if (distance2 >= limit2) continue;
-            bool range_ok = fighting_boss ? (distance2 <= 36) : (distance2 > 81);
-            if (!range_ok) continue;
-            if (mob_row[col]) continue;
-            int32_t block = map_row[col];
-            bool terrain_ok;
-            if (fighting_boss) {
-                terrain_ok = (block == CRAFTAX_BLOCK_GRAVE
-                           || block == CRAFTAX_BLOCK_GRAVE2
-                           || block == CRAFTAX_BLOCK_GRAVE3);
-            } else if (water_type) {
-                terrain_ok = (block == CRAFTAX_BLOCK_WATER);
-            } else {
-                terrain_ok = (block == CRAFTAX_BLOCK_GRASS
-                           || block == CRAFTAX_BLOCK_PATH
-                           || block == CRAFTAX_BLOCK_FIRE_GRASS
-                           || block == CRAFTAX_BLOCK_ICE_GRASS);
-            }
-            if (!terrain_ok) continue;
-            coords[n].row = (int16_t)row;
-            coords[n].col = (int16_t)col;
-            n++;
-        }
+    craftax_spawn_init_offsets_once();
+    const CraftaxSpawnOffsetSpan* spans = fighting_boss
+        ? craftax_spawn_boss_spans
+        : craftax_spawn_hostile_spans;
+    int32_t span_count = fighting_boss
+        ? craftax_spawn_boss_span_count
+        : craftax_spawn_hostile_span_count;
+    uint64_t terrain_mask;
+    if (fighting_boss) {
+        terrain_mask = CRAFTAX_SPAWN_GRAVE_BLOCK_MASK;
+    } else if (new_type == 5) {
+        terrain_mask = CRAFTAX_SPAWN_WATER_BLOCK_MASK;
+    } else {
+        terrain_mask = CRAFTAX_SPAWN_ALL_VALID_BLOCK_MASK;
     }
-    if (n == 0) return false;
-    int32_t k = craftax_spawn_pick_kth(n, pos_key);
-    *out_row = coords[k].row;
-    *out_col = coords[k].col;
-    return true;
+    return craftax_spawn_scan_spans(
+        state, level, spans, span_count, terrain_mask, pos_key,
+        out_row, out_col
+    );
 }
 
 // Both RNG keys are always consumed (preserves baseline RNG sequence).
@@ -365,7 +612,7 @@ static inline void craftax_spawn_passive_mob(
     state->passive_mobs.health[level][slot]      =
         craftax_spawn_mob_type_health(type, CRAFTAX_MOB_PASSIVE);
     state->passive_mobs.mask[level][slot]        = true;
-    state->mob_map[level][row][col] = true;
+    state->mob_bits[level][row] |= (1ULL << col);
 }
 
 static inline void craftax_spawn_melee_mob(
@@ -400,7 +647,7 @@ static inline void craftax_spawn_melee_mob(
     state->melee_mobs.health[level][slot]      =
         craftax_spawn_mob_type_health(type, CRAFTAX_MOB_MELEE);
     state->melee_mobs.mask[level][slot]        = true;
-    state->mob_map[level][row][col] = true;
+    state->mob_bits[level][row] |= (1ULL << col);
 }
 
 static inline void craftax_spawn_ranged_mob(
@@ -433,7 +680,7 @@ static inline void craftax_spawn_ranged_mob(
     state->ranged_mobs.health[level][slot]      =
         craftax_spawn_mob_type_health(type, CRAFTAX_MOB_RANGED);
     state->ranged_mobs.mask[level][slot]        = true;
-    state->mob_map[level][row][col] = true;
+    state->mob_bits[level][row] |= (1ULL << col);
 }
 
 static inline void craftax_spawn_mobs_native(
@@ -454,7 +701,146 @@ static inline void craftax_spawn_mobs_native(
         monster_spawn_coeff *= (int32_t)boss_spawn_wave * 1000;
     }
 
-    craftax_spawn_passive_mob(state, &rng, level, fighting_boss);
-    craftax_spawn_melee_mob(state, &rng, level, fighting_boss, monster_spawn_coeff);
-    craftax_spawn_ranged_mob(state, &rng, level, fighting_boss, monster_spawn_coeff);
+    int32_t passive_count, passive_slot;
+    craftax_spawn_mobs3_count_and_empty(
+        &state->passive_mobs, level, &passive_count, &passive_slot
+    );
+    CraftaxThreefryKey passive_prob_key = craftax_spawn_next_random_key(&rng);
+    CraftaxThreefryKey passive_pos_key = craftax_spawn_next_random_key(&rng);
+    int32_t passive_type = craftax_spawn_floor_mob_type(
+        level, CRAFTAX_MOB_PASSIVE
+    );
+    state->passive_mobs.type_id[level][passive_slot] = passive_type;
+
+    int32_t melee_count, melee_slot;
+    craftax_spawn_mobs3_count_and_empty(
+        &state->melee_mobs, level, &melee_count, &melee_slot
+    );
+    int32_t melee_type = fighting_boss
+        ? craftax_spawn_floor_mob_type(state->boss_progress, CRAFTAX_MOB_MELEE)
+        : craftax_spawn_floor_mob_type(level, CRAFTAX_MOB_MELEE);
+    CraftaxThreefryKey melee_prob_key = craftax_spawn_next_random_key(&rng);
+    float night_coeff = 1.0f - state->light_level;
+    float melee_spawn_chance = craftax_spawn_floor_spawn_chance(level, 1)
+        + craftax_spawn_floor_spawn_chance(level, 3) * night_coeff * night_coeff;
+    CraftaxThreefryKey melee_pos_key = craftax_spawn_next_random_key(&rng);
+    state->melee_mobs.type_id[level][melee_slot] = melee_type;
+
+    int32_t ranged_count, ranged_slot;
+    craftax_spawn_mobs2_count_and_empty(
+        &state->ranged_mobs, level, &ranged_count, &ranged_slot
+    );
+    int32_t ranged_type = fighting_boss
+        ? craftax_spawn_floor_mob_type(state->boss_progress, CRAFTAX_MOB_RANGED)
+        : craftax_spawn_floor_mob_type(level, CRAFTAX_MOB_RANGED);
+    CraftaxThreefryKey ranged_prob_key = craftax_spawn_next_random_key(&rng);
+    CraftaxThreefryKey ranged_pos_key = craftax_spawn_next_random_key(&rng);
+    state->ranged_mobs.type_id[level][ranged_slot] = ranged_type;
+
+    bool try_passive = !fighting_boss
+        && passive_count < CRAFTAX_MAX_PASSIVE_MOBS
+        && craftax_threefry_uniform_f32(passive_prob_key)
+            < craftax_spawn_floor_spawn_chance(level, 0);
+    bool try_melee = melee_count < CRAFTAX_MAX_MELEE_MOBS
+        && craftax_threefry_uniform_f32(melee_prob_key)
+            < melee_spawn_chance * (float)monster_spawn_coeff;
+    bool try_ranged = ranged_count < CRAFTAX_MAX_RANGED_MOBS
+        && craftax_threefry_uniform_f32(ranged_prob_key)
+            < craftax_spawn_floor_spawn_chance(level, 2)
+                * (float)monster_spawn_coeff;
+
+    if (!try_passive && !try_melee && !try_ranged) return;
+
+    int32_t try_count = (int32_t)try_passive
+        + (int32_t)try_melee
+        + (int32_t)try_ranged;
+    if (try_count == 1) {
+        int32_t row, col;
+        if (try_passive && craftax_spawn_scan_passive(
+                state, level, passive_pos_key, &row, &col
+        )) {
+            state->passive_mobs.position[level][passive_slot][0] = row;
+            state->passive_mobs.position[level][passive_slot][1] = col;
+            state->passive_mobs.health[level][passive_slot] =
+                craftax_spawn_mob_type_health(
+                    passive_type, CRAFTAX_MOB_PASSIVE
+                );
+            state->passive_mobs.mask[level][passive_slot] = true;
+            state->mob_bits[level][row] |= (1ULL << col);
+        } else if (try_melee && craftax_spawn_scan_melee(
+                state, level, fighting_boss, melee_pos_key, &row, &col
+        )) {
+            state->melee_mobs.position[level][melee_slot][0] = row;
+            state->melee_mobs.position[level][melee_slot][1] = col;
+            state->melee_mobs.health[level][melee_slot] =
+                craftax_spawn_mob_type_health(melee_type, CRAFTAX_MOB_MELEE);
+            state->melee_mobs.mask[level][melee_slot] = true;
+            state->mob_bits[level][row] |= (1ULL << col);
+        } else if (try_ranged && craftax_spawn_scan_ranged(
+                state, level, ranged_type, fighting_boss, ranged_pos_key,
+                &row, &col
+        )) {
+            state->ranged_mobs.position[level][ranged_slot][0] = row;
+            state->ranged_mobs.position[level][ranged_slot][1] = col;
+            state->ranged_mobs.health[level][ranged_slot] =
+                craftax_spawn_mob_type_health(ranged_type, CRAFTAX_MOB_RANGED);
+            state->ranged_mobs.mask[level][ranged_slot] = true;
+            state->mob_bits[level][row] |= (1ULL << col);
+        }
+        return;
+    }
+
+    CraftaxSpawnLists lists;
+    craftax_spawn_scan_all(
+        state, level, ranged_type, fighting_boss,
+        try_passive, try_melee, try_ranged, &lists
+    );
+
+    bool passive_spawned = false;
+    int32_t passive_row = 0;
+    int32_t passive_col = 0;
+    if (try_passive && craftax_spawn_pick_excluding(
+            lists.passive, lists.passive_count, passive_pos_key,
+            false, 0, 0, false, 0, 0, &passive_row, &passive_col
+        )) {
+        state->passive_mobs.position[level][passive_slot][0] = passive_row;
+        state->passive_mobs.position[level][passive_slot][1] = passive_col;
+        state->passive_mobs.health[level][passive_slot] =
+            craftax_spawn_mob_type_health(passive_type, CRAFTAX_MOB_PASSIVE);
+        state->passive_mobs.mask[level][passive_slot] = true;
+        state->mob_bits[level][passive_row] |= (1ULL << passive_col);
+        passive_spawned = true;
+    }
+
+    bool melee_spawned = false;
+    int32_t melee_row = 0;
+    int32_t melee_col = 0;
+    if (try_melee && craftax_spawn_pick_excluding(
+            lists.melee, lists.melee_count, melee_pos_key,
+            passive_spawned, passive_row, passive_col,
+            false, 0, 0, &melee_row, &melee_col
+        )) {
+        state->melee_mobs.position[level][melee_slot][0] = melee_row;
+        state->melee_mobs.position[level][melee_slot][1] = melee_col;
+        state->melee_mobs.health[level][melee_slot] =
+            craftax_spawn_mob_type_health(melee_type, CRAFTAX_MOB_MELEE);
+        state->melee_mobs.mask[level][melee_slot] = true;
+        state->mob_bits[level][melee_row] |= (1ULL << melee_col);
+        melee_spawned = true;
+    }
+
+    int32_t ranged_row = 0;
+    int32_t ranged_col = 0;
+    if (try_ranged && craftax_spawn_pick_excluding(
+            lists.ranged, lists.ranged_count, ranged_pos_key,
+            passive_spawned, passive_row, passive_col,
+            melee_spawned, melee_row, melee_col, &ranged_row, &ranged_col
+        )) {
+        state->ranged_mobs.position[level][ranged_slot][0] = ranged_row;
+        state->ranged_mobs.position[level][ranged_slot][1] = ranged_col;
+        state->ranged_mobs.health[level][ranged_slot] =
+            craftax_spawn_mob_type_health(ranged_type, CRAFTAX_MOB_RANGED);
+        state->ranged_mobs.mask[level][ranged_slot] = true;
+        state->mob_bits[level][ranged_row] |= (1ULL << ranged_col);
+    }
 }

--- a/ocean/craftax/step_update_mobs.h
+++ b/ocean/craftax/step_update_mobs.h
@@ -79,7 +79,7 @@ static inline void craftax_update_mobs_set_block(
         )) {
         return;
     }
-    state->map[map_level][map_row][map_col] = block;
+    craftax_set_map_block(state, map_level, map_row, map_col, block);
 }
 
 static inline bool craftax_update_mobs_read_mob_map(
@@ -91,7 +91,7 @@ static inline bool craftax_update_mobs_read_mob_map(
     int32_t map_level = craftax_step_jax_index(level, CRAFTAX_NUM_LEVELS);
     int32_t map_row = craftax_step_jax_index(row, CRAFTAX_MAP_SIZE);
     int32_t map_col = craftax_step_jax_index(col, CRAFTAX_MAP_SIZE);
-    return state->mob_map[map_level][map_row][map_col];
+    return (state->mob_bits[map_level][map_row] >> map_col) & 1ULL;
 }
 
 static inline void craftax_update_mobs_set_mob_map(
@@ -121,7 +121,11 @@ static inline void craftax_update_mobs_set_mob_map(
         )) {
         return;
     }
-    state->mob_map[map_level][map_row][map_col] = value;
+    if (value) {
+        state->mob_bits[map_level][map_row] |= (1ULL << map_col);
+    } else {
+        state->mob_bits[map_level][map_row] &= ~(1ULL << map_col);
+    }
 }
 
 static inline void craftax_update_mobs_clear_old_map_entry(
@@ -421,22 +425,18 @@ static inline int32_t craftax_update_mobs_count_mob_projectiles(
     const CraftaxState* state,
     int32_t level
 ) {
-    int32_t count = 0;
-    for (int32_t i = 0; i < CRAFTAX_MAX_MOB_PROJECTILES; i++) {
-        count += (int32_t)state->mob_projectiles.mask[level][i];
-    }
-    return count;
+    const bool* mask = state->mob_projectiles.mask[level];
+    return (int32_t)mask[0] + (int32_t)mask[1] + (int32_t)mask[2];
 }
 
 static inline int32_t craftax_update_mobs_first_empty_mob_projectile(
     const CraftaxState* state,
     int32_t level
 ) {
-    for (int32_t i = 0; i < CRAFTAX_MAX_MOB_PROJECTILES; i++) {
-        if (!state->mob_projectiles.mask[level][i]) {
-            return i;
-        }
-    }
+    const bool* mask = state->mob_projectiles.mask[level];
+    if (!mask[0]) return 0;
+    if (!mask[1]) return 1;
+    if (!mask[2]) return 2;
     return 0;
 }
 
@@ -1094,27 +1094,26 @@ static inline void craftax_update_mobs_native(
     CraftaxThreefryKey unused;
 
     craftax_threefry_split(rng, &rng, &unused);
-    for (int32_t i = 0; i < CRAFTAX_MAX_MELEE_MOBS; i++) {
-        craftax_update_mobs_move_melee(state, &rng, i);
-    }
+    craftax_update_mobs_move_melee(state, &rng, 0);
+    craftax_update_mobs_move_melee(state, &rng, 1);
+    craftax_update_mobs_move_melee(state, &rng, 2);
 
     craftax_threefry_split(rng, &rng, &unused);
-    for (int32_t i = 0; i < CRAFTAX_MAX_PASSIVE_MOBS; i++) {
-        craftax_update_mobs_move_passive(state, &rng, i);
-    }
+    craftax_update_mobs_move_passive(state, &rng, 0);
+    craftax_update_mobs_move_passive(state, &rng, 1);
+    craftax_update_mobs_move_passive(state, &rng, 2);
 
     craftax_threefry_split(rng, &rng, &unused);
-    for (int32_t i = 0; i < CRAFTAX_MAX_RANGED_MOBS; i++) {
-        craftax_update_mobs_move_ranged(state, &rng, i);
-    }
+    craftax_update_mobs_move_ranged(state, &rng, 0);
+    craftax_update_mobs_move_ranged(state, &rng, 1);
 
     craftax_threefry_split(rng, &rng, &unused);
-    for (int32_t i = 0; i < CRAFTAX_MAX_MOB_PROJECTILES; i++) {
-        craftax_update_mobs_move_mob_projectile(state, i);
-    }
+    craftax_update_mobs_move_mob_projectile(state, 0);
+    craftax_update_mobs_move_mob_projectile(state, 1);
+    craftax_update_mobs_move_mob_projectile(state, 2);
 
     craftax_threefry_split(rng, &rng, &unused);
-    for (int32_t i = 0; i < CRAFTAX_MAX_PLAYER_PROJECTILES; i++) {
-        craftax_update_mobs_move_player_projectile(state, i);
-    }
+    craftax_update_mobs_move_player_projectile(state, 0);
+    craftax_update_mobs_move_player_projectile(state, 1);
+    craftax_update_mobs_move_player_projectile(state, 2);
 }

--- a/ocean/craftax/threefry.h
+++ b/ocean/craftax/threefry.h
@@ -1,8 +1,6 @@
-// JAX-compatible threefry2x32 helpers for Craftax.
-//
-// The local JAX version uses the partitionable threefry split path by default:
-// split(key, n)[i] is threefry2x32(key, counter=(0, i)). 32-bit random bits
-// are bits0 ^ bits1 from the same counter schedule.
+// Fast RNG helpers for Craftax.
+// Replaces JAX Threefry with SplitMix64-based hashing for ~20-50x speedup.
+// NOT cryptographically secure and NOT JAX-compatible.
 
 #pragma once
 
@@ -14,13 +12,39 @@ typedef struct CraftaxThreefryKey {
     uint32_t word[2];
 } CraftaxThreefryKey;
 
+static inline uint64_t craftax_key_to_u64(CraftaxThreefryKey key) {
+    return ((uint64_t)key.word[1] << 32) | key.word[0];
+}
+
+static inline CraftaxThreefryKey craftax_u64_to_key(uint64_t x) {
+    CraftaxThreefryKey key = {{(uint32_t)x, (uint32_t)(x >> 32)}};
+    return key;
+}
+
 static inline uint32_t craftax_rotl32(uint32_t x, uint32_t k) {
     return (uint32_t)((x << k) | (x >> (32u - k)));
 }
 
 static inline CraftaxThreefryKey craftax_prng_key(uint32_t seed) {
-    CraftaxThreefryKey key = {{0u, seed}};
+    CraftaxThreefryKey key = {{seed, seed ^ 0x9E3779B9u}};
     return key;
+}
+
+// MurmurHash3 64-bit finalizer — fast and good mixing
+static inline uint64_t craftax_mix64(uint64_t x) {
+    x ^= x >> 33;
+    x *= 0xff51afd7ed558ccdULL;
+    x ^= x >> 33;
+    x *= 0xc4ceb9fe1a85ec53ULL;
+    x ^= x >> 33;
+    return x;
+}
+
+// Core hash: mixes key state with counter, returns 64 bits of pseudo-randomness
+static inline uint64_t craftax_fast_hash64(CraftaxThreefryKey key, uint64_t counter) {
+    uint64_t x = craftax_key_to_u64(key);
+    x ^= counter;
+    return craftax_mix64(x);
 }
 
 static inline void craftax_threefry2x32(
@@ -29,32 +53,9 @@ static inline void craftax_threefry2x32(
     uint32_t count1,
     uint32_t out[2]
 ) {
-    static const uint32_t rotations[2][4] = {
-        {13u, 15u, 26u, 6u},
-        {17u, 29u, 16u, 24u},
-    };
-
-    uint32_t ks[3] = {
-        key.word[0],
-        key.word[1],
-        key.word[0] ^ key.word[1] ^ 0x1BD11BDAu,
-    };
-    uint32_t x0 = count0 + ks[0];
-    uint32_t x1 = count1 + ks[1];
-
-    for (uint32_t block = 0; block < 5u; block++) {
-        const uint32_t* rs = rotations[block & 1u];
-        for (int i = 0; i < 4; i++) {
-            x0 += x1;
-            x1 = craftax_rotl32(x1, rs[i]);
-            x1 ^= x0;
-        }
-        x0 += ks[(block + 1u) % 3u];
-        x1 += ks[(block + 2u) % 3u] + block + 1u;
-    }
-
-    out[0] = x0;
-    out[1] = x1;
+    uint64_t h = craftax_fast_hash64(key, ((uint64_t)count1 << 32) | count0);
+    out[0] = (uint32_t)h;
+    out[1] = (uint32_t)(h >> 32);
 }
 
 static inline CraftaxThreefryKey craftax_threefry_counter_key(
@@ -62,19 +63,20 @@ static inline CraftaxThreefryKey craftax_threefry_counter_key(
     uint32_t count0,
     uint32_t count1
 ) {
-    uint32_t out[2];
-    craftax_threefry2x32(key, count0, count1, out);
-    CraftaxThreefryKey result = {{out[0], out[1]}};
-    return result;
+    return craftax_u64_to_key(craftax_fast_hash64(key, ((uint64_t)count1 << 32) | count0));
 }
 
+// Fast split: sequential PCG-style advancement
 static inline void craftax_threefry_split(
     CraftaxThreefryKey key,
     CraftaxThreefryKey* left,
     CraftaxThreefryKey* right
 ) {
-    *left = craftax_threefry_counter_key(key, 0u, 0u);
-    *right = craftax_threefry_counter_key(key, 0u, 1u);
+    uint64_t state = craftax_key_to_u64(key);
+    uint64_t s1 = state * 6364136223846793005ULL + 1;
+    uint64_t s2 = s1 * 6364136223846793005ULL + 1;
+    *left = craftax_u64_to_key(s1);
+    *right = craftax_u64_to_key(s2);
 }
 
 static inline void craftax_threefry_split_n(
@@ -82,13 +84,10 @@ static inline void craftax_threefry_split_n(
     CraftaxThreefryKey* out,
     size_t count
 ) {
+    uint64_t state = craftax_key_to_u64(key);
     for (size_t i = 0; i < count; i++) {
-        uint64_t counter = (uint64_t)i;
-        out[i] = craftax_threefry_counter_key(
-            key,
-            (uint32_t)(counter >> 32),
-            (uint32_t)counter
-        );
+        state = state * 6364136223846793005ULL + 1;
+        out[i] = craftax_u64_to_key(state);
     }
 }
 
@@ -103,14 +102,8 @@ static inline uint32_t craftax_threefry_uniform_u32_at(
     CraftaxThreefryKey key,
     uint64_t index
 ) {
-    uint32_t out[2];
-    craftax_threefry2x32(
-        key,
-        (uint32_t)(index >> 32),
-        (uint32_t)index,
-        out
-    );
-    return out[0] ^ out[1];
+    uint64_t h = craftax_fast_hash64(key, index);
+    return (uint32_t)h ^ (uint32_t)(h >> 32);
 }
 
 static inline uint32_t craftax_threefry_uniform_u32(CraftaxThreefryKey key) {

--- a/ocean/craftax/worldgen.h
+++ b/ocean/craftax/worldgen.h
@@ -23,7 +23,99 @@
 #define CRAFTAX_WG_NUM_MOB_CLASSES 5
 #define CRAFTAX_WG_NUM_MOB_TYPES 8
 #define CRAFTAX_WG_INVENTORY_OBS_SIZE 51
-#define CRAFTAX_WG_OBS_SIZE 8268
+
+// Compact binary observation encoding.
+// Each cell uses binary channels instead of one-hot:
+//   6 bits: block type (0-63, covers 37 block types)
+//   3 bits: item type+1 (0=no item, 1-5=item types)
+//   4 bits per mob class: mob type+1 (0=no mob, 1-8=types) x 5 classes
+//   1 bit : visibility
+// Total: 30 binary channels per cell.
+#define CRAFTAX_WG_BINARY_BLOCK_BITS 6
+#define CRAFTAX_WG_BINARY_ITEM_BITS 3
+#define CRAFTAX_WG_BINARY_MOB_BITS 4
+#define CRAFTAX_WG_BINARY_VISIBILITY_BITS 1
+
+#define CRAFTAX_WG_BINARY_CHANNELS_PER_CELL ( \
+    CRAFTAX_WG_BINARY_BLOCK_BITS + \
+    CRAFTAX_WG_BINARY_ITEM_BITS + \
+    CRAFTAX_WG_NUM_MOB_CLASSES * CRAFTAX_WG_BINARY_MOB_BITS + \
+    CRAFTAX_WG_BINARY_VISIBILITY_BITS \
+)
+
+#define CRAFTAX_WG_BINARY_MAP_OBS_SIZE ( \
+    CRAFTAX_WG_OBS_ROWS * CRAFTAX_WG_OBS_COLS * CRAFTAX_WG_BINARY_CHANNELS_PER_CELL \
+)
+#define CRAFTAX_WG_OBS_WINDOW_CELLS (CRAFTAX_WG_OBS_ROWS * CRAFTAX_WG_OBS_COLS)
+#define CRAFTAX_WG_CELL_TEMPLATE_BYTES ( \
+    CRAFTAX_WG_BINARY_CHANNELS_PER_CELL * sizeof(float) \
+)
+#define CRAFTAX_WG_FULL_OBS_SIZE ( \
+    CRAFTAX_WG_BINARY_MAP_OBS_SIZE + CRAFTAX_WG_INVENTORY_OBS_SIZE \
+)
+
+// Moonshot symbolic observation. Each visible cell stores compact float IDs:
+// block, item+1, visible, and one mob type+1 slot for each mob class.
+// The 51 scalar channels remain exact floats for oracle-expandability.
+#define CRAFTAX_WG_PACKED_CHANNELS_PER_CELL (3 + CRAFTAX_WG_NUM_MOB_CLASSES)
+#define CRAFTAX_WG_PACKED_MAP_OBS_SIZE ( \
+    CRAFTAX_WG_OBS_ROWS * CRAFTAX_WG_OBS_COLS * CRAFTAX_WG_PACKED_CHANNELS_PER_CELL \
+)
+#define CRAFTAX_WG_PACKED_OBS_SIZE ( \
+    CRAFTAX_WG_PACKED_MAP_OBS_SIZE + CRAFTAX_WG_INVENTORY_OBS_SIZE \
+)
+
+// Lookup tables for fast binary bit writing (eliminates loops/branches)
+static const float CRAFTAX_WG_BLOCK_LUT[64][6] = {
+    {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f},{1.0f,0.0f,0.0f,0.0f,0.0f,0.0f},{0.0f,1.0f,0.0f,0.0f,0.0f,0.0f},{1.0f,1.0f,0.0f,0.0f,0.0f,0.0f},
+    {0.0f,0.0f,1.0f,0.0f,0.0f,0.0f},{1.0f,0.0f,1.0f,0.0f,0.0f,0.0f},{0.0f,1.0f,1.0f,0.0f,0.0f,0.0f},{1.0f,1.0f,1.0f,0.0f,0.0f,0.0f},
+    {0.0f,0.0f,0.0f,1.0f,0.0f,0.0f},{1.0f,0.0f,0.0f,1.0f,0.0f,0.0f},{0.0f,1.0f,0.0f,1.0f,0.0f,0.0f},{1.0f,1.0f,0.0f,1.0f,0.0f,0.0f},
+    {0.0f,0.0f,1.0f,1.0f,0.0f,0.0f},{1.0f,0.0f,1.0f,1.0f,0.0f,0.0f},{0.0f,1.0f,1.0f,1.0f,0.0f,0.0f},{1.0f,1.0f,1.0f,1.0f,0.0f,0.0f},
+    {0.0f,0.0f,0.0f,0.0f,1.0f,0.0f},{1.0f,0.0f,0.0f,0.0f,1.0f,0.0f},{0.0f,1.0f,0.0f,0.0f,1.0f,0.0f},{1.0f,1.0f,0.0f,0.0f,1.0f,0.0f},
+    {0.0f,0.0f,1.0f,0.0f,1.0f,0.0f},{1.0f,0.0f,1.0f,0.0f,1.0f,0.0f},{0.0f,1.0f,1.0f,0.0f,1.0f,0.0f},{1.0f,1.0f,1.0f,0.0f,1.0f,0.0f},
+    {0.0f,0.0f,0.0f,1.0f,1.0f,0.0f},{1.0f,0.0f,0.0f,1.0f,1.0f,0.0f},{0.0f,1.0f,0.0f,1.0f,1.0f,0.0f},{1.0f,1.0f,0.0f,1.0f,1.0f,0.0f},
+    {0.0f,0.0f,1.0f,1.0f,1.0f,0.0f},{1.0f,0.0f,1.0f,1.0f,1.0f,0.0f},{0.0f,1.0f,1.0f,1.0f,1.0f,0.0f},{1.0f,1.0f,1.0f,1.0f,1.0f,0.0f},
+    {0.0f,0.0f,0.0f,0.0f,0.0f,1.0f},{1.0f,0.0f,0.0f,0.0f,0.0f,1.0f},{0.0f,1.0f,0.0f,0.0f,0.0f,1.0f},{1.0f,1.0f,0.0f,0.0f,0.0f,1.0f},
+    {0.0f,0.0f,1.0f,0.0f,0.0f,1.0f},{1.0f,0.0f,1.0f,0.0f,0.0f,1.0f},{0.0f,1.0f,1.0f,0.0f,0.0f,1.0f},{1.0f,1.0f,1.0f,0.0f,0.0f,1.0f},
+    {0.0f,0.0f,0.0f,1.0f,0.0f,1.0f},{1.0f,0.0f,0.0f,1.0f,0.0f,1.0f},{0.0f,1.0f,0.0f,1.0f,0.0f,1.0f},{1.0f,1.0f,0.0f,1.0f,0.0f,1.0f},
+    {0.0f,0.0f,1.0f,1.0f,0.0f,1.0f},{1.0f,0.0f,1.0f,1.0f,0.0f,1.0f},{0.0f,1.0f,1.0f,1.0f,0.0f,1.0f},{1.0f,1.0f,1.0f,1.0f,0.0f,1.0f},
+    {0.0f,0.0f,0.0f,0.0f,1.0f,1.0f},{1.0f,0.0f,0.0f,0.0f,1.0f,1.0f},{0.0f,1.0f,0.0f,0.0f,1.0f,1.0f},{1.0f,1.0f,0.0f,0.0f,1.0f,1.0f},
+    {0.0f,0.0f,1.0f,0.0f,1.0f,1.0f},{1.0f,0.0f,1.0f,0.0f,1.0f,1.0f},{0.0f,1.0f,1.0f,0.0f,1.0f,1.0f},{1.0f,1.0f,1.0f,0.0f,1.0f,1.0f},
+    {0.0f,0.0f,0.0f,1.0f,1.0f,1.0f},{1.0f,0.0f,0.0f,1.0f,1.0f,1.0f},{0.0f,1.0f,0.0f,1.0f,1.0f,1.0f},{1.0f,1.0f,0.0f,1.0f,1.0f,1.0f},
+    {0.0f,0.0f,1.0f,1.0f,1.0f,1.0f},{1.0f,0.0f,1.0f,1.0f,1.0f,1.0f},{0.0f,1.0f,1.0f,1.0f,1.0f,1.0f},{1.0f,1.0f,1.0f,1.0f,1.0f,1.0f},
+};
+static const float CRAFTAX_WG_ITEM_LUT[8][3] = {
+    {0.0f,0.0f,0.0f},{1.0f,0.0f,0.0f},{0.0f,1.0f,0.0f},{1.0f,1.0f,0.0f},
+    {0.0f,0.0f,1.0f},{1.0f,0.0f,1.0f},{0.0f,1.0f,1.0f},{1.0f,1.0f,1.0f},
+};
+static const float CRAFTAX_WG_MOB_LUT[16][4] = {
+    {0.0f,0.0f,0.0f,0.0f},{1.0f,0.0f,0.0f,0.0f},{0.0f,1.0f,0.0f,0.0f},{1.0f,1.0f,0.0f,0.0f},
+    {0.0f,0.0f,1.0f,0.0f},{1.0f,0.0f,1.0f,0.0f},{0.0f,1.0f,1.0f,0.0f},{1.0f,1.0f,1.0f,0.0f},
+    {0.0f,0.0f,0.0f,1.0f},{1.0f,0.0f,0.0f,1.0f},{0.0f,1.0f,0.0f,1.0f},{1.0f,1.0f,0.0f,1.0f},
+    {0.0f,0.0f,1.0f,1.0f},{1.0f,0.0f,1.0f,1.0f},{0.0f,1.0f,1.0f,1.0f},{1.0f,1.0f,1.0f,1.0f},
+};
+static float CRAFTAX_WG_VISIBLE_CELL_TEMPLATE_LUT[64][8][CRAFTAX_WG_BINARY_CHANNELS_PER_CELL];
+static float CRAFTAX_WG_EMPTY_CELL_TEMPLATE[CRAFTAX_WG_BINARY_CHANNELS_PER_CELL];
+static bool CRAFTAX_WG_CELL_TEMPLATE_READY = false;
+
+static inline void craftax_wg_init_cell_templates(void) {
+    if (CRAFTAX_WG_CELL_TEMPLATE_READY) {
+        return;
+    }
+
+    for (int block = 0; block < 64; block++) {
+        for (int item = 0; item < 8; item++) {
+            float* cell = CRAFTAX_WG_VISIBLE_CELL_TEMPLATE_LUT[block][item];
+            memcpy(cell, CRAFTAX_WG_BLOCK_LUT[block], 6 * sizeof(float));
+            memcpy(cell + CRAFTAX_WG_BINARY_BLOCK_BITS, CRAFTAX_WG_ITEM_LUT[item], 3 * sizeof(float));
+            cell[CRAFTAX_WG_BINARY_CHANNELS_PER_CELL - 1] = 1.0f;
+        }
+    }
+
+    CRAFTAX_WG_CELL_TEMPLATE_READY = true;
+}
+
+#define CRAFTAX_WG_OBS_SIZE CRAFTAX_WG_PACKED_OBS_SIZE
 #define CRAFTAX_WG_NUM_ACHIEVEMENTS 67
 #define CRAFTAX_WG_MAX_MELEE_MOBS 3
 #define CRAFTAX_WG_MAX_PASSIVE_MOBS 3
@@ -86,9 +178,9 @@
 #define CRAFTAX_WG_PI 3.14159265358979323846f
 
 typedef struct CraftaxOverworldFloor {
-    int32_t map[CRAFTAX_OVERWORLD_SIZE][CRAFTAX_OVERWORLD_SIZE];
-    int32_t item_map[CRAFTAX_OVERWORLD_SIZE][CRAFTAX_OVERWORLD_SIZE];
-    float light_map[CRAFTAX_OVERWORLD_SIZE][CRAFTAX_OVERWORLD_SIZE];
+    uint8_t map[CRAFTAX_OVERWORLD_SIZE][CRAFTAX_OVERWORLD_SIZE];
+    uint8_t item_map[CRAFTAX_OVERWORLD_SIZE][CRAFTAX_OVERWORLD_SIZE];
+    uint8_t light_map[CRAFTAX_OVERWORLD_SIZE][CRAFTAX_OVERWORLD_SIZE];
     int32_t ladder_down[2];
     int32_t ladder_up[2];
 } CraftaxOverworldFloor;
@@ -129,15 +221,7 @@ typedef struct CraftaxWGMobs2 {
 } CraftaxWGMobs2;
 
 typedef struct CraftaxWorldState {
-    int32_t map[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE];
-    int32_t item_map[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE];
-    bool mob_map[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE];
-    float light_map[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE];
-    int32_t down_ladders[CRAFTAX_WG_NUM_LEVELS][2];
-    int32_t up_ladders[CRAFTAX_WG_NUM_LEVELS][2];
-    bool chests_opened[CRAFTAX_WG_NUM_LEVELS];
-    int32_t monsters_killed[CRAFTAX_WG_NUM_LEVELS];
-
+    // === Hot data (accessed every step) ===
     int32_t player_position[2];
     int32_t player_level;
     int32_t player_direction;
@@ -191,6 +275,22 @@ typedef struct CraftaxWorldState {
     uint32_t state_rng[2];
     int32_t timestep;
     int32_t fractal_noise_angles[4];
+
+    // === Medium-hot bitmaps ===
+    uint64_t mob_bits[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE];
+    uint64_t spawn_all_bits[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE];
+    uint64_t spawn_grave_bits[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE];
+    uint64_t spawn_water_bits[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE];
+
+    // === Cold data (large maps) ===
+    uint8_t map[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE];
+    uint8_t item_map[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE];
+    uint8_t light_map[CRAFTAX_WG_NUM_LEVELS][CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE];
+
+    int32_t down_ladders[CRAFTAX_WG_NUM_LEVELS][2];
+    int32_t up_ladders[CRAFTAX_WG_NUM_LEVELS][2];
+    bool chests_opened[CRAFTAX_WG_NUM_LEVELS];
+    int32_t monsters_killed[CRAFTAX_WG_NUM_LEVELS];
 } CraftaxWorldState;
 
 typedef struct CraftaxSmoothGenConfig {
@@ -460,20 +560,15 @@ static inline uint32_t craftax_randint_u32_at(
     uint32_t minval,
     uint32_t maxval
 ) {
-    CraftaxThreefryKey k1;
-    CraftaxThreefryKey k2;
-    craftax_threefry_split(key, &k1, &k2);
-
-    uint32_t higher_bits = craftax_threefry_uniform_u32_at(k1, index);
-    uint32_t lower_bits = craftax_threefry_uniform_u32_at(k2, index);
     uint32_t span = maxval > minval ? maxval - minval : 1u;
-    uint32_t multiplier = 65536u % span;
-    multiplier = (uint32_t)(((uint64_t)multiplier * (uint64_t)multiplier) % (uint64_t)span);
-    uint32_t random_offset = (uint32_t)(
-        (((uint64_t)(higher_bits % span) * (uint64_t)multiplier) + (uint64_t)(lower_bits % span))
-        % (uint64_t)span
-    );
-    return minval + random_offset;
+    // Fast path for power-of-2 spans: just mask
+    if ((span & (span - 1)) == 0) {
+        uint32_t bits = craftax_threefry_uniform_u32_at(key, index);
+        return minval + (bits & (span - 1));
+    }
+    // General path: use top-32 of hash, scale to span
+    uint64_t h = craftax_fast_hash64(key, index);
+    return minval + (uint32_t)(((h >> 32) * (uint64_t)span) >> 32);
 }
 
 static inline int32_t craftax_randint_i32_at(
@@ -529,7 +624,7 @@ static inline float craftax_torch_light_value(int row, int col, float default_li
 }
 
 static inline void craftax_apply_ladder_light(
-    float light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
     const int32_t ladder_up[2],
     float default_light
 ) {
@@ -546,13 +641,13 @@ static inline void craftax_apply_ladder_light(
     for (int row = 0; row < 9; row++) {
         for (int col = 0; col < 9; col++) {
             light_map[start_row + row][start_col + col] =
-                craftax_torch_light_value(row, col, default_light);
+                (uint8_t)(craftax_torch_light_value(row, col, default_light) * 255.0f);
         }
     }
 }
 
 static inline void craftax_add_lava_light(
-    float light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
     const bool lava_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
     bool lava_emits_light
 ) {
@@ -582,7 +677,8 @@ static inline void craftax_add_lava_light(
                     add += lava_map[src_row][src_col] ? kernel[kr][kc] : 0.0f;
                 }
             }
-            light_map[row][col] = craftax_wg_clampf(light_map[row][col] + add, 0.0f, 1.0f);
+            float new_light = craftax_wg_clampf(light_map[row][col] / 255.0f + add, 0.0f, 1.0f);
+            light_map[row][col] = (uint8_t)(new_light * 255.0f);
         }
     }
 }
@@ -622,9 +718,9 @@ static inline int craftax_dungeon_config_index_for_floor(int floor_idx) {
 static inline void craftax_generate_smoothworld_config(
     CraftaxThreefryKey rng,
     int config_idx,
-    int32_t map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
-    int32_t item_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
-    float light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t item_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
     int32_t ladder_down[2],
     int32_t ladder_up[2]
 ) {
@@ -714,9 +810,9 @@ static inline void craftax_generate_smoothworld_config(
                 block = config->tree;
             }
 
-            map[row][col] = block;
+            map[row][col] = (uint8_t)block;
             item_map[row][col] = CRAFTAX_WG_ITEM_NONE;
-            light_map[row][col] = config->default_light;
+            light_map[row][col] = (uint8_t)(config->default_light * 255.0f);
         }
     }
 
@@ -731,7 +827,7 @@ static inline void craftax_generate_smoothworld_config(
                 bool is_ore = map[row][col] == config->ore_requirement_blocks[ore_index]
                     && craftax_threefry_uniform_f32_at(ore_key, idx) < config->ore_chances[ore_index];
                 if (is_ore) {
-                    map[row][col] = config->ores[ore_index];
+                    map[row][col] = (uint8_t)config->ores[ore_index];
                 }
             }
         }
@@ -742,7 +838,7 @@ static inline void craftax_generate_smoothworld_config(
             size_t idx = craftax_wg_index(row, col);
             lava_map[row][col] = mountain[idx] > 0.85f && tree_noise[idx] > 0.7f;
             if (lava_map[row][col]) {
-                map[row][col] = config->lava;
+                map[row][col] = (uint8_t)config->lava;
             }
         }
     }
@@ -755,9 +851,9 @@ static inline void craftax_generate_smoothworld_config(
         }
     }
     int diamond_index = craftax_choice_bool_flat(subkey, valid_diamond, (int)cells);
-    map[diamond_index / size][diamond_index % size] = CRAFTAX_WG_BLOCK_STONE;
+    map[diamond_index / size][diamond_index % size] = (uint8_t)CRAFTAX_WG_BLOCK_STONE;
 
-    map[player_row][player_col] = config->player_spawn;
+    map[player_row][player_col] = (uint8_t)config->player_spawn;
 
     bool valid_ladder[CRAFTAX_WG_MAP_CELLS];
     for (int row = 0; row < size; row++) {
@@ -790,17 +886,17 @@ static inline void craftax_generate_smoothworld_config(
 static inline void craftax_generate_smoothworld_floor(
     CraftaxThreefryKey seed_key,
     int floor_idx,
-    int32_t map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
-    int32_t item_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
-    float light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t item_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
     int32_t ladder_down[2],
     int32_t ladder_up[2]
 ) {
     int config_idx = craftax_smooth_config_index_for_floor(floor_idx);
     if (config_idx < 0) {
-        memset(map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(int32_t));
-        memset(item_map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(int32_t));
-        memset(light_map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(float));
+        memset(map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(uint8_t));
+        memset(item_map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(uint8_t));
+        memset(light_map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(uint8_t));
         ladder_down[0] = 0;
         ladder_down[1] = 0;
         ladder_up[0] = 0;
@@ -821,9 +917,9 @@ static inline void craftax_generate_smoothworld_floor(
 static inline void craftax_generate_dungeon_config(
     CraftaxThreefryKey rng,
     int config_idx,
-    int32_t map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
-    int32_t item_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
-    float light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t item_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
     int32_t ladder_down[2],
     int32_t ladder_up[2]
 ) {
@@ -835,8 +931,8 @@ static inline void craftax_generate_dungeon_config(
     const int max_room_size = 10;
     const int padded_size = CRAFTAX_WG_MAP_SIZE + 2 * max_room_size;
 
-    int32_t padded_map[68][68];
-    int32_t padded_item_map[68][68];
+    uint8_t padded_map[68][68];
+    uint8_t padded_item_map[68][68];
     bool room_occupancy_chunks[9];
     int32_t room_sizes[8][2];
     int32_t room_positions[8][2];
@@ -1005,7 +1101,7 @@ static inline void craftax_generate_dungeon_config(
             } else {
                 map[row][col] = path_map;
             }
-            light_map[row][col] = 1.0f;
+            light_map[row][col] = 255;
         }
     }
 
@@ -1034,17 +1130,17 @@ static inline void craftax_generate_dungeon_config(
 static inline void craftax_generate_dungeon_floor(
     CraftaxThreefryKey seed_key,
     int floor_idx,
-    int32_t map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
-    int32_t item_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
-    float light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t item_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
+    uint8_t light_map[CRAFTAX_WG_MAP_SIZE][CRAFTAX_WG_MAP_SIZE],
     int32_t ladder_down[2],
     int32_t ladder_up[2]
 ) {
     int config_idx = craftax_dungeon_config_index_for_floor(floor_idx);
     if (config_idx < 0) {
-        memset(map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(int32_t));
-        memset(item_map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(int32_t));
-        memset(light_map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(float));
+        memset(map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(uint8_t));
+        memset(item_map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(uint8_t));
+        memset(light_map, 0, CRAFTAX_WG_MAP_CELLS * sizeof(uint8_t));
         ladder_down[0] = 0;
         ladder_down[1] = 0;
         ladder_up[0] = 0;
@@ -1310,8 +1406,7 @@ static inline void craftax_encode_mobs3_observation(
             && world_row < CRAFTAX_WG_MAP_SIZE
             && world_col >= 0
             && world_col < CRAFTAX_WG_MAP_SIZE;
-        float light = in_bounds ? state->light_map[level][world_row][world_col] : 0.0f;
-        bool visible = light > 0.05f;
+        bool visible = in_bounds && state->light_map[level][world_row][world_col] > 12;
         int obs_base = (scatter_row * CRAFTAX_WG_OBS_COLS + scatter_col) * channels;
         int channel = mob_channels_offset
             + mob_class_index * CRAFTAX_WG_NUM_MOB_TYPES
@@ -1365,8 +1460,7 @@ static inline void craftax_encode_mobs2_observation(
             && world_row < CRAFTAX_WG_MAP_SIZE
             && world_col >= 0
             && world_col < CRAFTAX_WG_MAP_SIZE;
-        float light = in_bounds ? state->light_map[level][world_row][world_col] : 0.0f;
-        bool visible = light > 0.05f;
+        bool visible = in_bounds && state->light_map[level][world_row][world_col] > 12;
         int obs_base = (scatter_row * CRAFTAX_WG_OBS_COLS + scatter_col) * channels;
         int channel = mob_channels_offset
             + mob_class_index * CRAFTAX_WG_NUM_MOB_TYPES
@@ -1376,95 +1470,328 @@ static inline void craftax_encode_mobs2_observation(
     }
 }
 
-static inline void craftax_encode_reset_observation(
+static inline void craftax_write_binary_bits(
+    float* obs,
+    int base,
+    int value,
+    int num_bits
+) {
+    if (num_bits == 6) {
+        memcpy(obs + base, CRAFTAX_WG_BLOCK_LUT[value], 6 * sizeof(float));
+    } else if (num_bits == 3) {
+        memcpy(obs + base, CRAFTAX_WG_ITEM_LUT[value], 3 * sizeof(float));
+    } else if (num_bits == 4) {
+        memcpy(obs + base, CRAFTAX_WG_MOB_LUT[value], 4 * sizeof(float));
+    } else {
+        for (int i = 0; i < num_bits; i++) {
+            obs[base + i] = (value & (1 << i)) ? 1.0f : 0.0f;
+        }
+    }
+}
+
+static inline void craftax_encode_mobs3_binary(
+    const CraftaxWorldState* state,
+    const CraftaxWGMobs3* mobs,
+    int mob_class_index,
+    int channels_per_cell,
+    int mob_bits_offset,
+    float* obs
+) {
+    int level = craftax_wg_jax_index(state->player_level, CRAFTAX_WG_NUM_LEVELS);
+    for (int i = 0; i < 3; i++) {
+        int type_id = mobs->type_id[level][i];
+        if (type_id < 0 || type_id >= CRAFTAX_WG_NUM_MOB_TYPES
+            || !mobs->mask[level][i]) {
+            continue;
+        }
+
+        int local_row = mobs->position[level][i][0]
+            - state->player_position[0]
+            + CRAFTAX_WG_OBS_ROWS / 2;
+        int local_col = mobs->position[level][i][1]
+            - state->player_position[1]
+            + CRAFTAX_WG_OBS_COLS / 2;
+        if (local_row < 0 || local_row >= CRAFTAX_WG_OBS_ROWS
+            || local_col < 0 || local_col >= CRAFTAX_WG_OBS_COLS) {
+            continue;
+        }
+
+        int world_row = mobs->position[level][i][0];
+        int world_col = mobs->position[level][i][1];
+        if (world_row < 0 || world_row >= CRAFTAX_WG_MAP_SIZE
+            || world_col < 0 || world_col >= CRAFTAX_WG_MAP_SIZE
+            || state->light_map[level][world_row][world_col] <= 12) {
+            continue;
+        }
+
+        int obs_base = (local_row * CRAFTAX_WG_OBS_COLS + local_col)
+            * channels_per_cell;
+        int class_offset = mob_bits_offset
+            + mob_class_index * CRAFTAX_WG_BINARY_MOB_BITS;
+        memcpy(obs + obs_base + class_offset,
+               CRAFTAX_WG_MOB_LUT[type_id + 1],
+               CRAFTAX_WG_BINARY_MOB_BITS * sizeof(float));
+    }
+}
+
+static inline void craftax_encode_mobs2_binary(
+    const CraftaxWorldState* state,
+    const CraftaxWGMobs2* mobs,
+    int mob_class_index,
+    int channels_per_cell,
+    int mob_bits_offset,
+    float* obs
+) {
+    int level = craftax_wg_jax_index(state->player_level, CRAFTAX_WG_NUM_LEVELS);
+    for (int i = 0; i < 2; i++) {
+        int type_id = mobs->type_id[level][i];
+        if (type_id < 0 || type_id >= CRAFTAX_WG_NUM_MOB_TYPES
+            || !mobs->mask[level][i]) {
+            continue;
+        }
+
+        int local_row = mobs->position[level][i][0]
+            - state->player_position[0]
+            + CRAFTAX_WG_OBS_ROWS / 2;
+        int local_col = mobs->position[level][i][1]
+            - state->player_position[1]
+            + CRAFTAX_WG_OBS_COLS / 2;
+        if (local_row < 0 || local_row >= CRAFTAX_WG_OBS_ROWS
+            || local_col < 0 || local_col >= CRAFTAX_WG_OBS_COLS) {
+            continue;
+        }
+
+        int world_row = mobs->position[level][i][0];
+        int world_col = mobs->position[level][i][1];
+        if (world_row < 0 || world_row >= CRAFTAX_WG_MAP_SIZE
+            || world_col < 0 || world_col >= CRAFTAX_WG_MAP_SIZE
+            || state->light_map[level][world_row][world_col] <= 12) {
+            continue;
+        }
+
+        int obs_base = (local_row * CRAFTAX_WG_OBS_COLS + local_col)
+            * channels_per_cell;
+        int class_offset = mob_bits_offset
+            + mob_class_index * CRAFTAX_WG_BINARY_MOB_BITS;
+        memcpy(obs + obs_base + class_offset,
+               CRAFTAX_WG_MOB_LUT[type_id + 1],
+               CRAFTAX_WG_BINARY_MOB_BITS * sizeof(float));
+    }
+}
+
+static inline void craftax_encode_map_base_observation(
     const CraftaxWorldState* state,
     float* obs
 ) {
-    memset(obs, 0, CRAFTAX_WG_OBS_SIZE * sizeof(float));
+    const int channels = CRAFTAX_WG_BINARY_CHANNELS_PER_CELL;
+    const int top = state->player_position[0] - CRAFTAX_WG_OBS_ROWS / 2;
+    const int left = state->player_position[1] - CRAFTAX_WG_OBS_COLS / 2;
+    const int level = state->player_level;
+    const float* empty_cell = CRAFTAX_WG_EMPTY_CELL_TEMPLATE;
 
-    const int channels = CRAFTAX_WG_NUM_BLOCK_TYPES
-        + CRAFTAX_WG_NUM_ITEM_TYPES
-        + CRAFTAX_WG_NUM_MOB_CLASSES * CRAFTAX_WG_NUM_MOB_TYPES
-        + 1;
-    const int item_channels_offset = CRAFTAX_WG_NUM_BLOCK_TYPES;
-    const int mob_channels_offset = CRAFTAX_WG_NUM_BLOCK_TYPES + CRAFTAX_WG_NUM_ITEM_TYPES;
-    const int light_channel_offset = mob_channels_offset
-        + CRAFTAX_WG_NUM_MOB_CLASSES * CRAFTAX_WG_NUM_MOB_TYPES;
-    const int obs_map_size = CRAFTAX_WG_OBS_ROWS * CRAFTAX_WG_OBS_COLS * channels;
+    for (int row = 0; row < CRAFTAX_WG_OBS_ROWS; row++) {
+        int world_row = top + row;
+        bool row_in_bounds = world_row >= 0 && world_row < CRAFTAX_WG_MAP_SIZE;
+        for (int col = 0; col < CRAFTAX_WG_OBS_COLS; col++) {
+            int world_col = left + col;
+            int obs_base = (row * CRAFTAX_WG_OBS_COLS + col) * channels;
+            const float* cell = empty_cell;
+
+            if (row_in_bounds && world_col >= 0 && world_col < CRAFTAX_WG_MAP_SIZE
+                && state->light_map[level][world_row][world_col] > 12) {
+                uint8_t block = state->map[level][world_row][world_col];
+                uint8_t item = state->item_map[level][world_row][world_col];
+                cell = CRAFTAX_WG_VISIBLE_CELL_TEMPLATE_LUT[block][item + 1];
+            }
+
+            memcpy(obs + obs_base, cell, CRAFTAX_WG_CELL_TEMPLATE_BYTES);
+        }
+    }
+}
+
+static inline void craftax_encode_packed_map_base_observation(
+    const CraftaxWorldState* state,
+    float* obs
+) {
+    const int channels = CRAFTAX_WG_PACKED_CHANNELS_PER_CELL;
     const int top = state->player_position[0] - CRAFTAX_WG_OBS_ROWS / 2;
     const int left = state->player_position[1] - CRAFTAX_WG_OBS_COLS / 2;
     const int level = state->player_level;
 
+    memset(obs, 0, CRAFTAX_WG_PACKED_MAP_OBS_SIZE * sizeof(float));
     for (int row = 0; row < CRAFTAX_WG_OBS_ROWS; row++) {
+        int world_row = top + row;
+        bool row_in_bounds = world_row >= 0 && world_row < CRAFTAX_WG_MAP_SIZE;
         for (int col = 0; col < CRAFTAX_WG_OBS_COLS; col++) {
-            int world_row = top + row;
             int world_col = left + col;
             int obs_base = (row * CRAFTAX_WG_OBS_COLS + col) * channels;
-            bool in_bounds = world_row >= 0
-                && world_row < CRAFTAX_WG_MAP_SIZE
-                && world_col >= 0
-                && world_col < CRAFTAX_WG_MAP_SIZE;
-            float light = in_bounds ? state->light_map[level][world_row][world_col] : 0.0f;
-            bool visible = light > 0.05f;
-
-            if (visible) {
-                int block = state->map[level][world_row][world_col];
-                if (block >= 0 && block < CRAFTAX_WG_NUM_BLOCK_TYPES) {
-                    obs[obs_base + block] = 1.0f;
-                }
-
-                int item = state->item_map[level][world_row][world_col];
-                if (item >= 0 && item < CRAFTAX_WG_NUM_ITEM_TYPES) {
-                    obs[obs_base + item_channels_offset + item] = 1.0f;
-                }
+            if (row_in_bounds && world_col >= 0 && world_col < CRAFTAX_WG_MAP_SIZE
+                && state->light_map[level][world_row][world_col] > 12) {
+                obs[obs_base + 0] = (float)state->map[level][world_row][world_col];
+                obs[obs_base + 1] = (float)state->item_map[level][world_row][world_col] + 1.0f;
+                obs[obs_base + 2] = 1.0f;
             }
-
-            obs[obs_base + light_channel_offset] = visible ? 1.0f : 0.0f;
         }
     }
+}
 
-    craftax_encode_mobs3_observation(
+static inline void craftax_clear_mob_channels_observation(float* obs) {
+    const int channels = CRAFTAX_WG_BINARY_CHANNELS_PER_CELL;
+    const int mob_bits_offset = CRAFTAX_WG_BINARY_BLOCK_BITS + CRAFTAX_WG_BINARY_ITEM_BITS;
+    const size_t mob_channel_bytes =
+        CRAFTAX_WG_NUM_MOB_CLASSES * CRAFTAX_WG_BINARY_MOB_BITS * sizeof(float);
+
+    for (int cell = 0; cell < CRAFTAX_WG_OBS_WINDOW_CELLS; cell++) {
+        memset(obs + cell * channels + mob_bits_offset, 0, mob_channel_bytes);
+    }
+}
+
+static inline void craftax_encode_mobs3_packed(
+    const CraftaxWorldState* state,
+    const CraftaxWGMobs3* mobs,
+    int mob_class_index,
+    float* obs
+) {
+    const int level = craftax_wg_jax_index(state->player_level, CRAFTAX_WG_NUM_LEVELS);
+    const int mob_slot_offset = 3 + mob_class_index;
+    for (int i = 0; i < 3; i++) {
+        int type_id = mobs->type_id[level][i];
+        if (type_id < 0 || type_id >= CRAFTAX_WG_NUM_MOB_TYPES
+            || !mobs->mask[level][i]) {
+            continue;
+        }
+
+        int local_row = mobs->position[level][i][0]
+            - state->player_position[0]
+            + CRAFTAX_WG_OBS_ROWS / 2;
+        int local_col = mobs->position[level][i][1]
+            - state->player_position[1]
+            + CRAFTAX_WG_OBS_COLS / 2;
+        if (local_row < 0 || local_row >= CRAFTAX_WG_OBS_ROWS
+            || local_col < 0 || local_col >= CRAFTAX_WG_OBS_COLS) {
+            continue;
+        }
+
+        int world_row = mobs->position[level][i][0];
+        int world_col = mobs->position[level][i][1];
+        if (world_row < 0 || world_row >= CRAFTAX_WG_MAP_SIZE
+            || world_col < 0 || world_col >= CRAFTAX_WG_MAP_SIZE
+            || state->light_map[level][world_row][world_col] <= 12) {
+            continue;
+        }
+
+        int obs_base = (local_row * CRAFTAX_WG_OBS_COLS + local_col)
+            * CRAFTAX_WG_PACKED_CHANNELS_PER_CELL;
+        obs[obs_base + mob_slot_offset] = (float)(type_id + 1);
+    }
+}
+
+static inline void craftax_encode_mobs2_packed(
+    const CraftaxWorldState* state,
+    const CraftaxWGMobs2* mobs,
+    int mob_class_index,
+    float* obs
+) {
+    const int level = craftax_wg_jax_index(state->player_level, CRAFTAX_WG_NUM_LEVELS);
+    const int mob_slot_offset = 3 + mob_class_index;
+    for (int i = 0; i < 2; i++) {
+        int type_id = mobs->type_id[level][i];
+        if (type_id < 0 || type_id >= CRAFTAX_WG_NUM_MOB_TYPES
+            || !mobs->mask[level][i]) {
+            continue;
+        }
+
+        int local_row = mobs->position[level][i][0]
+            - state->player_position[0]
+            + CRAFTAX_WG_OBS_ROWS / 2;
+        int local_col = mobs->position[level][i][1]
+            - state->player_position[1]
+            + CRAFTAX_WG_OBS_COLS / 2;
+        if (local_row < 0 || local_row >= CRAFTAX_WG_OBS_ROWS
+            || local_col < 0 || local_col >= CRAFTAX_WG_OBS_COLS) {
+            continue;
+        }
+
+        int world_row = mobs->position[level][i][0];
+        int world_col = mobs->position[level][i][1];
+        if (world_row < 0 || world_row >= CRAFTAX_WG_MAP_SIZE
+            || world_col < 0 || world_col >= CRAFTAX_WG_MAP_SIZE
+            || state->light_map[level][world_row][world_col] <= 12) {
+            continue;
+        }
+
+        int obs_base = (local_row * CRAFTAX_WG_OBS_COLS + local_col)
+            * CRAFTAX_WG_PACKED_CHANNELS_PER_CELL;
+        obs[obs_base + mob_slot_offset] = (float)(type_id + 1);
+    }
+}
+
+static inline void craftax_encode_packed_mobs_observation(
+    const CraftaxWorldState* state,
+    float* obs
+) {
+    craftax_encode_mobs3_packed(state, &state->melee_mobs, 0, obs);
+    craftax_encode_mobs3_packed(state, &state->passive_mobs, 1, obs);
+    craftax_encode_mobs2_packed(state, &state->ranged_mobs, 2, obs);
+    craftax_encode_mobs3_packed(state, &state->mob_projectiles, 3, obs);
+    craftax_encode_mobs3_packed(state, &state->player_projectiles, 4, obs);
+}
+
+static inline void craftax_encode_mobs_observation(
+    const CraftaxWorldState* state,
+    float* obs
+) {
+    const int channels = CRAFTAX_WG_BINARY_CHANNELS_PER_CELL;
+    const int mob_bits_offset = CRAFTAX_WG_BINARY_BLOCK_BITS + CRAFTAX_WG_BINARY_ITEM_BITS;
+
+    craftax_encode_mobs3_binary(
         state,
         &state->melee_mobs,
         0,
         channels,
-        mob_channels_offset,
+        mob_bits_offset,
         obs
     );
-    craftax_encode_mobs3_observation(
+    craftax_encode_mobs3_binary(
         state,
         &state->passive_mobs,
         1,
         channels,
-        mob_channels_offset,
+        mob_bits_offset,
         obs
     );
-    craftax_encode_mobs2_observation(
+    craftax_encode_mobs2_binary(
         state,
         &state->ranged_mobs,
         2,
         channels,
-        mob_channels_offset,
+        mob_bits_offset,
         obs
     );
-    craftax_encode_mobs3_observation(
+    craftax_encode_mobs3_binary(
         state,
         &state->mob_projectiles,
         3,
         channels,
-        mob_channels_offset,
+        mob_bits_offset,
         obs
     );
-    craftax_encode_mobs3_observation(
+    craftax_encode_mobs3_binary(
         state,
         &state->player_projectiles,
         4,
         channels,
-        mob_channels_offset,
+        mob_bits_offset,
         obs
     );
+}
 
-    int index = obs_map_size;
+static inline void craftax_encode_scalar_observation_tail_at(
+    const CraftaxWorldState* state,
+    float* obs,
+    int index
+) {
+    const int level = state->player_level;
     obs[index++] = sqrtf((float)state->inventory.wood) / 10.0f;
     obs[index++] = sqrtf((float)state->inventory.stone) / 10.0f;
     obs[index++] = sqrtf((float)state->inventory.coal) / 10.0f;
@@ -1516,4 +1843,20 @@ static inline void craftax_encode_reset_observation(
     obs[index++] = (float)state->player_level / 10.0f;
     obs[index++] = state->monsters_killed[level] >= CRAFTAX_WG_MONSTERS_KILLED_TO_CLEAR_LEVEL ? 1.0f : 0.0f;
     obs[index++] = craftax_wg_is_boss_vulnerable(state) ? 1.0f : 0.0f;
+}
+
+static inline void craftax_encode_scalar_observation_tail(
+    const CraftaxWorldState* state,
+    float* obs
+) {
+    craftax_encode_scalar_observation_tail_at(state, obs, CRAFTAX_WG_BINARY_MAP_OBS_SIZE);
+}
+
+static inline void craftax_encode_reset_observation(
+    const CraftaxWorldState* state,
+    float* obs
+) {
+    craftax_encode_packed_map_base_observation(state, obs);
+    craftax_encode_packed_mobs_observation(state, obs);
+    craftax_encode_scalar_observation_tail_at(state, obs, CRAFTAX_WG_PACKED_MAP_OBS_SIZE);
 }

--- a/src/vecenv.h
+++ b/src/vecenv.h
@@ -192,6 +192,9 @@ extern const char* cudaGetErrorString(cudaError_t);
 void my_init(Env* env, Dict* kwargs);
 void my_log(Log* log, Dict* out);
 
+#ifdef MY_VEC_STEP_RANGE
+void MY_VEC_STEP_RANGE(StaticVec* vec, int env_start, int env_count, int num_workers);
+#endif
 
 struct StaticThreading {
     atomic_int* buffer_states;
@@ -234,8 +237,6 @@ static void* static_omp_threadmanager(void* arg) {
     int num_workers = threading->num_threads / vec->buffers;
     if (num_workers < 1) num_workers = 1;
 
-    Env* envs = (Env*)vec->envs;
-
     printf("Num workers: %d\n", num_workers);
     while (true) {
         while (atomic_load(&buffer_states[buf]) != OMP_RUNNING) {
@@ -264,10 +265,15 @@ static void* static_omp_threadmanager(void* arg) {
             memset(&vec->rewards[agent_start], 0, agents_per_buffer * sizeof(float));
             memset(&vec->terminals[agent_start], 0, agents_per_buffer * sizeof(float));
             clock_gettime(CLOCK_MONOTONIC, &t0);
+            #ifdef MY_VEC_STEP_RANGE
+            MY_VEC_STEP_RANGE(vec, env_start, env_count, num_workers);
+            #else
+            Env* envs = (Env*)vec->envs;
             #pragma omp parallel for schedule(static) num_threads(num_workers)
             for (int i = env_start; i < env_start + env_count; i++) {
                 c_step(&envs[i]);
             }
+            #endif
             clock_gettime(CLOCK_MONOTONIC, &t1);
             my_accum[EVAL_ENV_STEP] += (t1.tv_sec - t0.tv_sec) * 1000.0f + (t1.tv_nsec - t0.tv_nsec) / 1e6f;
 
@@ -603,6 +609,12 @@ int get_num_act_sizes(void) { return (int)(sizeof(_act_sizes) / sizeof(_act_size
 const char* get_obs_dtype(void) { return dtype_symbol; }
 size_t get_obs_elem_size(void) { return obs_element_size(); }
 
+#ifdef MY_VEC_STEP
+void MY_VEC_STEP(StaticVec* vec);
+static inline void _static_vec_env_step(StaticVec* vec) {
+    MY_VEC_STEP(vec);
+}
+#else
 static inline void _static_vec_env_step(StaticVec* vec) {
     memset(vec->rewards, 0, vec->total_agents * sizeof(float));
     memset(vec->terminals, 0, vec->total_agents * sizeof(float));
@@ -612,6 +624,7 @@ static inline void _static_vec_env_step(StaticVec* vec) {
         c_step(&envs[i]);
     }
 }
+#endif
 
 void gpu_vec_step(StaticVec* vec) {
     assert(vec->buffers == 1);


### PR DESCRIPTION
## Summary

Reworks the existing `craftax` environment for faster CPU rollouts instead of adding a parallel environment. This keeps the public env name as `craftax` and updates the core Craftax C implementation directly.

Main changes:

- Uses an arena-backed state layout so env handles stay lightweight while heavy Craftax state is stored contiguously.
- Adds tiled vector stepping for the synchronous path.
- Adds a narrow optional `MY_VEC_STEP_RANGE` hook in `vecenv.h` so envs that opt in can customize the per-buffer rollout step. Default env behavior remains the existing `c_step` loop.
- Keeps reset-state pooling and packed observation behavior in the core Craftax path.
- Updates `config/craftax.ini` to a measured higher-throughput training profile.

This replaces the earlier side-by-side `craftax_moonshot` PR, which has been closed.

## Measured throughput

On a Ryzen 9 9950X3D + RTX PRO 6000 Blackwell workstation, pinned to the V-Cache cores:

```bash
env OMP_NUM_THREADS=1 taskset -c 0-7,16-23 \
  uv run puffer train craftax \
  --train.total-timesteps 200000000 \
  --vec.total-agents 16384 \
  --vec.num-buffers 16 \
  --vec.num-threads 16 \
  --policy.hidden-size 32 \
  --policy.num-layers 1 \
  --policy.expansion-factor 1 \
  --train.horizon 128 \
  --train.minibatch-size 32768
```
<img width="947" height="441" alt="image" src="https://github.com/user-attachments/assets/b15f3b67-b395-4569-b891-9f419198325f" />

Short smoke measurement: about 3.8M training SPS with `Env craftax`, env around 45% of wall time. The `taskset` affinity is specific to this 9950X3D; other CPUs should omit it or choose affinity based on local topology.

## Verification

```bash
uv run --with pybind11 --with rich_argparse --with nvidia-cudnn-cu12 --with nvidia-nccl-cu12 ./build.sh craftax
uv run --with ruff ruff check ocean/craftax/pack_textures.py --fix
```

Results:

```text
Built: pufferlib/_C.cpython-313-x86_64-linux-gnu.so
All checks passed!
```

Also ran a short Puffer training smoke with `Env craftax`, which launched successfully and reported ~3.8M SPS.

Repo-wide checks are currently blocked by existing upstream issues unrelated to this PR:

- `uv run --with pytest pytest` fails during collection on missing optional dependencies/modules: `jax`, `heavyball`, `pyximport`, `pandas`, and `pufferlib.emulation`.
- `uv run ruff check . --fix` fails on existing lint issues outside this PR. Unrelated auto-fixes were reverted.
