### PR TITLE
make training and sweeps work on amd gpu hip/rocm

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,10 +10,12 @@ set -e
 #   ./build.sh breakout --fast       # Standalone executable (optimized)
 #   ./build.sh breakout --web        # Emscripten web build
 #   ./build.sh breakout --profile    # Kernel profiling binary
+#   ./build.sh breakout --rocm       # HIP/ROCm training backend
+#   ./build.sh breakout --cuda       # CUDA training backend
 #   ./build.sh all                   # Build all envs with default and --float
 
 if [ -z "$1" ]; then
-    echo "Usage: ./build.sh ENV_NAME [--float] [--debug] [--local|--fast|--web|--profile|--cpu|--all]"
+    echo "Usage: ./build.sh ENV_NAME [--float] [--debug] [--cuda|--rocm] [--local|--fast|--web|--profile|--cpu|--all]"
     exit 1
 fi
 ENV=$1
@@ -28,6 +30,8 @@ for arg in "$@"; do
         --web)   MODE=web ;;
         --profile) MODE=profile ;;
         --cpu)   MODE=cpu; PRECISION="-DPRECISION_FLOAT" ;;
+        --cuda)  BACKEND=cuda ;;
+        --rocm)  BACKEND=rocm ;;
         *) echo "Error: unknown argument '$arg'" && exit 1 ;;
     esac
 done
@@ -168,57 +172,9 @@ elif [ "$MODE" = "web" ]; then
     exit 0
 fi
 
-# Find cuDNN path
-CUDA_HOME=${CUDA_HOME:-${CUDA_PATH:-$(dirname "$(dirname "$(which nvcc)")")}}
-CUDNN_IFLAG=""
-CUDNN_LFLAG=""
-for dir in /usr/local/cuda/include /usr/include; do
-    if [ -f "$dir/cudnn.h" ]; then
-        CUDNN_IFLAG="-I$dir"
-        break
-    fi
-done
-for dir in /usr/local/cuda/lib64 /usr/lib/x86_64-linux-gnu; do
-    if [ -f "$dir/libcudnn.so" ]; then
-        CUDNN_LFLAG="-L$dir"
-        break
-    fi
-done
-if [ -z "$CUDNN_IFLAG" ]; then
-    CUDNN_IFLAG=$(python -c "import nvidia.cudnn, os; print('-I' + os.path.join(nvidia.cudnn.__path__[0], 'include'))" 2>/dev/null || echo "")
-fi
-if [ -z "$CUDNN_LFLAG" ]; then
-    CUDNN_LFLAG=$(python -c "import nvidia.cudnn, os; print('-L' + os.path.join(nvidia.cudnn.__path__[0], 'lib'))" 2>/dev/null || echo "")
-fi
-
-# NCCL include/lib fallback (mirrors the cuDNN fallback above).
-# Needed when NCCL is provided by the nvidia-nccl-cu12 wheel in the active venv.
-NCCL_IFLAG=""
-NCCL_LFLAG=""
-for dir in /usr/include /usr/local/cuda/include; do
-    if [ -f "$dir/nccl.h" ]; then NCCL_IFLAG="-I$dir"; break; fi
-done
-for dir in /usr/lib/x86_64-linux-gnu /usr/local/cuda/lib64; do
-    if [ -f "$dir/libnccl.so" ] || [ -f "$dir/libnccl.so.2" ]; then NCCL_LFLAG="-L$dir"; break; fi
-done
-if [ -z "$NCCL_IFLAG" ]; then
-    NCCL_IFLAG=$(python -c "import nvidia.nccl, os; print('-I' + os.path.join(nvidia.nccl.__path__[0], 'include'))" 2>/dev/null || echo "")
-fi
-if [ -z "$NCCL_LFLAG" ]; then
-    NCCL_LFLAG=$(python -c "import nvidia.nccl, os; print('-L' + os.path.join(nvidia.nccl.__path__[0], 'lib'))" 2>/dev/null || echo "")
-fi
-
-WHEEL_RPATH_FLAGS=()
-for lib_flag in "$CUDNN_LFLAG" "$NCCL_LFLAG"; do
-    if [[ "$lib_flag" == -L* ]]; then
-        WHEEL_RPATH_FLAGS+=("-Wl,-rpath,${lib_flag#-L}")
-    fi
-done
-
 export CCACHE_DIR="${CCACHE_DIR:-$HOME/.ccache}"
 export CCACHE_BASEDIR="$(pwd)"
 export CCACHE_COMPILERCHECK=content
-NVCC="ccache $CUDA_HOME/bin/nvcc"
 CC="${CC:-$(command -v ccache >/dev/null && echo 'ccache clang' || echo 'clang')}"
 ARCH=${NVCC_ARCH:-native}
 
@@ -238,10 +194,42 @@ if [ ! -f "$BINDING_SRC" ]; then
     exit 1
 fi
 
+if [ -z "$MODE" ]; then
+    if [ -z "$BACKEND" ]; then
+        if python -c "from torch.utils.cpp_extension import IS_HIP_EXTENSION; raise SystemExit(0 if IS_HIP_EXTENSION else 1)" 2>/dev/null && ! command -v nvcc >/dev/null 2>&1; then
+            BACKEND=rocm
+        else
+            BACKEND=cuda
+        fi
+    fi
+elif [ -n "$BACKEND" ]; then
+    echo "Error: --cuda/--rocm only apply to the training backend"
+    exit 1
+fi
+
+if [ "$BACKEND" = "rocm" ] && [ "$ENV" = "nmmo3" ]; then
+    echo "Error: NMMO3 native encoder is CUDA-only in build.sh --rocm"
+    exit 1
+fi
+
+CUDA_HOME=${CUDA_HOME:-${CUDA_PATH:-}}
+CUDA_IFLAG=""
+if [ "$BACKEND" = "cuda" ] || [ "$MODE" = "profile" ]; then
+    if [ -z "$CUDA_HOME" ]; then
+        if command -v nvcc >/dev/null 2>&1; then
+            CUDA_HOME=$(dirname "$(dirname "$(command -v nvcc)")")
+        else
+            echo "Error: nvcc not found. Use --rocm for HIP/ROCm or --cpu for CPU fallback."
+            exit 1
+        fi
+    fi
+    CUDA_IFLAG="-I$CUDA_HOME/include"
+fi
+
 echo "Compiling static library for $ENV..."
 ${CC:-clang} -c "${CLANG_OPT[@]}" $EXTRA_CFLAGS \
     -I. -Isrc -I$SRC_DIR -Ivendor \
