### PR TITLE
Fix log access for target_key in sweep.py

### DIFF
--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -951,7 +951,7 @@ class Protein:
                 logs['is_loss_nan'] = True
                 return True
 
-        if 'uptime' not in logs or target_key not in logs:
+        if 'uptime' not in logs or target_key not in logs['env']:
             return False
 
         metric_val, cost = logs['env'][target_key], logs['uptime']


### PR DESCRIPTION
```PYTHON
if cost > 1.2 * self.upper_cost_threshold:
    return 0.9 * self.max_score
 ```


This check doesn't work if the numbers have a nonzero offset, as the offset is scaled as well. Most visually, if I have a negative score, it will push the target up toward zero, instead of down into an easier regime.

The intended code is likely closer to `max_score - 0.1 * (max_score - min_score)` 