### PR TITLE
Fix float truncation in SPEED and MIN_TICKS constants

### DIFF
--- a/ocean/minimal/minimal.h
+++ b/ocean/minimal/minimal.h
@@ -6,8 +6,8 @@
 
 #define AGENTS 8
 #define TARGETS 8
-const int WIDTH = 1080, HEIGHT = 720, COOLDOWN = 30, TYPES = 4, SPEED = 20.0f;
-const int MIN_TICKS = COOLDOWN*AGENTS/(float)TARGETS;
+const int WIDTH = 1080, HEIGHT = 720, COOLDOWN = 30, TYPES = 4;
+const float SPEED = 20.0f, MIN_TICKS = COOLDOWN*AGENTS/(float)TARGETS;
 float clip(float val, float min, float max) { return fmaxf(fminf(val, max), min); }
 
 // Required struct. Floats only, n last


### PR DESCRIPTION
I read through `ocean/minimal/minimal.h` for line count reduction, but wasn't able to find anything.
But I did find a float truncation(I don't know if its intended or not).

`SPEED = 20.0f` and `MIN_TICKS = COOLDOWN*AGENTS/(float)TARGETS` are declared in a `const int` list, silently truncating their float values.

I Fixed it by splitting them onto their own `const float` line.
