### PR TITLE
fix constellation compilation error

### DIFF
--- a/constellation/constellation.c
+++ b/constellation/constellation.c
@@ -57,9 +57,9 @@ void CustomUpdateCamera(Camera *camera, float orbitSpeed) {
 #define LOG 1
 #define LOGIT 2
 
-const Color PUFF_CYAN = (Color){0, 187, 187, 255};
-const Color PUFF_WHITE = (Color){241, 241, 241, 241};
-const Color PUFF_BACKGROUND = (Color){6, 24, 24, 255};
+#define PUFF_CYAN ((Color){0, 187, 187, 255})
+#define PUFF_WHITE ((Color){241, 241, 241, 255})
+#define PUFF_BACKGROUND ((Color){6, 24, 24, 255})
 
 int hyper_count = 25;
 char *hyper_key[25] = {
@@ -279,7 +279,7 @@ void draw_ticks(char x_ticks[][32], int x_n, char y_ticks[][32], int y_n, PlotAr
 
     float plot_width = width - args.left_margin - args.right_margin;
     float plot_height = height - args.top_margin - args.bottom_margin;
- 
+
     for (int i=0; i<x_n; i++) {
         char* label = x_ticks[i];
         float x_pos = args.left_margin + i*plot_width/(x_n - 1.0f);
@@ -372,7 +372,7 @@ void boxplot(Hyper* hyper, int x_scale, int i, int hyper_count, PlotArgs args, C
 
     float x_min = scale_val(x_scale, args.mmin[0]);
     float x_max = scale_val(x_scale, args.mmax[0]);
- 
+
     float dy = plot_height/((float)hyper_count);
 
     float* ary = hyper->ary;
@@ -450,7 +450,7 @@ void GuiDropdownFilter(int x, int y, char* options, int *selection, bool *dropdo
         *text2_val = atof(text2);
     }
 }
- 
+
 void apply_filter(bool* filter, Hyper* param, float min, float max) {
     for (int i=0; i<param->n; i++) {
         float val = param->ary[i];
@@ -630,7 +630,7 @@ float fast_atof(char **s) {
   *s = p;
   return sign * val;
 }
- 
+
 int main(void) {
     FILE *file = fopen("resources/constellation/experiments.json", "r");
     if (!file) {
@@ -905,7 +905,7 @@ int main(void) {
             apply_filter(filter, filter_param_1, fig_range1_min_val, fig_range1_max_val);
             Hyper* filter_param_2 = get_hyper(&data, env, hyper_key[fig_range2_idx]);
             apply_filter(filter, filter_param_2, fig_range2_min_val, fig_range2_max_val);
- 
+
             for (int j=0; j<x->n; j++) {
                 if (!filter[j]) {
                     continue;
@@ -968,7 +968,7 @@ int main(void) {
             apply_filter(filter, filter_param_1, fig_range1_min_val, fig_range1_max_val);
             Hyper* filter_param_2 = get_hyper(&data, env, hyper_key[fig_range2_idx]);
             apply_filter(filter, filter_param_2, fig_range2_min_val, fig_range2_max_val);
- 
+
             for (int j=0; j<x->n; j++) {
                 if (!filter[j]) {
                     continue;
@@ -1238,9 +1238,9 @@ int main(void) {
     UnloadRenderTexture(fig1);
     UnloadRenderTexture(fig1_overlay);
     UnloadRenderTexture(fig2);
-    UnloadRenderTexture(fig3);                                                                                                   
+    UnloadRenderTexture(fig3);
     UnloadRenderTexture(fig3_overlay);
-    UnloadRenderTexture(fig4);                                                                                                   
-    CloseWindow();  
+    UnloadRenderTexture(fig4);
+    CloseWindow();
     return 0;
 }


### PR DESCRIPTION
Currently I have a bug when I try to compile constellation on clang v14.0.6.

The following is the error I get

```sh
(.venv) ⎇ improve_boids_4.0* ~/src/PufferLib=> ./build.sh constellation --local
Compiling constellation...
warning: unknown warning option '-Werror=array-parameter'; did you mean '-Werror=unused-parameter'? [-Wunknown-warning-option]
constellation/constellation.c:185:19: error: initializer element is not a compile-time constant
    .font_color = PUFF_WHITE,
                  ^~~~~~~~~~
1 warning and 1 error generated.
warning: unknown warning option '-Werror=array-parameter'; did you mean '-Werror=unused-parameter'? [-Wunknown-warning-option]
1 warning generated.
```

I fixed it by just "# defining" the colors


# Extra

Sorry for the redundant white space deletions... My editor did that.