### PR TITLE
Add native tower defence ocean environment

### DIFF
--- a/config/tower_defence.ini
+++ b/config/tower_defence.ini
@@ -1,0 +1,27 @@
+[base]
+env_name = tower_defence
+checkpoint_interval = 8
+
+[vec]
+total_agents = 128
+num_buffers = 2
+
+[env]
+max_episode_steps = 12000
+base_seed = 1
+invalid_action_reward = -0.25
+raw_observation_scalars = 1
+
+[policy]
+hidden_size = 128
+num_layers = 2
+
+[train]
+gpus = 1
+total_timesteps = 12_000_000
+learning_rate = 0.0003
+gamma = 0.995
+gae_lambda = 0.95
+horizon = 128
+minibatch_size = 2048
+ent_coef = 0.02

--- a/config/tower_defence.ini
+++ b/config/tower_defence.ini
@@ -10,7 +10,6 @@ num_buffers = 2
 max_episode_steps = 12000
 base_seed = 1
 invalid_action_reward = -0.25
-raw_observation_scalars = 1
 
 [policy]
 hidden_size = 128

--- a/config/tower_defence_flat.ini
+++ b/config/tower_defence_flat.ini
@@ -10,7 +10,6 @@ num_buffers = 2
 max_episode_steps = 12000
 base_seed = 1
 invalid_action_reward = -0.25
-raw_observation_scalars = 1
 
 [policy]
 hidden_size = 128

--- a/config/tower_defence_flat.ini
+++ b/config/tower_defence_flat.ini
@@ -1,0 +1,28 @@
+[base]
+env_name = tower_defence_flat
+checkpoint_interval = 8
+
+[vec]
+total_agents = 128
+num_buffers = 2
+
+[env]
+max_episode_steps = 12000
+base_seed = 1
+invalid_action_reward = -0.25
+raw_observation_scalars = 1
+
+[policy]
+hidden_size = 128
+num_layers = 2
+
+[train]
+gpus = 1
+total_timesteps = 12_000_000
+learning_rate = 0.0001
+gamma = 0.995
+gae_lambda = 0.95
+horizon = 64
+minibatch_size = 2048
+ent_coef = 0.005
+target_kl = 0.002

--- a/ocean/tower_defence/binding.c
+++ b/ocean/tower_defence/binding.c
@@ -30,7 +30,6 @@ void my_init(Env* env, Dict* kwargs) {
     env->max_episode_steps = td_get_int(
         kwargs, "max_episode_steps", TD_DEFAULT_MAX_EPISODE_STEPS);
     env->base_seed = td_get_int(kwargs, "base_seed", TD_DEFAULT_BASE_SEED);
-    env->raw_observation_scalars = td_get_int(kwargs, "raw_observation_scalars", 1);
     env->episode_index = 0;
     env->step_count = 0;
     env->invalid_action_count = 0;

--- a/ocean/tower_defence/binding.c
+++ b/ocean/tower_defence/binding.c
@@ -1,0 +1,52 @@
+#include "tower_defence.h"
+
+#define OBS_TENSOR_T FloatTensor
+#define OBS_SIZE TD_OBS_SIZE
+#define NUM_ATNS TD_FACTOR_NUM_ATNS
+#define ACT_SIZES {TD_FACTOR_VERB_COUNT, TD_NUM_PLACEMENT_SLOTS, TD_NUM_UPGRADE_PATHS}
+
+#define Env TowerDefence
+#include "vecenv.h"
+
+static int td_get_int(Dict* kwargs, const char* key, int fallback) {
+    DictItem* item = dict_get_unsafe(kwargs, key);
+    if (item == NULL) {
+        return fallback;
+    }
+    return (int)item->value;
+}
+
+static float td_get_float(Dict* kwargs, const char* key, float fallback) {
+    DictItem* item = dict_get_unsafe(kwargs, key);
+    if (item == NULL) {
+        return fallback;
+    }
+    return item->value;
+}
+
+void my_init(Env* env, Dict* kwargs) {
+    memset(&env->log, 0, sizeof(env->log));
+    td_init(env);
+    env->max_episode_steps = td_get_int(
+        kwargs, "max_episode_steps", TD_DEFAULT_MAX_EPISODE_STEPS);
+    env->base_seed = td_get_int(kwargs, "base_seed", TD_DEFAULT_BASE_SEED);
+    env->raw_observation_scalars = td_get_int(kwargs, "raw_observation_scalars", 1);
+    env->episode_index = 0;
+    env->step_count = 0;
+    env->invalid_action_count = 0;
+    memset(env->valid_actions, 0, sizeof(env->valid_actions));
+    env->valid_actions[TD_ACTION_NOOP] = 1;
+    env->invalid_action_reward = td_get_float(
+        kwargs, "invalid_action_reward", TD_DEFAULT_INVALID_ACTION_REWARD);
+    env->episode_return = 0.0f;
+    env->latest_score = 0.0f;
+    env->latest_perf = 0.0f;
+}
+
+void my_log(Log* log, Dict* out) {
+    dict_set(out, "score", log->score);
+    dict_set(out, "perf", log->perf);
+    dict_set(out, "episode_return", log->episode_return);
+    dict_set(out, "episode_length", log->episode_length);
+    dict_set(out, "invalid_action_rate", log->invalid_action_rate);
+}

--- a/ocean/tower_defence/tower_defence.c
+++ b/ocean/tower_defence/tower_defence.c
@@ -1,0 +1,90 @@
+#include "tower_defence.h"
+#include "puffernet.h"
+#include <unistd.h>
+
+#ifndef TD_DEMO_WEIGHT_PATH
+#define TD_DEMO_WEIGHT_PATH "resources/tower_defence/tower_defence_weights.bin"
+#endif
+
+static int demo_action(TowerDefence* env) {
+    if (IsKeyDown(KEY_LEFT_SHIFT)) {
+        int slot = env->hover_slot >= 0 ? env->hover_slot : 0;
+        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) return 1 + slot;
+        if (IsKeyPressed(KEY_Q)) return TD_ACTION_UPGRADE_SLOT_01_TOP + slot * TD_NUM_UPGRADE_PATHS;
+        if (IsKeyPressed(KEY_W)) return TD_ACTION_UPGRADE_SLOT_01_TOP + slot * TD_NUM_UPGRADE_PATHS + 1;
+        if (IsKeyPressed(KEY_E)) return TD_ACTION_UPGRADE_SLOT_01_TOP + slot * TD_NUM_UPGRADE_PATHS + 2;
+        if (IsMouseButtonPressed(MOUSE_RIGHT_BUTTON) || IsKeyPressed(KEY_X)) {
+            return TD_ACTION_SELL_SLOT_01 + slot;
+        }
+        if (IsKeyPressed(KEY_SPACE) || IsKeyPressed(KEY_ENTER)) return TD_ACTION_TRIGGER_NEXT_ROUND;
+        return TD_ACTION_NOOP;
+    }
+    for (int action = 1; action < TD_ACTION_SELL_SLOT_01; action++) {
+        if (env->valid_actions[action]) return action;
+    }
+    if (env->valid_actions[TD_ACTION_TRIGGER_NEXT_ROUND]) return TD_ACTION_TRIGGER_NEXT_ROUND;
+    for (int action = TD_ACTION_SELL_SLOT_01; action < TD_ACTION_TRIGGER_NEXT_ROUND; action++) {
+        if (env->valid_actions[action]) return action;
+    }
+    return TD_ACTION_NOOP;
+}
+
+static void set_action(TowerDefence* env, int action) {
+#if TD_USE_FACTORED_ACTIONS
+    env->actions[0] = TD_FACTOR_VERB_NOOP;
+    env->actions[1] = 0;
+    env->actions[2] = 0;
+    if (action >= 1 && action <= TD_NUM_PLACEMENT_SLOTS) {
+        env->actions[0] = TD_FACTOR_VERB_PLACE;
+        env->actions[1] = action - 1;
+    } else if (action >= TD_ACTION_UPGRADE_SLOT_01_TOP && action < TD_ACTION_SELL_SLOT_01) {
+        int idx = action - TD_ACTION_UPGRADE_SLOT_01_TOP;
+        env->actions[0] = TD_FACTOR_VERB_UPGRADE;
+        env->actions[1] = idx / TD_NUM_UPGRADE_PATHS;
+        env->actions[2] = idx % TD_NUM_UPGRADE_PATHS;
+    } else if (action >= TD_ACTION_SELL_SLOT_01 && action < TD_ACTION_TRIGGER_NEXT_ROUND) {
+        env->actions[0] = TD_FACTOR_VERB_SELL;
+        env->actions[1] = action - TD_ACTION_SELL_SLOT_01;
+    } else if (action == TD_ACTION_TRIGGER_NEXT_ROUND) {
+        env->actions[0] = TD_FACTOR_VERB_TRIGGER;
+    }
+#else
+    env->actions[0] = action;
+#endif
+}
+
+int main() {
+    TowerDefence env = {0};
+    allocate(&env);
+    c_reset(&env);
+    c_render(&env);
+
+    Weights* weights = access(TD_DEMO_WEIGHT_PATH, R_OK) == 0
+        ? load_weights(TD_DEMO_WEIGHT_PATH)
+        : NULL;
+#if TD_USE_FACTORED_ACTIONS
+    int logit_sizes[3] = {TD_FACTOR_VERB_COUNT, TD_NUM_PLACEMENT_SLOTS, TD_NUM_UPGRADE_PATHS};
+    int num_atns = 3;
+#else
+    int logit_sizes[1] = {TD_NUM_ACTIONS};
+    int num_atns = 1;
+#endif
+    PufferNet* net = weights ? make_puffernet(weights, 1, TD_OBS_SIZE, 128, 2, logit_sizes, num_atns) : NULL;
+
+    while (!WindowShouldClose()) {
+        if (net && !IsKeyDown(KEY_LEFT_SHIFT)) {
+            forward_puffernet(net, env.observations, env.actions);
+        } else {
+            set_action(&env, demo_action(&env));
+        }
+        c_step(&env);
+        if (IsKeyDown(KEY_LEFT_SHIFT)) set_action(&env, TD_ACTION_NOOP);
+        c_render(&env);
+    }
+
+    if (net) free_puffernet(net);
+    free(weights);
+    c_close(&env);
+    free_allocated(&env);
+    return 0;
+}