-    -I./$RAYLIB_NAME/include -I$CUDA_HOME/include \
+    -I./$RAYLIB_NAME/include $CUDA_IFLAG \
     -DPLATFORM_DESKTOP \
     -fno-semantic-interposition -fvisibility=hidden \
     -fPIC -fopenmp \
@@ -255,7 +243,59 @@ if [ -z "$OBS_TENSOR_T" ]; then
     exit 1
 fi
 
-if [ -z "$MODE" ]; then
+if [ -z "$MODE" ] && [ "$BACKEND" = "cuda" ]; then
+    # Find cuDNN path
+    CUDNN_IFLAG=""
+    CUDNN_LFLAG=""
+    for dir in /usr/local/cuda/include /usr/include; do
+        if [ -f "$dir/cudnn.h" ]; then
+            CUDNN_IFLAG="-I$dir"
+            break
+        fi
+    done
+    for dir in /usr/local/cuda/lib64 /usr/lib/x86_64-linux-gnu; do
+        if [ -f "$dir/libcudnn.so" ]; then
+            CUDNN_LFLAG="-L$dir"
+            break
+        fi
+    done
+    if [ -z "$CUDNN_IFLAG" ]; then
+        CUDNN_IFLAG=$(python -c "import nvidia.cudnn, os; print('-I' + os.path.join(nvidia.cudnn.__path__[0], 'include'))" 2>/dev/null || echo "")
+    fi
+    if [ -z "$CUDNN_LFLAG" ]; then
+        CUDNN_LFLAG=$(python -c "import nvidia.cudnn, os; print('-L' + os.path.join(nvidia.cudnn.__path__[0], 'lib'))" 2>/dev/null || echo "")
+    fi
+
+    # NCCL include/lib fallback (mirrors the cuDNN fallback above).
+    # Needed when NCCL is provided by the nvidia-nccl-cu12 wheel in the active venv.
+    NCCL_IFLAG=""
+    NCCL_LFLAG=""
+    for dir in /usr/include /usr/local/cuda/include; do
+        if [ -f "$dir/nccl.h" ]; then NCCL_IFLAG="-I$dir"; break; fi
+    done
+    for dir in /usr/lib/x86_64-linux-gnu /usr/local/cuda/lib64; do
+        if [ -f "$dir/libnccl.so" ] || [ -f "$dir/libnccl.so.2" ]; then NCCL_LFLAG="-L$dir"; break; fi
+    done
+    if [ -z "$NCCL_IFLAG" ]; then
+        NCCL_IFLAG=$(python -c "import nvidia.nccl, os; print('-I' + os.path.join(nvidia.nccl.__path__[0], 'include'))" 2>/dev/null || echo "")
+    fi
+    if [ -z "$NCCL_LFLAG" ]; then
+        NCCL_LFLAG=$(python -c "import nvidia.nccl, os; print('-L' + os.path.join(nvidia.nccl.__path__[0], 'lib'))" 2>/dev/null || echo "")
+    fi
+
+    WHEEL_RPATH_FLAGS=()
+    for lib_flag in "$CUDNN_LFLAG" "$NCCL_LFLAG"; do
+        if [[ "$lib_flag" == -L* ]]; then
+            WHEEL_RPATH_FLAGS+=("-Wl,-rpath,${lib_flag#-L}")
+        fi
+    done
+
+    if command -v ccache >/dev/null 2>&1; then
+        NVCC="ccache $CUDA_HOME/bin/nvcc"
+    else
+        NVCC="$CUDA_HOME/bin/nvcc"
+    fi
+
     echo "Compiling CUDA ($ARCH) training backend..."
     $NVCC -c -arch=$ARCH -Xcompiler -fPIC \
         -Xcompiler=-D_GLIBCXX_USE_CXX11_ABI=1 \
@@ -278,6 +318,142 @@ if [ -z "$MODE" ]; then
         "${WHEEL_RPATH_FLAGS[@]}"
         -lcudart -lnccl -lnvidia-ml -lcublas -lcusolver -lcurand -lcudnn
         $OMP_LIB $LINK_OPT