--- a/ocean/tower_defence/tower_defence.h
+++ b/ocean/tower_defence/tower_defence.h
@@ -653,7 +653,9 @@ static void td_advance_world(TowerDefence* env, float* reward) {
     for (int s = 0; s < env->active_spawns; s++) {
         TdSpawn* spawn = &env->spawns[s];
         while (spawn->emitted < spawn->count && env->wave_elapsed >= spawn->next_time) {
-            td_add_enemy(env, spawn->type, spawn->camo, spawn->fortified, spawn->regrow, 0.0f);
+            if (td_add_enemy(env, spawn->type, spawn->camo, spawn->fortified, spawn->regrow, 0.0f) < 0) {
+                break;
+            }
             spawn->emitted += 1;
             spawn->next_time += spawn->interval;
         }

--- a/ocean/tower_defence/tower_defence.h
+++ b/ocean/tower_defence/tower_defence.h
@@ -573,6 +573,9 @@ static void td_prepare_wave(TowerDefence* env) {
 static void td_start_round(TowerDefence* env) {
     if (env->status_code != TD_STATUS_WARMUP && env->status_code != TD_STATUS_INTERMISSION) return;
     env->status_code = TD_STATUS_SPAWNING;
+    // Preserve the JS raw-v2 checkpoint ABI: startNextRound keeps the
+    // intermission scalar at 2 while the new wave is spawning. It is a policy
+    // compatibility feature, not an active countdown outside intermission.
     env->intermission_remaining = 2.0f;
     td_prepare_wave(env);
 }

--- a/ocean/tower_defence/tower_defence.h
+++ b/ocean/tower_defence/tower_defence.h
@@ -27,8 +27,8 @@
 #define TD_OBS_V2_FEATURE_OFFSET TD_BASE_OBS_SIZE
 #define TD_OBS_V2_ACTION_MASK_OFFSET (TD_OBS_V2_FEATURE_OFFSET + TD_NUM_OBSERVATION_V2_FEATURES)
 #define TD_OBS_V2_SIZE (TD_OBS_V2_ACTION_MASK_OFFSET + TD_NUM_ACTIONS)
-#define TD_OBS_V1_ACTION_MASK_OFFSET TD_BASE_OBS_SIZE
-#define TD_OBS_V1_SIZE (TD_OBS_V1_ACTION_MASK_OFFSET + TD_NUM_ACTIONS)
+#define TD_OBS_ACTION_MASK_OFFSET TD_OBS_V2_ACTION_MASK_OFFSET
+#define TD_OBS_SIZE TD_OBS_V2_SIZE
 #define TD_FACTOR_NUM_ATNS 3
 #define TD_FACTOR_VERB_COUNT 5
 #define TD_MAX_ENEMIES 256
@@ -40,18 +40,6 @@
 
 #ifndef TD_USE_FACTORED_ACTIONS
 #define TD_USE_FACTORED_ACTIONS 1
-#endif
-
-#ifndef TD_NATIVE_OBSERVATION_RAW_V2
-#define TD_NATIVE_OBSERVATION_RAW_V2 1
-#endif
-
-#if TD_NATIVE_OBSERVATION_RAW_V2
-#define TD_OBS_ACTION_MASK_OFFSET TD_OBS_V2_ACTION_MASK_OFFSET
-#define TD_OBS_SIZE TD_OBS_V2_SIZE
-#else
-#define TD_OBS_ACTION_MASK_OFFSET TD_OBS_V1_ACTION_MASK_OFFSET
-#define TD_OBS_SIZE TD_OBS_V1_SIZE
 #endif
 
 enum TdActionId {
@@ -163,7 +151,6 @@ typedef struct {
 
     int max_episode_steps;
     int base_seed;
-    int raw_observation_scalars;
     int episode_index;
     int step_count;
     int invalid_action_count;
@@ -384,7 +371,6 @@ static void td_init(TowerDefence* env) {
     env->num_agents = 1;
     env->max_episode_steps = TD_DEFAULT_MAX_EPISODE_STEPS;
     env->base_seed = TD_DEFAULT_BASE_SEED;
-    env->raw_observation_scalars = 1;
     env->invalid_action_reward = TD_DEFAULT_INVALID_ACTION_REWARD;
     env->hover_slot = -1;
 }
@@ -404,25 +390,21 @@ static void free_allocated(TowerDefence* env) {
     free(env->terminals);
 }
 
-static float td_obs_scalar(TowerDefence* env, float value, float divisor) {
-    return env->raw_observation_scalars ? value : value / divisor;
-}
-
 static void td_write_observation(TowerDefence* env) {
     memset(env->observations, 0, TD_OBS_SIZE * sizeof(float));
-    env->observations[0] = td_obs_scalar(env, env->time, 400.0f);
-    env->observations[1] = td_obs_scalar(env, (float)env->round, 20.0f);
+    env->observations[0] = env->time;
+    env->observations[1] = (float)env->round;
     if (env->status_code >= 0 && env->status_code <= TD_STATUS_COMPLETE) {
         env->observations[2 + env->status_code] = 1.0f;
     }
-    env->observations[8] = td_obs_scalar(env, env->lives, 100.0f);
-    env->observations[9] = td_obs_scalar(env, env->cash, 650.0f);
-    env->observations[10] = td_obs_scalar(env, env->intermission_remaining, 2.0f);
-    env->observations[11] = td_obs_scalar(env, (float)env->round, 20.0f);
-    env->observations[12] = td_obs_scalar(env, env->wave_elapsed, 15.0f);
-    env->observations[13] = td_obs_scalar(env, (float)td_enemy_count(env), 20.0f);
-    env->observations[14] = td_obs_scalar(env, (float)td_tower_count(env), 20.0f);
-    env->observations[15] = td_obs_scalar(env, env->time - env->last_shot_time < 0.35f ? 1.0f : 0.0f, 1.0f);
+    env->observations[8] = env->lives;
+    env->observations[9] = env->cash;
+    env->observations[10] = env->intermission_remaining;
+    env->observations[11] = (float)env->round;
+    env->observations[12] = env->wave_elapsed;
+    env->observations[13] = (float)td_enemy_count(env);
+    env->observations[14] = (float)td_tower_count(env);
+    env->observations[15] = env->time - env->last_shot_time < 0.35f ? 1.0f : 0.0f;
 
     int idx = TD_SCALAR_OBS_SIZE;
     for (int slot = 0; slot < TD_NUM_PLACEMENT_SLOTS; slot++) {
@@ -465,7 +447,6 @@ static void td_write_observation(TowerDefence* env) {
     for (int i = 0; i < TD_NUM_ENEMY_PROGRESS_BINS; i++) env->observations[idx++] = td_squash(count_bins[i], 3.0f);
     for (int i = 0; i < TD_NUM_ENEMY_PROGRESS_BINS; i++) env->observations[idx++] = td_squash(hp_bins[i], 3.0f);
 
-#if TD_NATIVE_OBSERVATION_RAW_V2
     idx = TD_OBS_V2_FEATURE_OFFSET;
     for (int i = 0; i < 10; i++) env->observations[idx++] = td_squash(type_mass[i], 12.0f);
     for (int i = 0; i < 8; i++) env->observations[idx++] = td_squash(prop_mass[i], 12.0f);
@@ -502,7 +483,6 @@ static void td_write_observation(TowerDefence* env) {
     env->observations[idx++] = td_squash(comp[7], 8.0f);
     env->observations[idx++] = td_squash(comp[8], 4.0f);
     env->observations[idx++] = td_squash(comp[9], 8000.0f);
-#endif
 
     td_update_masks(env);
     for (int action = 0; action < TD_NUM_ACTIONS; action++) {

--- a/ocean/tower_defence/tower_defence.h
+++ b/ocean/tower_defence/tower_defence.h
@@ -404,7 +404,9 @@ static void td_write_observation(TowerDefence* env) {
     env->observations[12] = env->wave_elapsed;
     env->observations[13] = (float)td_enemy_count(env);
     env->observations[14] = (float)td_tower_count(env);
-    env->observations[15] = env->time - env->last_shot_time < 0.35f ? 1.0f : 0.0f;
+    // Raw-v2 scalar slot 15 is projectile count in the JS/native contract.
+    // The native env resolves shots immediately, so the count is always zero.
+    env->observations[15] = 0.0f;
 
     int idx = TD_SCALAR_OBS_SIZE;
     for (int slot = 0; slot < TD_NUM_PLACEMENT_SLOTS; slot++) {
@@ -442,7 +444,8 @@ static void td_write_observation(TowerDefence* env) {
         band_mass[band][1] += hp;
         band_mass[band][2] += leak;
         band_mass[band][3] += (enemy->camo || TD_ENEMY_SHARP_IMMUNE[enemy->type] ||
-            TD_ENEMY_EXPLOSIVE_IMMUNE[enemy->type]) ? leak : 0.0f;
+            TD_ENEMY_EXPLOSIVE_IMMUNE[enemy->type] || TD_ENEMY_BURN_IMMUNE[enemy->type] ||
+            TD_ENEMY_SLOW_IMMUNE[enemy->type]) ? leak : 0.0f;
     }
     for (int i = 0; i < TD_NUM_ENEMY_PROGRESS_BINS; i++) env->observations[idx++] = td_squash(count_bins[i], 3.0f);
     for (int i = 0; i < TD_NUM_ENEMY_PROGRESS_BINS; i++) env->observations[idx++] = td_squash(hp_bins[i], 3.0f);

--- a/ocean/tower_defence/tower_defence.h
+++ b/ocean/tower_defence/tower_defence.h
@@ -573,7 +573,7 @@ static void td_prepare_wave(TowerDefence* env) {
 static void td_start_round(TowerDefence* env) {
     if (env->status_code != TD_STATUS_WARMUP && env->status_code != TD_STATUS_INTERMISSION) return;
     env->status_code = TD_STATUS_SPAWNING;
-    env->intermission_remaining = 0.0f;
+    env->intermission_remaining = 2.0f;
     td_prepare_wave(env);
 }
 

--- a/ocean/tower_defence/tower_defence.h
+++ b/ocean/tower_defence/tower_defence.h
@@ -531,7 +531,7 @@ static void td_add_spawn(TowerDefence* env, int type, int count, float interval,
     spawn->count = count;
     spawn->emitted = 0;
     spawn->interval = interval;
-    spawn->next_time = env->wave_elapsed + 0.01f * env->active_spawns;
+    spawn->next_time = env->wave_elapsed + 0.01f * (env->active_spawns - 1);
     spawn->camo = camo;
     spawn->fortified = fortified;
     spawn->regrow = regrow;

--- a/ocean/tower_defence/tower_defence.h
+++ b/ocean/tower_defence/tower_defence.h
@@ -1,0 +1,931 @@
+#pragma once
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "raylib.h"
+
+#define TD_DEFAULT_MAX_EPISODE_STEPS 12000
+#define TD_DEFAULT_BASE_SEED 1
+#define TD_DEFAULT_INVALID_ACTION_REWARD (-0.25f)
+#define TD_WIDTH 960
+#define TD_HEIGHT 540
+#define TD_NUM_PLACEMENT_SLOTS 20
+#define TD_NUM_UPGRADE_PATHS 3
+#define TD_NUM_SLOT_FEATURES_PER_SLOT 4
+#define TD_NUM_SLOT_FEATURES (TD_NUM_PLACEMENT_SLOTS * TD_NUM_SLOT_FEATURES_PER_SLOT)
+#define TD_NUM_ENEMY_PROGRESS_BINS 8
+#define TD_NUM_ENEMY_PROGRESS_FEATURES_PER_BIN 2
+#define TD_NUM_ENEMY_PROGRESS_FEATURES (TD_NUM_ENEMY_PROGRESS_BINS * TD_NUM_ENEMY_PROGRESS_FEATURES_PER_BIN)
+#define TD_NUM_UPGRADE_ACTIONS (TD_NUM_PLACEMENT_SLOTS * TD_NUM_UPGRADE_PATHS)
+#define TD_NUM_SELL_ACTIONS TD_NUM_PLACEMENT_SLOTS
+#define TD_SCALAR_OBS_SIZE 16
+#define TD_NUM_ACTIONS (1 + TD_NUM_PLACEMENT_SLOTS + TD_NUM_UPGRADE_ACTIONS + TD_NUM_SELL_ACTIONS + 1)
+#define TD_BASE_OBS_SIZE (TD_SCALAR_OBS_SIZE + TD_NUM_SLOT_FEATURES + TD_NUM_ENEMY_PROGRESS_FEATURES)
+#define TD_NUM_OBSERVATION_V2_FEATURES 64
+#define TD_OBS_V2_FEATURE_OFFSET TD_BASE_OBS_SIZE
+#define TD_OBS_V2_ACTION_MASK_OFFSET (TD_OBS_V2_FEATURE_OFFSET + TD_NUM_OBSERVATION_V2_FEATURES)
+#define TD_OBS_V2_SIZE (TD_OBS_V2_ACTION_MASK_OFFSET + TD_NUM_ACTIONS)
+#define TD_OBS_V1_ACTION_MASK_OFFSET TD_BASE_OBS_SIZE
+#define TD_OBS_V1_SIZE (TD_OBS_V1_ACTION_MASK_OFFSET + TD_NUM_ACTIONS)
+#define TD_FACTOR_NUM_ATNS 3
+#define TD_FACTOR_VERB_COUNT 5
+#define TD_MAX_ENEMIES 256
+#define TD_MAX_SPAWNS 4
+#define TD_MAX_TIER 4
+#define TD_REPEAT_UPGRADE_UNLOCK_ROUND 31
+#define TD_MAX_ACTIVE_PATHS 2
+#define TD_DT 0.25f
+
+#ifndef TD_USE_FACTORED_ACTIONS
+#define TD_USE_FACTORED_ACTIONS 1
+#endif
+
+#ifndef TD_NATIVE_OBSERVATION_RAW_V2
+#define TD_NATIVE_OBSERVATION_RAW_V2 1
+#endif
+
+#if TD_NATIVE_OBSERVATION_RAW_V2
+#define TD_OBS_ACTION_MASK_OFFSET TD_OBS_V2_ACTION_MASK_OFFSET
+#define TD_OBS_SIZE TD_OBS_V2_SIZE
+#else
+#define TD_OBS_ACTION_MASK_OFFSET TD_OBS_V1_ACTION_MASK_OFFSET
+#define TD_OBS_SIZE TD_OBS_V1_SIZE
+#endif
+
+enum TdActionId {
+    TD_ACTION_NOOP = 0,
+    TD_ACTION_DART_SLOT_01 = 1,
+    TD_ACTION_DART_SLOT_02 = 2,
+    TD_ACTION_DART_SLOT_03 = 3,
+    TD_ACTION_DART_SLOT_04 = 4,
+    TD_ACTION_DART_SLOT_05 = 5,
+    TD_ACTION_DART_SLOT_06 = 6,
+    TD_ACTION_DART_SLOT_07 = 7,
+    TD_ACTION_DART_SLOT_08 = 8,
+    TD_ACTION_DART_SLOT_09 = 9,
+    TD_ACTION_DART_SLOT_10 = 10,
+    TD_ACTION_DART_SLOT_11 = 11,
+    TD_ACTION_DART_SLOT_12 = 12,
+    TD_ACTION_SNIPER_SLOT_01 = 13,
+    TD_ACTION_SNIPER_SLOT_02 = 14,
+    TD_ACTION_SNIPER_SLOT_03 = 15,
+    TD_ACTION_SNIPER_SLOT_04 = 16,
+    TD_ACTION_CANNON_SLOT_01 = 17,
+    TD_ACTION_CANNON_SLOT_02 = 18,
+    TD_ACTION_CANNON_SLOT_03 = 19,
+    TD_ACTION_CANNON_SLOT_04 = 20,
+    TD_ACTION_UPGRADE_SLOT_01_TOP = 21,
+    TD_ACTION_SELL_SLOT_01 = 81,
+    TD_ACTION_TRIGGER_NEXT_ROUND = 101,
+    TD_ACTION_LAST = TD_NUM_ACTIONS - 1,
+};
+
+enum TdStatusCode {
+    TD_STATUS_WARMUP = 0,
+    TD_STATUS_SPAWNING = 1,
+    TD_STATUS_INTERMISSION = 2,
+    TD_STATUS_ACTIVE = 3,
+    TD_STATUS_DEFEAT = 4,
+    TD_STATUS_COMPLETE = 5,
+};
+
+enum TdFactorVerb {
+    TD_FACTOR_VERB_NOOP = 0,
+    TD_FACTOR_VERB_PLACE = 1,
+    TD_FACTOR_VERB_UPGRADE = 2,
+    TD_FACTOR_VERB_SELL = 3,
+    TD_FACTOR_VERB_TRIGGER = 4,
+};
+
+typedef struct {
+    float perf;
+    float score;
+    float episode_return;
+    float episode_length;
+    float invalid_action_rate;
+    float n;
+} Log;
+
+typedef struct {
+    int kind;
+    float x;
+    float y;
+} TdSlotSpec;
+
+typedef struct {
+    int alive;
+    int kind;
+    int upgrades[TD_NUM_UPGRADE_PATHS];
+    float x;
+    float y;
+    float cooldown;
+    float invested;
+    float fire_anim;
+} TdTower;
+
+typedef struct {
+    int alive;
+    int type;
+    int camo;
+    int fortified;
+    int regrow;
+    float progress;
+    float hp;
+    float max_hp;
+    float speed;
+    float burn_dps;
+    float burn_time;
+    float slow_mult;
+    float slow_time;
+} TdEnemy;
+
+typedef struct {
+    int type;
+    int count;
+    int emitted;
+    float interval;
+    float next_time;
+    int camo;
+    int fortified;
+    int regrow;
+} TdSpawn;
+
+typedef struct {
+    Log log;
+    float* observations;
+    float* actions;
+    float* rewards;
+    float* terminals;
+    int num_agents;
+    int rng;
+
+    int max_episode_steps;
+    int base_seed;
+    int raw_observation_scalars;
+    int episode_index;
+    int step_count;
+    int invalid_action_count;
+    int valid_actions[TD_NUM_ACTIONS];
+    float invalid_action_reward;
+    float episode_return;
+    float latest_score;
+    float latest_perf;
+
+    unsigned int rng_state;
+    int round;
+    int status_code;
+    float time;
+    float lives;
+    float cash;
+    float intermission_remaining;
+    float wave_elapsed;
+    float score;
+    int active_spawns;
+    TdSpawn spawns[TD_MAX_SPAWNS];
+    TdTower towers[TD_NUM_PLACEMENT_SLOTS];
+    TdEnemy enemies[TD_MAX_ENEMIES];
+    int last_shot_tower;
+    int last_shot_enemy;
+    float last_shot_time;
+    int hover_slot;
+    int human_control;
+} TowerDefence;
+
+static const TdSlotSpec TD_SLOTS[TD_NUM_PLACEMENT_SLOTS] = {
+    {0, 20, 70}, {0, 100, 70}, {0, 220, 70}, {0, 300, 70},
+    {0, 100, 146}, {0, 340, 146}, {0, 432, 152}, {0, 520, 210},
+    {0, 600, 180}, {0, 710, 330}, {0, 620, 421}, {0, 860, 421},
+    {1, 420, 30}, {1, 350, 400}, {1, 770, 180}, {1, 920, 520},
+    {2, 220, 190}, {2, 370, 350}, {2, 500, 340}, {2, 600, 310},
+};
+
+static const float TD_PATH_X[] = {0, 384, 384, 672, 672, 960};
+static const float TD_PATH_Y[] = {108, 108, 270, 270, 459, 459};
+static const float TD_TOWER_COST[] = {100, 260, 420};
+static const float TD_TOWER_RANGE[] = {140, 500, 160};
+static const float TD_TOWER_FIRE_RATE[] = {0.7f, 1.35f, 1.6f};
+static const float TD_TOWER_DAMAGE[] = {1, 2, 3};
+static const int TD_TOWER_DAMAGE_TYPE[] = {0, 0, 1};
+static const int TD_TOWER_RADIUS[] = {14, 12, 16};
+static const int TD_UPGRADE_COST[3][3] = {
+    {90, 105, 120},
+    {180, 210, 195},
+    {240, 200, 225},
+};
+static const float TD_ENEMY_HP[] = {1, 2, 3, 4, 5, 6, 6, 8, 7, 12};
+static const float TD_ENEMY_SPEED[] = {60, 70, 80, 95, 115, 85, 85, 60, 90, 65};
+static const float TD_ENEMY_REWARD[] = {1, 1, 1, 1, 1, 1, 1, 2, 2, 4};
+static const float TD_ENEMY_LEAK[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 5};
+static const int TD_ENEMY_SHARP_IMMUNE[] = {0, 0, 0, 0, 0, 0, 0, 1, 0, 0};
+static const int TD_ENEMY_EXPLOSIVE_IMMUNE[] = {0, 0, 0, 0, 0, 1, 0, 0, 1, 0};
+static const int TD_ENEMY_BURN_IMMUNE[] = {0, 0, 0, 0, 0, 1, 0, 0, 1, 0};
+static const int TD_ENEMY_SLOW_IMMUNE[] = {0, 0, 0, 0, 0, 0, 1, 0, 1, 0};
+static const int TD_ENEMY_CHILD_A[] = {-1, 0, 1, 2, 3, 4, 4, 5, 5, 8};
+static const int TD_ENEMY_CHILD_B[] = {-1, -1, -1, -1, -1, -1, -1, -1, 6, 8};
+
+static void c_reset(TowerDefence* env);
+
+static float td_clampf(float value, float lo, float hi) {
+    if (value < lo) return lo;
+    if (value > hi) return hi;
+    return value;
+}
+
+static float td_squash(float value, float scale) {
+    return tanhf(fmaxf(0.0f, value) / fmaxf(0.0001f, scale));
+}
+
+static unsigned int td_rand(TowerDefence* env) {
+    env->rng_state = env->rng_state * 1664525u + 1013904223u;
+    return env->rng_state;
+}
+
+static float td_randf(TowerDefence* env) {
+    return (td_rand(env) >> 8) / 16777216.0f;
+}
+
+static int td_normalize_action(float raw_action) {
+    if (!isfinite(raw_action)) return TD_ACTION_NOOP;
+    int action = (int)lrintf(raw_action);
+    return (action < 0 || action >= TD_NUM_ACTIONS) ? TD_ACTION_NOOP : action;
+}
+
+static int td_normalize_factor_component(float raw_action, int size) {
+    if (!isfinite(raw_action)) return 0;
+    int action = (int)lrintf(raw_action);
+    return (action < 0 || action >= size) ? 0 : action;
+}
+
+static int td_decode_action(const TowerDefence* env) {
+#if TD_USE_FACTORED_ACTIONS
+    int verb = td_normalize_factor_component(env->actions[0], TD_FACTOR_VERB_COUNT);
+    int slot = td_normalize_factor_component(env->actions[1], TD_NUM_PLACEMENT_SLOTS);
+    int path = td_normalize_factor_component(env->actions[2], TD_NUM_UPGRADE_PATHS);
+    if (verb == TD_FACTOR_VERB_PLACE) return 1 + slot;
+    if (verb == TD_FACTOR_VERB_UPGRADE) return 1 + TD_NUM_PLACEMENT_SLOTS + slot * TD_NUM_UPGRADE_PATHS + path;
+    if (verb == TD_FACTOR_VERB_SELL) return 1 + TD_NUM_PLACEMENT_SLOTS + TD_NUM_UPGRADE_ACTIONS + slot;
+    if (verb == TD_FACTOR_VERB_TRIGGER) return TD_ACTION_TRIGGER_NEXT_ROUND;
+    return TD_ACTION_NOOP;
+#else
+    return td_normalize_action(env->actions[0]);
+#endif
+}
+
+static int td_tower_count(const TowerDefence* env) {
+    int count = 0;
+    for (int i = 0; i < TD_NUM_PLACEMENT_SLOTS; i++) count += env->towers[i].alive;
+    return count;
+}
+
+static int td_enemy_count(const TowerDefence* env) {
+    int count = 0;
+    for (int i = 0; i < TD_MAX_ENEMIES; i++) count += env->enemies[i].alive;
+    return count;
+}
+
+static float td_path_length(void) {
+    float length = 0.0f;
+    for (int i = 0; i < 5; i++) {
+        float dx = TD_PATH_X[i + 1] - TD_PATH_X[i];
+        float dy = TD_PATH_Y[i + 1] - TD_PATH_Y[i];
+        length += sqrtf(dx * dx + dy * dy);
+    }
+    return length;
+}
+
+static Vector2 td_path_point(float progress) {
+    float distance = td_clampf(progress, 0.0f, 1.0f) * td_path_length();
+    for (int i = 0; i < 5; i++) {
+        float dx = TD_PATH_X[i + 1] - TD_PATH_X[i];
+        float dy = TD_PATH_Y[i + 1] - TD_PATH_Y[i];
+        float seg = sqrtf(dx * dx + dy * dy);
+        if (distance <= seg || i == 4) {
+            float t = seg > 0 ? distance / seg : 0.0f;
+            return (Vector2){TD_PATH_X[i] + dx * t, TD_PATH_Y[i] + dy * t};
+        }
+        distance -= seg;
+    }
+    return (Vector2){TD_PATH_X[5], TD_PATH_Y[5]};
+}
+
+static int td_active_paths(const TdTower* tower) {
+    int count = 0;
+    for (int p = 0; p < TD_NUM_UPGRADE_PATHS; p++) count += tower->upgrades[p] > 0;
+    return count;
+}
+
+static float td_upgrade_cost(const TdTower* tower, int path) {
+    int next = tower->upgrades[path] + 1;
+    return (float)(TD_UPGRADE_COST[tower->kind][path] * next * next);
+}
+
+static void td_tower_stats(const TdTower* tower, float* range, float* damage,
+        float* fire_rate, int* damage_type, int* detect_camo, float* burn_dps,
+        float* burn_time, float* slow_mult, float* slow_time) {
+    int kind = tower->kind;
+    *range = TD_TOWER_RANGE[kind];
+    *damage = TD_TOWER_DAMAGE[kind];
+    *fire_rate = TD_TOWER_FIRE_RATE[kind];
+    *damage_type = TD_TOWER_DAMAGE_TYPE[kind];
+    *detect_camo = 0;
+    *burn_dps = kind == 2 ? 1.4f : 0.0f;
+    *burn_time = kind == 2 ? 2.2f : 0.0f;
+    *slow_mult = kind == 1 ? 0.72f : 1.0f;
+    *slow_time = kind == 1 ? 1.2f : 0.0f;
+
+    for (int t = 0; t < tower->upgrades[0]; t++) {
+        *damage += kind == 0 ? 1.0f : (kind == 1 ? 2.0f : 2.0f);
+        if (kind == 1) {
+            *slow_mult = fminf(*slow_mult, 0.65f);
+            *slow_time += 0.45f;
+        }
+        if (kind == 2) {
+            *burn_dps += 1.0f;
+            *burn_time += 0.75f;
+        }
+    }
+    for (int t = 0; t < tower->upgrades[1]; t++) {
+        *range += kind == 0 ? 45.0f : (kind == 1 ? 90.0f : 55.0f);
+        if (kind != 0) *detect_camo = 1;
+    }
+    for (int t = 0; t < tower->upgrades[2]; t++) {
+        *fire_rate *= kind == 1 ? 0.82f : 0.8f;
+    }
+}
+
+static int td_can_upgrade(const TowerDefence* env, int slot, int path) {
+    if (slot < 0 || slot >= TD_NUM_PLACEMENT_SLOTS || path < 0 || path >= TD_NUM_UPGRADE_PATHS) return 0;
+    const TdTower* tower = &env->towers[slot];
+    if (!tower->alive || tower->upgrades[path] >= TD_MAX_TIER) return 0;
+    if (tower->upgrades[path] > 0 && env->round < TD_REPEAT_UPGRADE_UNLOCK_ROUND) return 0;
+    if (tower->upgrades[path] == 0 && td_active_paths(tower) >= TD_MAX_ACTIVE_PATHS) return 0;
+    return env->cash >= td_upgrade_cost(tower, path);
+}
+
+static void td_update_masks(TowerDefence* env) {
+    memset(env->valid_actions, 0, sizeof(env->valid_actions));
+    env->valid_actions[TD_ACTION_NOOP] = 1;
+    for (int slot = 0; slot < TD_NUM_PLACEMENT_SLOTS; slot++) {
+        int kind = TD_SLOTS[slot].kind;
+        env->valid_actions[1 + slot] = !env->towers[slot].alive && env->cash >= TD_TOWER_COST[kind];
+        env->valid_actions[TD_ACTION_SELL_SLOT_01 + slot] = env->towers[slot].alive;
+        for (int path = 0; path < TD_NUM_UPGRADE_PATHS; path++) {
+            env->valid_actions[TD_ACTION_UPGRADE_SLOT_01_TOP + slot * TD_NUM_UPGRADE_PATHS + path] =
+                td_can_upgrade(env, slot, path);
+        }
+    }
+    env->valid_actions[TD_ACTION_TRIGGER_NEXT_ROUND] =
+        env->status_code == TD_STATUS_WARMUP || env->status_code == TD_STATUS_INTERMISSION;
+}
+
+static void td_init(TowerDefence* env) {
+    env->num_agents = 1;
+    env->max_episode_steps = TD_DEFAULT_MAX_EPISODE_STEPS;
+    env->base_seed = TD_DEFAULT_BASE_SEED;
+    env->raw_observation_scalars = 1;
+    env->invalid_action_reward = TD_DEFAULT_INVALID_ACTION_REWARD;
+    env->hover_slot = -1;
+}
+
+static void allocate(TowerDefence* env) {
+    td_init(env);
+    env->observations = (float*)calloc(TD_OBS_SIZE, sizeof(float));
+    env->actions = (float*)calloc(TD_USE_FACTORED_ACTIONS ? TD_FACTOR_NUM_ATNS : 1, sizeof(float));
+    env->rewards = (float*)calloc(1, sizeof(float));
+    env->terminals = (float*)calloc(1, sizeof(float));
+}
+
+static void free_allocated(TowerDefence* env) {
+    free(env->observations);
+    free(env->actions);
+    free(env->rewards);
+    free(env->terminals);
+}
+
+static float td_obs_scalar(TowerDefence* env, float value, float divisor) {
+    return env->raw_observation_scalars ? value : value / divisor;
+}
+
+static void td_write_observation(TowerDefence* env) {
+    memset(env->observations, 0, TD_OBS_SIZE * sizeof(float));
+    env->observations[0] = td_obs_scalar(env, env->time, 400.0f);
+    env->observations[1] = td_obs_scalar(env, (float)env->round, 20.0f);
+    if (env->status_code >= 0 && env->status_code <= TD_STATUS_COMPLETE) {
+        env->observations[2 + env->status_code] = 1.0f;
+    }
+    env->observations[8] = td_obs_scalar(env, env->lives, 100.0f);
+    env->observations[9] = td_obs_scalar(env, env->cash, 650.0f);
+    env->observations[10] = td_obs_scalar(env, env->intermission_remaining, 2.0f);
+    env->observations[11] = td_obs_scalar(env, (float)env->round, 20.0f);
+    env->observations[12] = td_obs_scalar(env, env->wave_elapsed, 15.0f);
+    env->observations[13] = td_obs_scalar(env, (float)td_enemy_count(env), 20.0f);
+    env->observations[14] = td_obs_scalar(env, (float)td_tower_count(env), 20.0f);
+    env->observations[15] = td_obs_scalar(env, env->time - env->last_shot_time < 0.35f ? 1.0f : 0.0f, 1.0f);
+
+    int idx = TD_SCALAR_OBS_SIZE;
+    for (int slot = 0; slot < TD_NUM_PLACEMENT_SLOTS; slot++) {
+        TdTower* tower = &env->towers[slot];
+        env->observations[idx++] = tower->alive ? 1.0f : 0.0f;
+        env->observations[idx++] = tower->alive ? fminf(1.0f, tower->upgrades[0] / (float)TD_MAX_TIER) : 0.0f;
+        env->observations[idx++] = tower->alive ? fminf(1.0f, tower->upgrades[1] / (float)TD_MAX_TIER) : 0.0f;
+        env->observations[idx++] = tower->alive ? fminf(1.0f, tower->upgrades[2] / (float)TD_MAX_TIER) : 0.0f;
+    }
+
+    float count_bins[TD_NUM_ENEMY_PROGRESS_BINS] = {0};
+    float hp_bins[TD_NUM_ENEMY_PROGRESS_BINS] = {0};
+    float type_mass[10] = {0};
+    float prop_mass[8] = {0};
+    float band_mass[4][4] = {{0}};
+    for (int i = 0; i < TD_MAX_ENEMIES; i++) {
+        TdEnemy* enemy = &env->enemies[i];
+        if (!enemy->alive) continue;
+        int bin = (int)fminf(TD_NUM_ENEMY_PROGRESS_BINS - 1, floorf(enemy->progress * TD_NUM_ENEMY_PROGRESS_BINS));
+        int band = (int)fminf(3, floorf(enemy->progress * 4));
+        float hp = fmaxf(0.0f, enemy->hp);
+        float leak = TD_ENEMY_LEAK[enemy->type];
+        count_bins[bin] += 1.0f;
+        hp_bins[bin] += fminf(1.0f, hp / fmaxf(1.0f, enemy->max_hp));
+        type_mass[enemy->type] += fmaxf(1.0f, hp);
+        prop_mass[0] += enemy->camo ? hp : 0.0f;
+        prop_mass[1] += enemy->fortified ? hp : 0.0f;
+        prop_mass[2] += enemy->regrow ? hp : 0.0f;
+        prop_mass[3] += TD_ENEMY_SHARP_IMMUNE[enemy->type] ? hp : 0.0f;
+        prop_mass[4] += TD_ENEMY_EXPLOSIVE_IMMUNE[enemy->type] ? hp : 0.0f;
+        prop_mass[5] += TD_ENEMY_BURN_IMMUNE[enemy->type] ? hp : 0.0f;
+        prop_mass[6] += TD_ENEMY_SLOW_IMMUNE[enemy->type] ? hp : 0.0f;
+        prop_mass[7] += enemy->type == 9 ? hp : 0.0f;
+        band_mass[band][0] += 1.0f;
+        band_mass[band][1] += hp;
+        band_mass[band][2] += leak;
+        band_mass[band][3] += (enemy->camo || TD_ENEMY_SHARP_IMMUNE[enemy->type] ||
+            TD_ENEMY_EXPLOSIVE_IMMUNE[enemy->type]) ? leak : 0.0f;
+    }
+    for (int i = 0; i < TD_NUM_ENEMY_PROGRESS_BINS; i++) env->observations[idx++] = td_squash(count_bins[i], 3.0f);
+    for (int i = 0; i < TD_NUM_ENEMY_PROGRESS_BINS; i++) env->observations[idx++] = td_squash(hp_bins[i], 3.0f);
+
+#if TD_NATIVE_OBSERVATION_RAW_V2
+    idx = TD_OBS_V2_FEATURE_OFFSET;
+    for (int i = 0; i < 10; i++) env->observations[idx++] = td_squash(type_mass[i], 12.0f);
+    for (int i = 0; i < 8; i++) env->observations[idx++] = td_squash(prop_mass[i], 12.0f);
+    for (int band = 0; band < 4; band++) {
+        env->observations[idx++] = td_squash(band_mass[band][0], 4.0f);
+        env->observations[idx++] = td_squash(band_mass[band][1], 24.0f);
+        env->observations[idx++] = td_squash(band_mass[band][2], 10.0f);
+        env->observations[idx++] = td_squash(band_mass[band][3], 10.0f);
+    }
+    float comp[10] = {0};
+    for (int slot = 0; slot < TD_NUM_PLACEMENT_SLOTS; slot++) {
+        TdTower* tower = &env->towers[slot];
+        env->observations[idx++] = tower->alive ? fminf(1.0f, tower->invested / 3000.0f) : 0.0f;
+        if (!tower->alive) continue;
+        float range, damage, fire_rate, burn_dps, burn_time, slow_mult, slow_time;
+        int damage_type, detect_camo;
+        td_tower_stats(tower, &range, &damage, &fire_rate, &damage_type, &detect_camo,
+            &burn_dps, &burn_time, &slow_mult, &slow_time);
+        comp[tower->kind] += 1.0f;
+        comp[3] += 1.0f;
+        comp[damage_type == 0 ? 4 : 5] += damage / fmaxf(0.1f, fire_rate);
+        comp[6] += detect_camo ? 1.0f : 0.0f;
+        comp[7] += burn_dps;
+        comp[8] += (1.0f - slow_mult) * fmaxf(1.0f, slow_time);
+        comp[9] += tower->invested;
+    }
+    env->observations[idx++] = td_squash(comp[0], 6.0f);
+    env->observations[idx++] = td_squash(comp[1], 4.0f);
+    env->observations[idx++] = td_squash(comp[2], 4.0f);
+    env->observations[idx++] = td_squash(comp[3], 12.0f);
+    env->observations[idx++] = td_squash(comp[4], 20.0f);
+    env->observations[idx++] = td_squash(comp[5], 20.0f);
+    env->observations[idx++] = td_squash(comp[6], 4.0f);
+    env->observations[idx++] = td_squash(comp[7], 8.0f);
+    env->observations[idx++] = td_squash(comp[8], 4.0f);
+    env->observations[idx++] = td_squash(comp[9], 8000.0f);
+#endif
+
+    td_update_masks(env);
+    for (int action = 0; action < TD_NUM_ACTIONS; action++) {
+        env->observations[TD_OBS_ACTION_MASK_OFFSET + action] = (float)env->valid_actions[action];
+    }
+}
+
+static int td_spawn_done(const TowerDefence* env) {
+    for (int i = 0; i < env->active_spawns; i++) {
+        if (env->spawns[i].emitted < env->spawns[i].count) return 0;
+    }
+    return 1;
+}
+
+static int td_add_enemy(TowerDefence* env, int type, int camo, int fortified, int regrow, float progress) {
+    for (int i = 0; i < TD_MAX_ENEMIES; i++) {
+        TdEnemy* enemy = &env->enemies[i];
+        if (enemy->alive) continue;
+        float round_scale = env->round > 20 ? 1.0f + 0.018f * (env->round - 20) : 1.0f;
+        enemy->alive = 1;
+        enemy->type = type;
+        enemy->camo = camo;
+        enemy->fortified = fortified;
+        enemy->regrow = regrow;
+        enemy->progress = progress;
+        enemy->max_hp = TD_ENEMY_HP[type] * round_scale * (fortified ? 1.8f : 1.0f);
+        enemy->hp = enemy->max_hp;
+        enemy->speed = TD_ENEMY_SPEED[type] * (1.0f + 0.002f * fmaxf(0.0f, env->round - 20));
+        enemy->burn_dps = 0.0f;
+        enemy->burn_time = 0.0f;
+        enemy->slow_mult = 1.0f;
+        enemy->slow_time = 0.0f;
+        return i;
+    }
+    return -1;
+}
+
+static void td_add_spawn(TowerDefence* env, int type, int count, float interval,
+        int camo, int fortified, int regrow) {
+    if (env->active_spawns >= TD_MAX_SPAWNS) return;
+    TdSpawn* spawn = &env->spawns[env->active_spawns++];
+    spawn->type = type;
+    spawn->count = count;
+    spawn->emitted = 0;
+    spawn->interval = interval;
+    spawn->next_time = env->wave_elapsed + 0.01f * env->active_spawns;
+    spawn->camo = camo;
+    spawn->fortified = fortified;
+    spawn->regrow = regrow;
+}
+
+static void td_prepare_wave(TowerDefence* env) {
+    env->active_spawns = 0;
+    env->wave_elapsed = 0.0f;
+    int r = env->round;
+    if (r == 1) td_add_spawn(env, 0, 20, 0.6f, 0, 0, 0);
+    else if (r == 2) td_add_spawn(env, 0, 30, 0.5f, 0, 0, 0);
+    else if (r <= 5) {
+        td_add_spawn(env, 0, 12 + r * 2, 0.5f, 0, 0, 0);
+        td_add_spawn(env, r >= 3 ? 1 : 0, 6 + r, 0.55f, 0, 0, 0);
+    } else if (r <= 10) {
+        td_add_spawn(env, 2 + (r > 7), 12 + r, 0.45f, 0, 0, 0);
+        td_add_spawn(env, r >= 10 ? 5 : 4, 6 + r / 2, 0.42f, 0, 0, 0);
+    } else if (r <= 20) {
+        td_add_spawn(env, (r % 3) + 4, 8 + r / 2, 0.42f, 0, 0, 0);
+        td_add_spawn(env, r >= 12 ? 7 : 5, 3 + r / 3, 0.55f, 0, 0, 0);
+        if (r >= 13) td_add_spawn(env, 8, 2 + r / 5, 0.58f, 0, 0, 0);
+        if (r == 20) td_add_spawn(env, 9, 1, 0.01f, 0, 0, 0);
+    } else {
+        int base = r < 36 ? 1 : (r < 61 ? 3 : 5);
+        int groups = r < 36 ? 2 : (r < 70 ? 3 : 4);
+        int count = r <= 80 ? (int)fminf(150.0f / groups, 12.0f + r * 0.45f)
+                            : (int)fminf(180.0f / groups, 36.0f + r * 0.04f);
+        for (int g = 0; g < groups; g++) {
+            int type = (base + g + (td_rand(env) % 3)) % 10;
+            if (r > 100 && type == 9) type = 8;
+            int camo = r > 32 && td_randf(env) < fminf(0.32f, 0.03f + r * 0.0015f);
+            int fortified = r > 45 && td_randf(env) < fminf(0.28f, 0.02f + r * 0.0012f);
+            int regrow = r > 28 && td_randf(env) < fminf(0.25f, 0.02f + r * 0.001f);
+            td_add_spawn(env, type, count, fmaxf(0.28f, 0.52f - r * 0.002f), camo, fortified, regrow);
+        }
+    }
+}
+
+static void td_start_round(TowerDefence* env) {
+    if (env->status_code != TD_STATUS_WARMUP && env->status_code != TD_STATUS_INTERMISSION) return;
+    env->status_code = TD_STATUS_SPAWNING;
+    env->intermission_remaining = 0.0f;
+    td_prepare_wave(env);
+}
+
+static void td_kill_enemy(TowerDefence* env, int idx, float* reward) {
+    TdEnemy* enemy = &env->enemies[idx];
+    int child_a = TD_ENEMY_CHILD_A[enemy->type];
+    int child_b = TD_ENEMY_CHILD_B[enemy->type];
+    float progress = enemy->progress;
+    int camo = enemy->camo;
+    int regrow = enemy->regrow;
+    *reward += TD_ENEMY_REWARD[enemy->type] * 0.01f;
+    env->cash += TD_ENEMY_REWARD[enemy->type];
+    enemy->alive = 0;
+    if (child_a >= 0) td_add_enemy(env, child_a, camo, 0, regrow, progress);
+    if (child_b >= 0) td_add_enemy(env, child_b, camo, 0, regrow, progress);
+}
+
+static void td_apply_tower_damage(TowerDefence* env, float* reward) {
+    for (int slot = 0; slot < TD_NUM_PLACEMENT_SLOTS; slot++) {
+        TdTower* tower = &env->towers[slot];
+        if (!tower->alive) continue;
+        tower->cooldown -= TD_DT;
+        tower->fire_anim = fmaxf(0.0f, tower->fire_anim - TD_DT);
+        if (tower->cooldown > 0.0f) continue;
+
+        float range, damage, fire_rate, burn_dps, burn_time, slow_mult, slow_time;
+        int damage_type, detect_camo;
+        td_tower_stats(tower, &range, &damage, &fire_rate, &damage_type, &detect_camo,
+            &burn_dps, &burn_time, &slow_mult, &slow_time);
+        int target = -1;
+        float best_progress = -1.0f;
+        for (int i = 0; i < TD_MAX_ENEMIES; i++) {
+            TdEnemy* enemy = &env->enemies[i];
+            if (!enemy->alive) continue;
+            if (enemy->camo && !detect_camo) continue;
+            if (damage_type == 0 && TD_ENEMY_SHARP_IMMUNE[enemy->type]) continue;
+            if (damage_type == 1 && TD_ENEMY_EXPLOSIVE_IMMUNE[enemy->type]) continue;
+            Vector2 p = td_path_point(enemy->progress);
+            float dx = p.x - tower->x;
+            float dy = p.y - tower->y;
+            if (sqrtf(dx * dx + dy * dy) <= range && enemy->progress > best_progress) {
+                target = i;
+                best_progress = enemy->progress;
+            }
+        }
+        if (target < 0) continue;
+        TdEnemy* enemy = &env->enemies[target];
+        enemy->hp -= damage;
+        if (burn_dps > 0.0f && !TD_ENEMY_BURN_IMMUNE[enemy->type]) {
+            enemy->burn_dps = fmaxf(enemy->burn_dps, burn_dps);
+            enemy->burn_time = fmaxf(enemy->burn_time, burn_time);
+        }
+        if (slow_mult < 1.0f && !TD_ENEMY_SLOW_IMMUNE[enemy->type]) {
+            enemy->slow_mult = fminf(enemy->slow_mult, slow_mult);
+            enemy->slow_time = fmaxf(enemy->slow_time, slow_time);
+        }
+        tower->cooldown = fire_rate;
+        tower->fire_anim = 0.22f;
+        env->last_shot_tower = slot;
+        env->last_shot_enemy = target;
+        env->last_shot_time = env->time;
+        if (enemy->hp <= 0.0f) td_kill_enemy(env, target, reward);
+    }
+}
+
+static float td_round_clear_bonus(const TowerDefence* env) {
+    float rbe = 170.0f + fminf(120.0f, fmaxf(0.0f, env->round - 20) * 3.5f);
+    return floorf(42.0f + 4.0f * env->round + 0.052f * rbe);
+}
+
+static void td_advance_world(TowerDefence* env, float* reward) {
+    env->time += TD_DT;
+    if (env->status_code == TD_STATUS_INTERMISSION) {
+        env->intermission_remaining = fmaxf(0.0f, env->intermission_remaining - TD_DT);
+        return;
+    }
+    if (env->status_code != TD_STATUS_SPAWNING && env->status_code != TD_STATUS_ACTIVE) return;
+
+    env->wave_elapsed += TD_DT;
+    for (int s = 0; s < env->active_spawns; s++) {
+        TdSpawn* spawn = &env->spawns[s];
+        while (spawn->emitted < spawn->count && env->wave_elapsed >= spawn->next_time) {
+            td_add_enemy(env, spawn->type, spawn->camo, spawn->fortified, spawn->regrow, 0.0f);
+            spawn->emitted += 1;
+            spawn->next_time += spawn->interval;
+        }
+    }
+    if (td_spawn_done(env)) env->status_code = TD_STATUS_ACTIVE;
+
+    for (int i = 0; i < TD_MAX_ENEMIES; i++) {
+        TdEnemy* enemy = &env->enemies[i];
+        if (!enemy->alive) continue;
+        if (enemy->burn_time > 0.0f) {
+            enemy->hp -= enemy->burn_dps * TD_DT * (enemy->type == 9 ? 0.85f : 1.0f);
+            enemy->burn_time = fmaxf(0.0f, enemy->burn_time - TD_DT);
+        }
+        if (enemy->slow_time > 0.0f) {
+            enemy->slow_time = fmaxf(0.0f, enemy->slow_time - TD_DT);
+        } else {
+            enemy->slow_mult = 1.0f;
+        }
+        if (enemy->regrow && enemy->hp < enemy->max_hp) {
+            enemy->hp = fminf(enemy->max_hp, enemy->hp + 0.25f * TD_DT);
+        }
+        if (enemy->hp <= 0.0f) {
+            td_kill_enemy(env, i, reward);
+            continue;
+        }
+        enemy->progress += (enemy->speed * enemy->slow_mult * TD_DT) / td_path_length();
+        if (enemy->progress >= 1.0f) {
+            env->lives -= TD_ENEMY_LEAK[enemy->type];
+            *reward -= TD_ENEMY_LEAK[enemy->type] * 0.05f;
+            enemy->alive = 0;
+        }
+    }
+    td_apply_tower_damage(env, reward);
+
+    if (env->lives <= 0.0f) {
+        env->status_code = TD_STATUS_DEFEAT;
+        return;
+    }
+    if (td_spawn_done(env) && td_enemy_count(env) == 0) {
+        float bonus = td_round_clear_bonus(env);
+        env->cash += bonus;
+        *reward += 1.0f;
+        env->score = (float)env->round;
+        env->round += 1;
+        env->status_code = env->round > 200 ? TD_STATUS_COMPLETE : TD_STATUS_INTERMISSION;
+        env->intermission_remaining = 2.0f;
+    }
+}
+
+static void td_place(TowerDefence* env, int slot) {
+    int kind = TD_SLOTS[slot].kind;
+    TdTower* tower = &env->towers[slot];
+    tower->alive = 1;
+    tower->kind = kind;
+    tower->x = TD_SLOTS[slot].x;
+    tower->y = TD_SLOTS[slot].y;
+    tower->cooldown = 0.0f;
+    tower->invested = TD_TOWER_COST[kind];
+    tower->fire_anim = 0.0f;
+    memset(tower->upgrades, 0, sizeof(tower->upgrades));
+    env->cash -= TD_TOWER_COST[kind];
+}
+
+static void td_upgrade(TowerDefence* env, int slot, int path) {
+    TdTower* tower = &env->towers[slot];
+    float cost = td_upgrade_cost(tower, path);
+    tower->upgrades[path] += 1;
+    tower->invested += cost;
+    env->cash -= cost;
+}
+
+static void td_sell(TowerDefence* env, int slot) {
+    TdTower* tower = &env->towers[slot];
+    env->cash += floorf(tower->invested * 0.7f);
+    memset(tower, 0, sizeof(*tower));
+}
+
+static int td_apply_action(TowerDefence* env, int action) {
+    td_update_masks(env);
+    if (action < 0 || action >= TD_NUM_ACTIONS || !env->valid_actions[action]) return 0;
+    if (action >= 1 && action <= TD_NUM_PLACEMENT_SLOTS) td_place(env, action - 1);
+    else if (action >= TD_ACTION_UPGRADE_SLOT_01_TOP && action < TD_ACTION_SELL_SLOT_01) {
+        int idx = action - TD_ACTION_UPGRADE_SLOT_01_TOP;
+        td_upgrade(env, idx / TD_NUM_UPGRADE_PATHS, idx % TD_NUM_UPGRADE_PATHS);
+    } else if (action >= TD_ACTION_SELL_SLOT_01 && action < TD_ACTION_TRIGGER_NEXT_ROUND) {
+        td_sell(env, action - TD_ACTION_SELL_SLOT_01);
+    } else if (action == TD_ACTION_TRIGGER_NEXT_ROUND) td_start_round(env);
+    return 1;
+}
+
+static void td_log_episode(TowerDefence* env) {
+    float steps = env->step_count > 0 ? (float)env->step_count : 1.0f;
+    env->log.perf += fminf(1.0f, env->score / 200.0f);
+    env->log.score += env->score;
+    env->log.episode_return += env->episode_return;
+    env->log.episode_length += (float)env->step_count;
+    env->log.invalid_action_rate += (float)env->invalid_action_count / steps;
+    env->log.n += 1.0f;
+}
+
+static void c_reset(TowerDefence* env) {
+    env->rng_state = (unsigned int)(env->base_seed + env->rng * 100003 + env->episode_index++);
+    env->step_count = 0;
+    env->invalid_action_count = 0;
+    env->episode_return = 0.0f;
+    env->latest_score = 0.0f;
+    env->latest_perf = 0.0f;
+    env->round = 1;
+    env->status_code = TD_STATUS_WARMUP;
+    env->time = 0.0f;
+    env->lives = 200.0f;
+    env->cash = 10000.0f;
+    env->intermission_remaining = 0.0f;
+    env->wave_elapsed = 0.0f;
+    env->score = 0.0f;
+    env->active_spawns = 0;
+    env->last_shot_tower = -1;
+    env->last_shot_enemy = -1;
+    env->last_shot_time = -999.0f;
+    memset(env->spawns, 0, sizeof(env->spawns));
+    memset(env->towers, 0, sizeof(env->towers));
+    memset(env->enemies, 0, sizeof(env->enemies));
+    td_write_observation(env);
+}
+
+static void c_step(TowerDefence* env) {
+    int action = td_decode_action(env);
+    float reward = 0.0f;
+    int valid = td_apply_action(env, action);
+    if (!valid) {
+        env->invalid_action_count += 1;
+        reward += env->invalid_action_reward;
+    }
+    td_advance_world(env, &reward);
+    env->step_count += 1;
+    env->episode_return += reward;
+    env->latest_score = env->score;
+    env->latest_perf = fminf(1.0f, env->score / 200.0f);
+    env->rewards[0] = reward;
+    env->terminals[0] = 0.0f;
+    int done = env->status_code == TD_STATUS_DEFEAT ||
+        env->status_code == TD_STATUS_COMPLETE ||
+        env->step_count >= env->max_episode_steps;
+    if (done) {
+        env->terminals[0] = 1.0f;
+        td_log_episode(env);
+        c_reset(env);
+        return;
+    }
+    td_write_observation(env);
+}
+
+static Color td_enemy_color(int type) {
+    static const Color colors[10] = {
+        {239, 68, 68, 255}, {59, 130, 246, 255}, {34, 197, 94, 255},
+        {250, 204, 21, 255}, {244, 114, 182, 255}, {17, 24, 39, 255},
+        {229, 231, 235, 255}, {107, 114, 128, 255}, {249, 250, 251, 255},
+        {217, 119, 6, 255},
+    };
+    return colors[type];
+}
+
+static void c_render(TowerDefence* env) {
+    if (!IsWindowReady()) {
+        InitWindow(TD_WIDTH, TD_HEIGHT + 80, "PufferLib Tower Defence");
+        SetTargetFPS(60);
+    }
+    if (IsKeyDown(KEY_ESCAPE)) exit(0);
+
+    BeginDrawing();
+    ClearBackground((Color){12, 18, 24, 255});
+    for (int y = 0; y < TD_HEIGHT; y += 36) {
+        DrawLine(0, y, TD_WIDTH, y, (Color){24, 32, 42, 255});
+    }
+    for (int i = 0; i < 5; i++) {
+        Vector2 a = {TD_PATH_X[i], TD_PATH_Y[i]};
+        Vector2 b = {TD_PATH_X[i + 1], TD_PATH_Y[i + 1]};
+        DrawLineEx(a, b, 58, (Color){55, 65, 81, 255});
+        DrawLineEx(a, b, 42, (Color){17, 24, 39, 255});
+        DrawLineEx(a, b, 6, (Color){251, 146, 60, 255});
+    }
+
+    env->human_control = IsKeyDown(KEY_LEFT_SHIFT);
+    env->hover_slot = -1;
+    Vector2 mouse = GetMousePosition();
+    float best = 999999.0f;
+    for (int slot = 0; slot < TD_NUM_PLACEMENT_SLOTS; slot++) {
+        float dx = mouse.x - TD_SLOTS[slot].x;
+        float dy = mouse.y - TD_SLOTS[slot].y;
+        float d = dx * dx + dy * dy;
+        if (d < best) {
+            best = d;
+            env->hover_slot = slot;
+        }
+    }
+
+    for (int slot = 0; slot < TD_NUM_PLACEMENT_SLOTS; slot++) {
+        TdTower* tower = &env->towers[slot];
+        int kind = tower->alive ? tower->kind : TD_SLOTS[slot].kind;
+        Color color = kind == 0 ? (Color){59, 130, 246, 255}
+            : (kind == 1 ? (Color){229, 231, 235, 255} : (Color){156, 163, 175, 255});
+        Vector2 p = {TD_SLOTS[slot].x, TD_SLOTS[slot].y};
+        if (!tower->alive) {
+            DrawCircleLines((int)p.x, (int)p.y, TD_TOWER_RADIUS[kind], (Color){75, 85, 99, 160});
+            continue;
+        }
+        if (slot == env->hover_slot || tower->fire_anim > 0.0f) {
+            float range, damage, fire_rate, burn_dps, burn_time, slow_mult, slow_time;
+            int damage_type, detect_camo;
+            td_tower_stats(tower, &range, &damage, &fire_rate, &damage_type, &detect_camo,
+                &burn_dps, &burn_time, &slow_mult, &slow_time);
+            DrawCircleLines((int)p.x, (int)p.y, range, (Color){96, 165, 250, 80});
+        }
+        DrawCircleV(p, (float)TD_TOWER_RADIUS[kind] + 3, (Color){15, 23, 42, 255});
+        DrawCircleV(p, (float)TD_TOWER_RADIUS[kind], color);
+        DrawRectangle((int)p.x - 7, (int)p.y - 3, 14, 6, (Color){251, 146, 60, 255});
+    }
+
+    if (env->time - env->last_shot_time < 0.18f &&
+            env->last_shot_tower >= 0 && env->last_shot_enemy >= 0) {
+        TdTower* tower = &env->towers[env->last_shot_tower];
+        TdEnemy* enemy = &env->enemies[env->last_shot_enemy];
+        if (tower->alive && enemy->alive) {
+            DrawLineEx((Vector2){tower->x, tower->y}, td_path_point(enemy->progress),
+                3, (Color){251, 191, 36, 220});
+        }
+    }
+
+    for (int i = 0; i < TD_MAX_ENEMIES; i++) {
+        TdEnemy* enemy = &env->enemies[i];
+        if (!enemy->alive) continue;
+        Vector2 p = td_path_point(enemy->progress);
+        Color color = td_enemy_color(enemy->type);
+        DrawCircleV(p, enemy->type == 9 ? 11 : 8, color);
+        if (enemy->camo) DrawCircleLines((int)p.x, (int)p.y, 13, (Color){34, 211, 238, 255});
+        if (enemy->fortified) DrawCircleLines((int)p.x, (int)p.y, 16, (Color){251, 146, 60, 255});
+        DrawRectangle((int)p.x - 10, (int)p.y - 17, 20, 3, (Color){31, 41, 55, 255});
+        DrawRectangle((int)p.x - 10, (int)p.y - 17,
+            (int)(20 * td_clampf(enemy->hp / fmaxf(1.0f, enemy->max_hp), 0.0f, 1.0f)),
+            3, (Color){34, 197, 94, 255});
+    }
+
+    DrawRectangle(0, TD_HEIGHT, TD_WIDTH, 80, (Color){3, 7, 18, 255});
+    DrawText(TextFormat("Round %d  Lives %.0f  Cash %.0f  Score %.0f", env->round, env->lives, env->cash, env->score),
+        18, TD_HEIGHT + 12, 22, RAYWHITE);
+    DrawText(env->human_control ? "SHIFT takeover: LMB place, Q/W/E upgrade, RMB/X sell, Space trigger"
+                                : "Policy playback",
+        18, TD_HEIGHT + 44, 18, env->human_control ? (Color){251, 191, 36, 255} : (Color){148, 163, 184, 255});
+    EndDrawing();
+}
+
+static void c_close(TowerDefence* env) {
+    (void)env;
+    if (IsWindowReady()) CloseWindow();
+}

--- a/ocean/tower_defence/tower_defence.h
+++ b/ocean/tower_defence/tower_defence.h
@@ -652,15 +652,17 @@ static void td_advance_world(TowerDefence* env, float* reward) {
     }
     if (env->status_code != TD_STATUS_SPAWNING && env->status_code != TD_STATUS_ACTIVE) return;
 
-    env->wave_elapsed += TD_DT;
-    for (int s = 0; s < env->active_spawns; s++) {
-        TdSpawn* spawn = &env->spawns[s];
-        while (spawn->emitted < spawn->count && env->wave_elapsed + 1e-6f >= spawn->next_time) {
-            if (td_add_enemy(env, spawn->type, spawn->camo, spawn->fortified, spawn->regrow, 0.0f) < 0) {
-                break;
+    if (env->status_code == TD_STATUS_SPAWNING) {
+        env->wave_elapsed += TD_DT;
+        for (int s = 0; s < env->active_spawns; s++) {
+            TdSpawn* spawn = &env->spawns[s];
+            while (spawn->emitted < spawn->count && env->wave_elapsed + 1e-6f >= spawn->next_time) {
+                if (td_add_enemy(env, spawn->type, spawn->camo, spawn->fortified, spawn->regrow, 0.0f) < 0) {
+                    break;
+                }
+                spawn->emitted += 1;
+                spawn->next_time += spawn->interval;
             }
-            spawn->emitted += 1;
-            spawn->next_time += spawn->interval;
         }
     }
     if (td_spawn_done(env)) env->status_code = TD_STATUS_ACTIVE;

--- a/ocean/tower_defence/tower_defence.h
+++ b/ocean/tower_defence/tower_defence.h
@@ -655,7 +655,7 @@ static void td_advance_world(TowerDefence* env, float* reward) {
     env->wave_elapsed += TD_DT;
     for (int s = 0; s < env->active_spawns; s++) {
         TdSpawn* spawn = &env->spawns[s];
-        while (spawn->emitted < spawn->count && env->wave_elapsed >= spawn->next_time) {
+        while (spawn->emitted < spawn->count && env->wave_elapsed + 1e-6f >= spawn->next_time) {
             if (td_add_enemy(env, spawn->type, spawn->camo, spawn->fortified, spawn->regrow, 0.0f) < 0) {
                 break;
             }

--- a/ocean/tower_defence_flat/binding.c
+++ b/ocean/tower_defence_flat/binding.c
@@ -31,7 +31,6 @@ void my_init(Env* env, Dict* kwargs) {
     env->max_episode_steps = td_get_int(
         kwargs, "max_episode_steps", TD_DEFAULT_MAX_EPISODE_STEPS);
     env->base_seed = td_get_int(kwargs, "base_seed", TD_DEFAULT_BASE_SEED);
-    env->raw_observation_scalars = td_get_int(kwargs, "raw_observation_scalars", 1);
     env->episode_index = 0;
     env->step_count = 0;
     env->invalid_action_count = 0;

--- a/ocean/tower_defence_flat/binding.c
+++ b/ocean/tower_defence_flat/binding.c
@@ -1,0 +1,53 @@
+#define TD_USE_FACTORED_ACTIONS 0
+#include "../tower_defence/tower_defence.h"
+
+#define OBS_TENSOR_T FloatTensor
+#define OBS_SIZE TD_OBS_SIZE
+#define NUM_ATNS 1
+#define ACT_SIZES {TD_NUM_ACTIONS}
+
+#define Env TowerDefence
+#include "vecenv.h"
+
+static int td_get_int(Dict* kwargs, const char* key, int fallback) {
+    DictItem* item = dict_get_unsafe(kwargs, key);
+    if (item == NULL) {
+        return fallback;
+    }
+    return (int)item->value;
+}
+
+static float td_get_float(Dict* kwargs, const char* key, float fallback) {
+    DictItem* item = dict_get_unsafe(kwargs, key);
+    if (item == NULL) {
+        return fallback;
+    }
+    return item->value;
+}
+
+void my_init(Env* env, Dict* kwargs) {
+    memset(&env->log, 0, sizeof(env->log));
+    td_init(env);
+    env->max_episode_steps = td_get_int(
+        kwargs, "max_episode_steps", TD_DEFAULT_MAX_EPISODE_STEPS);
+    env->base_seed = td_get_int(kwargs, "base_seed", TD_DEFAULT_BASE_SEED);
+    env->raw_observation_scalars = td_get_int(kwargs, "raw_observation_scalars", 1);
+    env->episode_index = 0;
+    env->step_count = 0;
+    env->invalid_action_count = 0;
+    memset(env->valid_actions, 0, sizeof(env->valid_actions));
+    env->valid_actions[TD_ACTION_NOOP] = 1;
+    env->invalid_action_reward = td_get_float(
+        kwargs, "invalid_action_reward", TD_DEFAULT_INVALID_ACTION_REWARD);
+    env->episode_return = 0.0f;
+    env->latest_score = 0.0f;
+    env->latest_perf = 0.0f;
+}
+
+void my_log(Log* log, Dict* out) {
+    dict_set(out, "score", log->score);
+    dict_set(out, "perf", log->perf);
+    dict_set(out, "episode_return", log->episode_return);
+    dict_set(out, "episode_length", log->episode_length);
+    dict_set(out, "invalid_action_rate", log->invalid_action_rate);
+}

--- a/ocean/tower_defence_flat/tower_defence_flat.c
+++ b/ocean/tower_defence_flat/tower_defence_flat.c
@@ -1,0 +1,3 @@
+#define TD_USE_FACTORED_ACTIONS 0
+#define TD_DEMO_WEIGHT_PATH "resources/tower_defence_flat/tower_defence_flat_weights.bin"
+#include "../tower_defence/tower_defence.c"


### PR DESCRIPTION
## Summary

- Add a self-contained native Ocean `tower_defence` environment with a shared game core and raylib renderer.
- Add `tower_defence_flat` as the policy/checkpoint-compatible flat 102-action variant.
- Add configs for both variants with raw-v2 observation ABI: obs `278`, mask offset `176`, trigger-next-round action `101`.

## Validation

- Scoped diff from `d21a161a`: 7 files, 1,170 insertions, limited to `config/tower_defence*.ini` and `ocean/tower_defence*`.
- Static no-bridge gate passed: no `bridge`, `localhost`, `socket`, `websocket`, `monitor`, or `select` strings in the new env/config files.
- `git diff --check d21a161a..HEAD` passed for the scoped files.
- Clean CPU builds and reset smokes passed for `tower_defence_flat` and `tower_defence`; latest clean CPU builds passed again at `e85de143`.
- Standalone raylib builds passed for both variants in earlier clean validation.
- v445b checkpoint CPU load smoke passed: `tower_defence_flat 278 [102] torch.Size([128, 278]) torch.Size([102, 128])`.
- Native protected-seed smoke passed runtime/ABI checks with zero invalid actions across seeds `38`, `1000`, `1001`, `1002`, `1003`, and `1004`.
- JS/native parity probe passes 120 post-trigger no-tower steps for seeds `1`, `38`, and `1000`; a shorter no-tower control also passed for protected seed `1002`.
- Forced JS/native tower-action probe on protected seed `1002` fails at the first post-trigger step after action prefix `[1,21,21,81,13,101]`: native has `cash=9684`, `enemyCount=0`, reward `0.01`; JS has `cash=9683`, `enemyCount=1`, reward `25`. This isolates remaining divergence to tower/action semantics rather than no-tower trigger parity.
- Focused JS/native intermission harness confirms `obs[10] == 2` during spawning after trigger; this matches the trained raw-v2 JS checkpoint ABI and is documented in-code at `e85de143`.
- Factored/flat native CPU parity smoke matched terminal score/return/invalid-rate for seeds `1`, `38`, and `1000` under the same deterministic mask policy.
- Elegance review removed the old v1 observation ABI switch and raw scalar env knob.
- Final review found one saturated-spawn blocker, fixed in `0a788458`; latest clean deep review at `e85de143` reported no discrete correctness issues.

## Caveats

- Local WSL validation used temporary `/tmp` shims because the host lacks `clang`, `libomp5`, and a `libGL.so` development symlink. No shared `build.sh` changes are included in this PR.
- GPU training smoke was not run locally because CUDA/NVML were unavailable.
- GUI manual interaction was not exercised in the headless terminal, though raylib builds and Shift-held takeover paths are present.
- Reset lifecycle still differs from the JS benchmark manual-reset surface: native starts at `round=1`, `warmup`, while JS manual-reset starts at `round=0`, `intermission`; post-trigger no-tower parity passed.
- Native protected-seed scores were `29`-`35`, and the forced tower-action parity probe above fails, so this PR does not claim to preserve the existing JS/frontier score. Full tower/action parity fix or native rebaseline/retraining should be handled separately before making frontier-continuity claims.