+        "${SHARED_LDFLAGS[@]}"
+        -o "$OUTPUT"
+    )
+    "${LINK_CMD[@]}"
+    echo "Built: $OUTPUT"
+
+elif [ -z "$MODE" ] && [ "$BACKEND" = "rocm" ]; then
+    mapfile -t ROCM_INFO < <(python - <<'PY'
+import os
+from torch.utils.cpp_extension import ROCM_HOME, library_paths, include_paths
+
+rocm_home = os.environ.get("ROCM_HOME") or ROCM_HOME
+if not rocm_home:
+    raise SystemExit("ROCM_HOME not found. Install/use a ROCm-enabled PyTorch environment.")
+print(rocm_home)
+print(os.environ.get("HIPCC") or os.path.join(rocm_home, "bin", "hipcc"))
+print(os.pathsep.join(include_paths("cuda")))
+print(os.pathsep.join(library_paths("cuda")))
+PY
+)
+    ROCM_HOME=${ROCM_INFO[0]}
+    HIPCC=${ROCM_INFO[1]}
+    ROCM_INCLUDE_PATHS=${ROCM_INFO[2]}
+    ROCM_LIBRARY_PATHS=${ROCM_INFO[3]}
+
+    if [ ! -x "$HIPCC" ]; then
+        if command -v hipcc >/dev/null 2>&1; then
+            HIPCC=$(command -v hipcc)
+        else
+            echo "Error: hipcc not found"
+            exit 1
+        fi
+    fi
+
+    if [ -z "$HIP_CLANG_PATH" ] || [ ! -x "$HIP_CLANG_PATH/clang++" ]; then
+        for dir in "$ROCM_HOME/lib/llvm/bin" /usr/lib/llvm/*/bin; do
+            if [ -x "$dir/clang++" ]; then
+                export HIP_CLANG_PATH="$dir"
+                break
+            fi
+        done
+    fi
+
+    HIPIFY_SRC="build/hip/src"
+    HIPIFY_SRC_ABS="$(pwd)/$HIPIFY_SRC"
+    SRC_ABS="$(pwd)/src"
+    echo "Hipifying CUDA sources into $HIPIFY_SRC..."
+    rm -rf "$HIPIFY_SRC"
+    python - <<PY
+from torch.utils.hipify import hipify_python
+hipify_python.hipify(
+    project_directory="$SRC_ABS",
+    output_directory="$HIPIFY_SRC_ABS",
+    includes=["*"],
+    show_progress=False,
+    show_detailed=False,
+    is_pytorch_extension=True,
+)
+PY
+
+    ROCM_IFLAGS=()
+    IFS=':' read -ra ROCM_INC_ARR <<< "$ROCM_INCLUDE_PATHS"
+    for dir in "${ROCM_INC_ARR[@]}"; do
+        [ -n "$dir" ] && ROCM_IFLAGS+=("-I$dir")
+    done
+    ROCM_LFLAGS=()
+    ROCM_RPATH_FLAGS=()
+    if [ -d /usr/lib64 ]; then
+        ROCM_LFLAGS+=("-L/usr/lib64")
+        ROCM_RPATH_FLAGS+=("-Wl,-rpath,/usr/lib64")
+    fi
+    IFS=':' read -ra ROCM_LIB_ARR <<< "$ROCM_LIBRARY_PATHS"
+    for dir in "${ROCM_LIB_ARR[@]}"; do
+        [ -n "$dir" ] || continue
+        [ "$dir" = "/usr/lib" ] && [ -d /usr/lib64 ] && continue
+        ROCM_LFLAGS+=("-L$dir")
+        ROCM_RPATH_FLAGS+=("-Wl,-rpath,$dir")
+    done
+    ROCM_OMP_LIB=""
+    for dir in /usr/lib64 /usr/lib /usr/local/lib; do
+        if [ -f "$dir/libomp.so" ]; then
+            ROCM_LFLAGS+=("-L$dir")
+            ROCM_RPATH_FLAGS+=("-Wl,-rpath,$dir")
+            ROCM_OMP_LIB="-lomp"
+            break
+        elif [ -f "$dir/libomp5.so" ]; then
+            ROCM_LFLAGS+=("-L$dir")
+            ROCM_RPATH_FLAGS+=("-Wl,-rpath,$dir")
+            ROCM_OMP_LIB="-lomp5"
+            break
+        fi
+    done
+
+    ROCM_ARCH_FLAGS=()
+    if [ -n "$PYTORCH_ROCM_ARCH" ]; then
+        IFS=';' read -ra ROCM_ARCH_ARR <<< "$PYTORCH_ROCM_ARCH"
+        for arch in "${ROCM_ARCH_ARR[@]}"; do
+            [ -n "$arch" ] && ROCM_ARCH_FLAGS+=("--offload-arch=$arch")
+        done
+    fi
+
+    HIPCC_OPT=()
+    if [ -n "$DEBUG" ]; then
+        HIPCC_OPT=(-O0 -g)
+    else
+        HIPCC_OPT=(-O2)
+    fi
+
+    echo "Compiling ROCm/HIP training backend..."
+    "$HIPCC" "${ROCM_ARCH_FLAGS[@]}" -c -fPIC \
+        -D_GLIBCXX_USE_CXX11_ABI=1 \
+        -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION \
+        -DPLATFORM_DESKTOP \
+        -DUSE_ROCM \
+        -std=c++17 \
+        -I. -I"$HIPIFY_SRC" -I$SRC_DIR -Ivendor -I$RAYLIB_NAME/include \
+        -I$PYTHON_INCLUDE -I$PYBIND_INCLUDE -I$NUMPY_INCLUDE \
+        "${ROCM_IFLAGS[@]}" \
+        -fopenmp \
+        -DOBS_TENSOR_T=$OBS_TENSOR_T \
+        -DENV_NAME=$ENV \
+        $PRECISION "${HIPCC_OPT[@]}" \
+        "$HIPIFY_SRC/bindings.hip" -o build/bindings.o
+
+    "$HIPCC" -c -fPIC -std=c++17 \
+        "${ROCM_IFLAGS[@]}" \
+        src/rocm_cuda_shim.cpp -o build/rocm_cuda_shim.o
+
+    LINK_CMD=(
+        ${CXX:-g++} -shared -fPIC -fopenmp
+        build/bindings.o build/rocm_cuda_shim.o "$STATIC_LIB" "$RAYLIB_A"
+        "${ROCM_LFLAGS[@]}"
+        "${ROCM_RPATH_FLAGS[@]}"
+        -lamdhip64 -lhipblas -lhiprand -lrccl -lrocm_smi64
+        $ROCM_OMP_LIB
+        $LINK_OPT
         "${SHARED_LDFLAGS[@]}"
         -o "$OUTPUT"
     )

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -187,10 +187,49 @@ def _train_worker(args):
 
     backend.close(pufferl)
 
-def _train(env_name, args, sweep_obj=None, result_queue=None, verbose=False):
+def _downsample_logs(all_logs, n, exclude_keys=()):
+    if not all_logs:
+        raise ValueError('Cannot downsample empty logs')
+
+    expected_keys = set(all_logs[0])
+    exclude_keys = set(exclude_keys)
+    metrics = {k: [[]] for k in all_logs[0] if k not in exclude_keys}
+    logged_timesteps = all_logs[-1]['agent_steps']
+    next_bin = logged_timesteps / (n - 1) if n > 1 else np.inf
+    for idx, log in enumerate(all_logs):
+        keys = set(log)
+        missing = expected_keys - keys
+        unexpected = keys - expected_keys
+        if missing or unexpected:
+            raise KeyError(
+                f'Inconsistent log keys at index {idx}: '
+                f'missing={sorted(missing)}, unexpected={sorted(unexpected)}'
+            )
+
+        for k, v in log.items():
+            if k in metrics:
+                metrics[k][-1].append(v)
+
+        if log['agent_steps'] < next_bin:
+            continue
+
+        next_bin += logged_timesteps / (n - 1)
+        for k in metrics:
+            metrics[k][-1] = np.mean(metrics[k][-1])
+            metrics[k].append([])
+
+    for k in metrics:
+        metrics[k][-1] = all_logs[-1][k]
+
+    return metrics
+
+def _train(env_name, args, result_queue=None, verbose=False, sweep_early_stop=None):
     '''Single-GPU training worker. Process target for both DDP ranks and sweep trials.'''
     backend = _resolve_backend(args)
     rank = args['rank']
+    suppress_model_outputs = result_queue is not None or sweep_early_stop is not None
+    if sweep_early_stop is not None:
+        import pufferlib.sweep
     run_id = str(int(1000*time.time()))
     if args['wandb']:
         import wandb
@@ -207,7 +246,7 @@ def _train(env_name, args, sweep_obj=None, result_queue=None, verbose=False):
 
     # When sweeping, optionally score each trial by winrate vs a fixed enemy
     # checkpoint (match mode) instead of the training-time self-play metric.
-    match_mode = (sweep_obj is not None
+    match_mode = (result_queue is not None
         and bool(args.get('sweep', {}).get('match_enemy_model_path')))
 
     checkpoint_dir = os.path.join(args['checkpoint_dir'], args['env_name'], run_id)
@@ -254,7 +293,7 @@ def _train(env_name, args, sweep_obj=None, result_queue=None, verbose=False):
 
         # In match-sweep mode we need the final checkpoint to feed into match().
         is_final = epoch == train_epochs - 1
-        should_save = (sweep_obj is None
+        should_save = (not suppress_model_outputs
             and (epoch % args['checkpoint_interval'] == 0 or is_final)
         ) or (match_mode and is_final)
         if should_save:
@@ -267,6 +306,8 @@ def _train(env_name, args, sweep_obj=None, result_queue=None, verbose=False):
 
         logs = backend.eval_log(pufferl) if epoch >= train_epochs else backend.log(pufferl)
         flat_logs = {**flat_logs, **dict(unroll_nested_dict(logs))}
+        if sweep_early_stop is not None:
+            pufferlib.sweep.apply_early_stop_log_defaults(flat_logs)
 
         if epoch < train_epochs:
             selfplay.step(pufferl, backend, pool_state, flat_logs, epoch)
@@ -283,9 +324,9 @@ def _train(env_name, args, sweep_obj=None, result_queue=None, verbose=False):
         if epoch < train_epochs:
             all_logs.append(flat_logs)
 
-            if (sweep_obj is not None
-                    and pufferl.global_step > min(0.20*total_timesteps, 100_000_000) and
-                    sweep_obj.early_stop(logs, target_key)):
+            if (sweep_early_stop is not None
+                    and pufferl.global_step > min(0.20*total_timesteps, 100_000_000)
+                    and sweep_early_stop.early_stop(flat_logs, target_key)):
                 break
         elif flat_logs['env/n'] > args['eval_episodes']:
             break
@@ -326,25 +367,12 @@ def _train(env_name, args, sweep_obj=None, result_queue=None, verbose=False):
     # This version has the training perf logs and eval env logs
     all_logs.append(flat_logs)
 
-    # Downsample results
-    n = args['sweep']['downsample']
-    metrics = {k: [[]] for k in all_logs[0]}
-    logged_timesteps = all_logs[-1]['agent_steps']
-    next_bin = logged_timesteps / (n - 1) if n > 1 else np.inf
-    for log in all_logs:
-        for k, v in log.items():
-            metrics[k][-1].append(v)
+    exclude_keys = ()
+    if sweep_early_stop is not None:
+        exclude_keys = pufferlib.sweep.SWEEP_NON_METRIC_LOG_KEYS
 
-        if log['agent_steps'] < next_bin:
-            continue
-
-        next_bin += logged_timesteps / (n - 1)
-        for k in metrics:
-            metrics[k][-1] = np.mean(metrics[k][-1])
-            metrics[k].append([])
-
-    for k in metrics:
-        metrics[k][-1] = all_logs[-1][k]
+    metrics = _downsample_logs(
+        all_logs, args['sweep']['downsample'], exclude_keys=exclude_keys)
 
     # Match-mode: single observation at final-training cost. Protein's curve
     # fit collapses to one point — we only trust the match winrate, not any
@@ -361,7 +389,7 @@ def _train(env_name, args, sweep_obj=None, result_queue=None, verbose=False):
         json.dump({**args, 'metrics': metrics}, f)
 
     if args['wandb']:
-        if sweep_obj is None and model_path: # Don't spam uploads during sweeps
+        if not suppress_model_outputs and model_path: # Don't spam uploads during sweeps
             artifact = wandb.Artifact(run_id, type='model')
             artifact.add_file(model_path)
             wandb.run.log_artifact(artifact)
@@ -379,6 +407,9 @@ def _train(env_name, args, sweep_obj=None, result_queue=None, verbose=False):
 def train(env_name, args=None, gpus=None, **kwargs):
     args = args or load_config(env_name)
     validate_config(args)
+    sweep_obj = kwargs.pop('sweep_obj', None)
+    if sweep_obj is not None and 'sweep_early_stop' not in kwargs:
+        kwargs['sweep_early_stop'] = sweep_obj.early_stop_state()
 
     subprocess = gpus is not None
     gpus = list(gpus or range(args['train']['gpus']))
@@ -395,7 +426,7 @@ def train(env_name, args=None, gpus=None, **kwargs):
         worker_args['rank'] = rank
         worker_args['gpu_id'] = gpu_id
         if rank == 0 and not subprocess:
-            _train(env_name, worker_args, verbose=True)
+            _train(env_name, worker_args, verbose=True, **kwargs)
         else:
             # Protein's GP models live on cuda:0 on non-WSL setups; spawn-pickling
             # them works fine via CUDA IPC. On WSL, sweep.py forces device='cpu'
@@ -407,7 +438,7 @@ def sweep(env_name, args=None, pareto=False):
     '''Train entry point. Handles single-GPU, multi-GPU DDP, and sweeps.'''
     args = args or load_config(env_name)
     exp_gpus = args['train']['gpus']
-    sweep_gpus = args['sweep']['gpus'] or len(os.listdir('/proc/driver/nvidia/gpus'))
+    sweep_gpus = args['sweep']['gpus'] or torch.cuda.device_count()
     args['vec']['num_threads'] //= (sweep_gpus // exp_gpus)
     args['no_model_upload'] = True
 
@@ -430,12 +461,15 @@ def sweep(env_name, args=None, pareto=False):
     active = {}
     completed = 0
     while completed < num_experiments:
-        if len(active) >= sweep_gpus//exp_gpus: # Collect completed runs
+        max_active = sweep_gpus // exp_gpus
+        if active and (len(active) >= max_active or completed + len(active) >= num_experiments):
             gpu_id, scores, costs, timesteps = result_queue.get()
             done_args = active.pop(gpu_id)
 
             if not scores:
                 sweep_obj.observe(done_args, 0, 0, is_failure=True)
+                completed += 1
+                continue
             else:
                 completed += 1
 
@@ -463,7 +497,7 @@ def sweep(env_name, args=None, pareto=False):
         exp_args = deepcopy(args)
         active[gpu_id] = exp_args
         train(env_name, exp_args, range(gpu_id, gpu_id + exp_gpus),
-            sweep_obj=sweep_obj, result_queue=result_queue)
+            result_queue=result_queue, sweep_early_stop=sweep_obj.early_stop_state())
 
 def eval(env_name, args=None, load_path=None):
     '''Evaluate a trained policy. Supports both native and --slowly torch backends.'''

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -22,6 +22,72 @@ from scipy.spatial import KDTree
 from sklearn.linear_model import LogisticRegression
 
 EPSILON = 1e-6
+LOGIT_MIN = -5.0
+LOGIT_MAX = 100.0
+EARLY_STOP_THRESHOLD_FLOOR = LOGIT_MIN
+SWEEP_EARLY_STOP_LOG_DEFAULTS = {
+    'is_loss_nan': False,
+    'early_stop_threshold': EARLY_STOP_THRESHOLD_FLOOR,
+}
+SWEEP_NON_METRIC_LOG_KEYS = frozenset(('is_loss_nan',))
+
+def apply_early_stop_log_defaults(logs):
+    logs.update(SWEEP_EARLY_STOP_LOG_DEFAULTS)
+
+def _has_nan_loss(logs):
+    return any(
+        k.startswith('loss/') and np.issubdtype(type(v), np.number) and np.isnan(v)
+        for k, v in logs.items()
+    )
+
+def logit_transform(value, epsilon=1e-9):
+    value = np.clip(value, epsilon, 1 - epsilon)
+    return np.clip(np.log(value / (1 - value)), LOGIT_MIN, LOGIT_MAX)
+
+class NanLossEarlyStop:
+    def early_stop(self, logs, target_key):
+        if _has_nan_loss(logs):
+            logs['is_loss_nan'] = True
+            return True
+        return False
+
+class ProteinEarlyStop:
+    def __init__(self, metric_distribution, model_state):
+        self.metric_distribution = metric_distribution
+        self.model_state = model_state
+        self.running_targets = deque(maxlen=30)
+
+    def get_threshold(self, cost):
+        if not self.model_state['is_fitted'] or self.model_state['upper_cost_threshold'] is None:
+            return -np.inf
+
+        upper_cost = self.model_state['upper_cost_threshold']
+        min_allowed_cost = upper_cost * 0.3 + 10
+        if cost < min_allowed_cost:
+            return -np.inf
+
+        if cost > 1.2 * upper_cost:
+            return 0.9 * self.model_state['max_score']
+
+        return self.model_state['A'] + self.model_state['B'] * np.log(cost)
+
+    def early_stop(self, logs, target_key):
+        if _has_nan_loss(logs):
+            logs['is_loss_nan'] = True
+            return True
+
+        if 'uptime' not in logs or target_key not in logs:
+            return False
+
+        metric_val, cost = logs[target_key], logs['uptime']
+        self.running_targets.append(metric_val)
+        score = max(np.mean(self.running_targets), metric_val)
+        if self.metric_distribution == 'percentile':
+            score = logit_transform(score)
+
+        threshold = self.get_threshold(cost)
+        logs['early_stop_threshold'] = max(threshold, EARLY_STOP_THRESHOLD_FLOOR)
+        return score < threshold
 
 def unroll_nested_dict(d):
     if not isinstance(d, dict):
@@ -333,10 +399,10 @@ class Random:
         ))
 
     def early_stop(self, logs, target_key):
-        if any("loss/" in k and np.isnan(v) for k, v in logs.items()):
-            logs['is_loss_nan'] = True
-            return True
-        return False
+        return NanLossEarlyStop().early_stop(logs, target_key)
+
+    def early_stop_state(self):
+        return NanLossEarlyStop()
 
 
 class ParetoGenetic:
@@ -390,10 +456,10 @@ class ParetoGenetic:
         ))
 
     def early_stop(self, logs, target_key):
-        if any("loss/" in k and np.isnan(v) for k, v in logs.items()):
-            logs['is_loss_nan'] = True
-            return True
-        return False
+        return NanLossEarlyStop().early_stop(logs, target_key)
+
+    def early_stop_state(self):
+        return NanLossEarlyStop()
 
 
 class ExactGPModel(ExactGP):
@@ -900,9 +966,7 @@ class Protein:
         return self.hyperparameters.to_dict(best, fill), info
 
     def logit_transform(self, value, epsilon=1e-9):
-        value = np.clip(value, epsilon, 1 - epsilon)
-        logit = math.log(value / (1 - value))
-        return np.clip(logit, -5, 100)
+        return logit_transform(value, epsilon)
 
     def observe(self, hypers, score, cost, is_failure=False):
         params = self.hyperparameters.from_dict(hypers)
@@ -957,20 +1021,29 @@ class Protein:
         return score < threshold
 
     def early_stop(self, logs, target_key):
-        for k, v in logs['loss'].items():
-            if np.isnan(v):
-                logs['is_loss_nan'] = True
-                return True
+        if _has_nan_loss(logs):
+            logs['is_loss_nan'] = True
+            return True
 
         if 'uptime' not in logs or target_key not in logs:
             return False
 
-        metric_val, cost = logs['env'][target_key], logs['uptime']
+        metric_val, cost = logs[target_key], logs['uptime']
         self._running_target_buffer.append(metric_val)
         target_running_mean = np.mean(self._running_target_buffer)
         threshold = self.get_early_stop_threshold(cost)
-        logs['early_stop_threshold'] = max(threshold, -5)
-        if self.should_stop(max(target_running_mean, metric_val), cost):
-            logs['is_loss_nan'] = False
-            return True
-        return False
+        logs['early_stop_threshold'] = max(threshold, EARLY_STOP_THRESHOLD_FLOOR)
+        return self.should_stop(max(target_running_mean, metric_val), cost)
+
+    def early_stop_state(self):
+        model = self.stop_threshold_model
+        return ProteinEarlyStop(
+            self.metric_distribution,
+            dict(
+                is_fitted=model.is_fitted,
+                upper_cost_threshold=model.upper_cost_threshold,
+                max_score=model.max_score,
+                A=model.A,
+                B=model.B,
+            ),
+        )

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -212,7 +212,9 @@ def _params_from_puffer_sweep(sweep_config, only_include=None):
 
     for name, param in sweep_config.items():
         if name in ('method', 'metric', 'metric_distribution', 'goal', 'downsample', 'use_gpu', 'prune_pareto',
-                    'sweep_only', 'max_suggestion_cost', 'early_stop_quantile', 'gpus', 'max_runs'):
+                    'sweep_only', 'max_suggestion_cost', 'early_stop_quantile', 'gpus', 'max_runs',
+                    'match_enemy_model_path', 'match_num_games', 'match_enemy_hidden_size',
+                    'match_enemy_num_layers'):
             continue
 
         assert isinstance(param, dict), f'Param {name} is not a dict'

--- a/src/bindings.cu
+++ b/src/bindings.cu
@@ -70,18 +70,11 @@ pybind11::dict puf_log(pybind11::object pufferl_obj) {
 
     // Utilization
     pybind11::dict util_dict;
-    nvmlUtilization_t util;
-    nvmlDeviceGetUtilizationRates(pufferl.nvml_device, &util);
-    util_dict["gpu_percent"] = (float)util.gpu;
-
-    nvmlMemory_t mem;
-    nvmlDeviceGetMemoryInfo(pufferl.nvml_device, &mem);
-    util_dict["gpu_mem"] = 100.0f * (float)mem.used / (float)mem.total;
-
-    size_t cuda_free, cuda_total;
-    cudaMemGetInfo(&cuda_free, &cuda_total);
-    util_dict["vram_used_gb"] = (float)(cuda_total - cuda_free) / (1024.0f * 1024.0f * 1024.0f);
-    util_dict["vram_total_gb"] = (float)cuda_total / (1024.0f * 1024.0f * 1024.0f);
+    GpuUtil util = gpu_get_utilization(pufferl.gpu_device);
+    util_dict["gpu_percent"] = util.gpu_percent;
+    util_dict["gpu_mem"] = util.gpu_mem;
+    util_dict["vram_used_gb"] = util.vram_used_gb;
+    util_dict["vram_total_gb"] = util.vram_total_gb;
 
     long rss_kb = 0;
     FILE* f = fopen("/proc/self/status", "r");
@@ -472,25 +465,15 @@ PYBIND11_MODULE(_C, m) {
     });
     // Standalone utilization monitor (no PuffeRL instance needed)
     m.def("get_utilization", [](int gpu_id) {
-        static bool nvml_inited = false;
-        if (!nvml_inited) { nvmlInit(); nvml_inited = true; }
-
         py::dict util_dict;
-        nvmlDevice_t device;
-        nvmlDeviceGetHandleByIndex(gpu_id, &device);
-
-        nvmlUtilization_t util;
-        nvmlDeviceGetUtilizationRates(device, &util);
-        util_dict["gpu_percent"] = (float)util.gpu;
-
-        nvmlMemory_t mem;
-        nvmlDeviceGetMemoryInfo(device, &mem);
-        util_dict["gpu_mem"] = 100.0f * (float)mem.used / (float)mem.total;
-
-        size_t cuda_free, cuda_total;
-        cudaMemGetInfo(&cuda_free, &cuda_total);
-        util_dict["vram_used_gb"] = (float)(cuda_total - cuda_free) / (1024.0f * 1024.0f * 1024.0f);
-        util_dict["vram_total_gb"] = (float)cuda_total / (1024.0f * 1024.0f * 1024.0f);
+        PufferGpuDevice device;
+        gpu_monitor_init(gpu_id, &device);
+        GpuUtil util = gpu_get_utilization(device);
+        gpu_monitor_shutdown();
+        util_dict["gpu_percent"] = util.gpu_percent;
+        util_dict["gpu_mem"] = util.gpu_mem;
+        util_dict["vram_used_gb"] = util.vram_used_gb;
+        util_dict["vram_total_gb"] = util.vram_total_gb;
 
         long rss_kb = 0;
         FILE* f = fopen("/proc/self/status", "r");

--- a/src/ocean.cu
+++ b/src/ocean.cu
@@ -1,6 +1,10 @@
 // NMMO3 CUDA encoder: multihot, cuDNN conv, embedding, concat, projection
 // Included by pufferlib.cu — requires precision_t, PrecisionTensor, Allocator, puf_mm, etc.
 
+#ifdef USE_ROCM
+static void create_custom_encoder(const std::string&, Encoder*) {}
+#else
+
 #include "cudnn_conv2d.cu"
 
 // ---- NMMO3 constants ----
@@ -588,3 +592,5 @@ static void create_custom_encoder(const std::string& env_name, Encoder* enc) {
         };
     }
 }
+
+#endif

--- a/src/pufferlib.cu
+++ b/src/pufferlib.cu
@@ -1,7 +1,11 @@
 #include <cuda_runtime.h>
+#ifndef USE_ROCM
 #include <cuda_profiler_api.h>
 #include <nvtx3/nvToolsExt.h>
 #include <nvml.h>
+#else
+#include <rocm_smi/rocm_smi.h>
+#endif
 #include <nccl.h>
 #include <vector>
 
@@ -45,6 +49,110 @@ typedef struct {
     cudaEvent_t events[NUM_TRAIN_EVENTS];
     float accum[NUM_PROF];
 } ProfileT;
+
+struct GpuUtil {
+    float gpu_percent;
+    float gpu_mem;
+    float vram_used_gb;
+    float vram_total_gb;
+};
+
+#ifndef USE_ROCM
+using PufferGpuDevice = nvmlDevice_t;
+
+inline void gpu_monitor_init(int gpu_id, PufferGpuDevice* device) {
+    nvmlInit();
+    nvmlDeviceGetHandleByIndex(gpu_id, device);
+}
+
+inline void gpu_monitor_shutdown() {
+    nvmlShutdown();
+}
+
+inline GpuUtil gpu_get_utilization(PufferGpuDevice device) {
+    GpuUtil out = {};
+    nvmlUtilization_t util;
+    if (nvmlDeviceGetUtilizationRates(device, &util) == NVML_SUCCESS) {
+        out.gpu_percent = (float)util.gpu;
+    }
+
+    nvmlMemory_t mem;
+    if (nvmlDeviceGetMemoryInfo(device, &mem) == NVML_SUCCESS && mem.total > 0) {
+        out.gpu_mem = 100.0f * (float)mem.used / (float)mem.total;
+    }
+
+    size_t free_bytes = 0, total_bytes = 0;
+    cudaMemGetInfo(&free_bytes, &total_bytes);
+    if (total_bytes > 0) {
+        out.vram_used_gb = (float)(total_bytes - free_bytes) / (1024.0f * 1024.0f * 1024.0f);
+        out.vram_total_gb = (float)total_bytes / (1024.0f * 1024.0f * 1024.0f);
+    }
+    return out;
+}
+
+inline void profile_begin(const char* tag, bool enable) {
+    if (enable) nvtxRangePushA(tag);
+}
+
+inline void profile_end(bool enable) {
+    if (enable) nvtxRangePop();
+}
+
+inline void gpu_profiler_start(bool enable) {
+    if (enable) cudaProfilerStart();
+}
+
+inline void gpu_profiler_stop(bool enable) {
+    if (enable) cudaProfilerStop();
+}
+#else
+using PufferGpuDevice = uint32_t;
+
+inline void gpu_monitor_init(int gpu_id, PufferGpuDevice* device) {
+    *device = (uint32_t)gpu_id;
+    rsmi_init(RSMI_INIT_FLAG_ALL_GPUS);
+}
+
+inline void gpu_monitor_shutdown() {
+    rsmi_shut_down();
+}
+
+inline GpuUtil gpu_get_utilization(PufferGpuDevice device) {
+    GpuUtil out = {};
+    uint32_t busy = 0;
+    if (rsmi_dev_busy_percent_get(device, &busy) == RSMI_STATUS_SUCCESS) {
+        out.gpu_percent = (float)busy;
+    }
+
+    uint64_t used = 0, total = 0;
+    if (rsmi_dev_memory_usage_get(device, RSMI_MEM_TYPE_VRAM, &used) == RSMI_STATUS_SUCCESS &&
+            rsmi_dev_memory_total_get(device, RSMI_MEM_TYPE_VRAM, &total) == RSMI_STATUS_SUCCESS &&
+            total > 0) {
+        out.gpu_mem = 100.0f * (float)used / (float)total;
+    }
+
+    size_t free_bytes = 0, total_bytes = 0;
+    cudaMemGetInfo(&free_bytes, &total_bytes);
+    if (total_bytes > 0) {
+        out.vram_used_gb = (float)(total_bytes - free_bytes) / (1024.0f * 1024.0f * 1024.0f);
+        out.vram_total_gb = (float)total_bytes / (1024.0f * 1024.0f * 1024.0f);
+    }
+    return out;
+}
+
+inline void profile_begin(const char*, bool) {}
+inline void profile_end(bool) {}
+inline void gpu_profiler_start(bool) {}
+inline void gpu_profiler_stop(bool) {}
+#endif
+
+inline cudaError_t puf_graph_instantiate(cudaGraphExec_t* exec, cudaGraph_t graph) {
+#ifdef USE_ROCM
+    return cudaGraphInstantiate(exec, graph, nullptr, nullptr, 0);
+#else
+    return cudaGraphInstantiate(exec, graph, 0);
+#endif
+}
 
 // Data collected by parallel environment workers. Each worker handles
 // a constant subset of agents 
@@ -361,7 +469,7 @@ typedef struct {
     PrecisionTensor grad_puf;
     LongTensor rng_offset_puf;   // (num_buffers+1,) int64 CUDA device counters
     ProfileT profile;
-    nvmlDevice_t nvml_device;
+    PufferGpuDevice gpu_device;
     long epoch;
     long global_step;
     double start_time;
@@ -390,14 +498,6 @@ Dict* log_environments_impl(PuffeRL& pufferl) {
     Dict* out = create_dict(64);
     static_vec_log(pufferl.vec, out);
     return out;
-}
-
-inline void profile_begin(const char* tag, bool enable) {
-    if (enable) nvtxRangePushA(tag);
-}
-
-inline void profile_end(bool enable) {
-    if (enable) nvtxRangePop();
 }
 
 // Thread-local stream for per-buffer threads (set once by thread_init_wrapper)
@@ -691,7 +791,7 @@ extern "C" void net_callback_wrapper(void* ctx, int buf, int t) {
         cudaGraph_t _graph;
         assert(cudaStreamEndCapture(current_stream, &_graph) == cudaSuccess
                 && "cudaStreamEndCapture failed");
-        assert(cudaGraphInstantiate(&pufferl->fused_rollout_cudagraphs[graph], _graph, 0) == cudaSuccess
+        assert(puf_graph_instantiate(&pufferl->fused_rollout_cudagraphs[graph], _graph) == cudaSuccess
                 && "cudaGraphInstantiate failed");
         assert(cudaGraphDestroy(_graph) == cudaSuccess && "cudaGraphDestroy failed");
         cudaDeviceSynchronize();
@@ -1095,9 +1195,22 @@ void ppo_loss_fwd_bwd(
 }
 
 #define PRIO_WARP_SIZE 32
-#define PRIO_FULL_MASK 0xffffffff
+#ifdef USE_ROCM
+using PufWarpMask = unsigned long long;
+#else
+using PufWarpMask = unsigned int;
+#endif
 #define PRIO_BLOCK_SIZE 256
 #define PRIO_NUM_WARPS (PRIO_BLOCK_SIZE / PRIO_WARP_SIZE)
+
+__device__ __forceinline__ float prio_warp_sum(float val, int width = PRIO_WARP_SIZE) {
+    PufWarpMask mask = (PufWarpMask)__activemask();
+    for (int s = width / 2; s >= 1; s /= 2) {
+        val += __shfl_down_sync(mask, val, s, width);
+    }
+    return val;
+}
+
 __global__ void compute_prio_adv_reduction(
         const precision_t* __restrict__ advantages,
         float* prio_weights, float prio_alpha, int stride) {
@@ -1110,9 +1223,7 @@ __global__ void compute_prio_adv_reduction(
         local_sum += fabsf(to_float(advantages[offset + t]));
     }
 
-    for (int s = PRIO_WARP_SIZE / 2; s >= 1; s /= 2) {
-        local_sum += __shfl_down_sync(PRIO_FULL_MASK, local_sum, s);
-    }
+    local_sum = prio_warp_sum(local_sum);
     if (tx == 0) {
         float pw = __powf(local_sum, prio_alpha);
         if (isnan(pw) || isinf(pw)) {
@@ -1135,9 +1246,7 @@ __global__ void compute_prio_normalize(float* prio_weights, int length) {
     for (int t = tx; t < length; t += blockDim.x) {
         local_sum += prio_weights[t];
     }
-    for (int s = PRIO_WARP_SIZE / 2; s >= 1; s /= 2) {
-        local_sum += __shfl_down_sync(PRIO_FULL_MASK, local_sum, s);
-    }
+    local_sum = prio_warp_sum(local_sum);
     if (lane == 0) {
         shmem[warp_id] = local_sum;
     }
@@ -1145,9 +1254,7 @@ __global__ void compute_prio_normalize(float* prio_weights, int length) {
 
     if (warp_id == 0) {
         float val = (lane < PRIO_NUM_WARPS) ? shmem[lane] : 0.0f;
-        for (int s = PRIO_NUM_WARPS / 2; s >= 1; s /= 2) {
-            val += __shfl_down_sync(PRIO_FULL_MASK, val, s);
-        }
+        val = prio_warp_sum(val, PRIO_NUM_WARPS);
         if (tx == 0) {
             block_sum = val + eps;
         }
@@ -1627,7 +1734,7 @@ void train_impl(PuffeRL& pufferl) {
                 cudaGraph_t _graph;
                 assert(cudaStreamEndCapture(train_stream, &_graph) == cudaSuccess
                         && "cudaStreamEndCapture failed");
-                assert(cudaGraphInstantiate(&pufferl.train_cudagraph, _graph, 0) == cudaSuccess
+                assert(puf_graph_instantiate(&pufferl.train_cudagraph, _graph) == cudaSuccess
                         && "cudaGraphInstantiate failed");
                 assert(cudaGraphDestroy(_graph) == cudaSuccess && "cudaGraphDestroy failed");
                 cudaDeviceSynchronize();
@@ -1962,8 +2069,7 @@ std::unique_ptr<PuffeRL> create_pufferl_impl(HypersT& hypers,
         cudaEventCreate(&pufferl->profile.events[i]);
     }
     memset(pufferl->profile.accum, 0, sizeof(pufferl->profile.accum));
-    nvmlInit();
-    nvmlDeviceGetHandleByIndex(hypers.gpu_id, &pufferl->nvml_device);
+    gpu_monitor_init(hypers.gpu_id, &pufferl->gpu_device);
 
     // Create policy
     int input_size = pufferl->env.obs.shape[1];
@@ -2183,10 +2289,8 @@ std::unique_ptr<PuffeRL> create_pufferl_impl(HypersT& hypers,
         net_callback_wrapper, thread_init_wrapper);
     static_vec_reset(vec);
 
-    if (hypers.profile) {
-        cudaDeviceSynchronize();
-        cudaProfilerStart();
-    }
+    if (hypers.profile) cudaDeviceSynchronize();
+    gpu_profiler_start(hypers.profile);
 
     double now = wall_clock();
     pufferl->start_time = now;
@@ -2198,9 +2302,7 @@ std::unique_ptr<PuffeRL> create_pufferl_impl(HypersT& hypers,
 
 void close_impl(PuffeRL& pufferl) {
     cudaDeviceSynchronize();
-    if (pufferl.hypers.profile) {
-        cudaProfilerStop();
-    }
+    gpu_profiler_stop(pufferl.hypers.profile);
 
     cudaGraphExecDestroy(pufferl.train_cudagraph);
     for (int i = 0; i < pufferl.hypers.horizon * pufferl.hypers.num_buffers; i++) {
@@ -2232,7 +2334,7 @@ void close_impl(PuffeRL& pufferl) {
     for (int i = 0; i < NUM_TRAIN_EVENTS; i++) {
         cudaEventDestroy(pufferl.profile.events[i]);
     }
-    nvmlShutdown();
+    gpu_monitor_shutdown();
 
     static_vec_close(pufferl.vec);
 

--- a/src/rocm_cuda_shim.cpp
+++ b/src/rocm_cuda_shim.cpp
@@ -1,0 +1,57 @@
+#include <hip/hip_runtime.h>
+
+extern "C" {
+
+hipError_t cudaHostAlloc(void** ptr, size_t size, unsigned int flags) {
+    return hipHostMalloc(ptr, size, flags);
+}
+
+hipError_t cudaMalloc(void** ptr, size_t size) {
+    return hipMalloc(ptr, size);
+}
+
+hipError_t cudaMemcpy(void* dst, const void* src, size_t size, int kind) {
+    return hipMemcpy(dst, src, size, (hipMemcpyKind)kind);
+}
+
+hipError_t cudaMemcpyAsync(void* dst, const void* src, size_t size, int kind, hipStream_t stream) {
+    return hipMemcpyAsync(dst, src, size, (hipMemcpyKind)kind, stream);
+}
+
+hipError_t cudaMemset(void* dst, int value, size_t size) {
+    return hipMemset(dst, value, size);
+}
+
+hipError_t cudaFree(void* ptr) {
+    return hipFree(ptr);
+}
+
+hipError_t cudaFreeHost(void* ptr) {
+    return hipHostFree(ptr);
+}
+
+hipError_t cudaSetDevice(int device) {
+    return hipSetDevice(device);
+}
+
+hipError_t cudaDeviceSynchronize(void) {
+    return hipDeviceSynchronize();
+}
+
+hipError_t cudaStreamSynchronize(hipStream_t stream) {
+    return hipStreamSynchronize(stream);
+}
+
+hipError_t cudaStreamCreateWithFlags(hipStream_t* stream, unsigned int flags) {
+    return hipStreamCreateWithFlags(stream, flags);
+}
+
+hipError_t cudaStreamQuery(hipStream_t stream) {
+    return hipStreamQuery(stream);
+}
+
+const char* cudaGetErrorString(hipError_t error) {
+    return hipGetErrorString(error);
+}
+
+}


### PR DESCRIPTION
Allows training and sweeps to run on amd gpu [hip/rocm],
cuda specific code is hipified during build and is placed in build/hip/src.

There has been a problem with sweep_obj being passed between processes when protein sweep is on gpu [apparently special synchronization handling is implemented for cuda, but not rocm in torch], so this PR contains a change related to that.

Tested only breakout sweep / eval on amd gpu.

Mostly done through codex gpt-5.5.

@jsuarez5341 please let me know if you care to merge amd gpu support in a shape similar to this draft PR