### PR TITLE
Add NetHack environment (native C vecenv)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -98,6 +98,7 @@ RAYLIB_A="$RAYLIB_NAME/lib/libraylib.a"
 INCLUDES=(-I./$RAYLIB_NAME/include -I./src -I./vendor)
 LINK_ARCHIVES=("$RAYLIB_A")
 EXTRA_SRC=""
+EXTRA_LDFLAGS=()
 
 if [ "$ENV" = "constellation" ]; then
     SRC_DIR="constellation"
@@ -116,6 +117,21 @@ elif [ "$ENV" = "impulse_wars" ]; then
     download "$BOX2D_NAME" "$BOX2D_URL/$BOX2D_NAME.tar.gz"
     INCLUDES+=(-I./$BOX2D_NAME/include -I./$BOX2D_NAME/src)
     LINK_ARCHIVES+=("./$BOX2D_NAME/libbox2d.a")
+elif [ "$ENV" = "nethack" ]; then
+    SRC_DIR="ocean/$ENV"
+    NLE_DIR="vendor/nle"
+    NLE_REPO="https://github.com/liujonathan24/NetHack.git"
+    if [ ! -d "$NLE_DIR/src" ]; then
+        echo "Cloning modified NLE from $NLE_REPO ..."
+        git clone --depth 1 "$NLE_REPO" "$NLE_DIR"
+    fi
+    NETHACK_LIB_DIR="$(pwd)/$NLE_DIR/src/build"
+    if [ ! -f "$NETHACK_LIB_DIR/libnethack.so" ]; then
+        echo "Building libnethack.so ..."
+        make -C "$NETHACK_LIB_DIR" nethack -j$(nproc)
+    fi
+    INCLUDES+=(-I./$NLE_DIR/include)
+    EXTRA_LDFLAGS+=(-L"$NETHACK_LIB_DIR" -lnethack -Wl,-rpath,"$NETHACK_LIB_DIR" -ldl)
 elif [ -d "ocean/$ENV" ]; then
     SRC_DIR="ocean/$ENV"
 else
@@ -142,6 +158,7 @@ if [ "$MODE" = "local" ] || [ "$MODE" = "fast" ]; then
         "${INCLUDES[@]}"
         "$SRC_DIR/$ENV.c" $EXTRA_SRC -o "$OUTPUT_NAME"
         "${LINK_ARCHIVES[@]}"
+        "${EXTRA_LDFLAGS[@]}"
         "${STANDALONE_LDFLAGS[@]}"
         -lm -lpthread -fopenmp
         -DPLATFORM_DESKTOP
@@ -244,6 +261,7 @@ fi
 echo "Compiling static library for $ENV..."
 ${CC:-clang} -c "${CLANG_OPT[@]}" $EXTRA_CFLAGS \
     -I. -Isrc -I$SRC_DIR -Ivendor \
+    "${INCLUDES[@]}" \
     -I./$RAYLIB_NAME/include -I$CUDA_HOME/include \
     -DPLATFORM_DESKTOP \
     -fno-semantic-interposition -fvisibility=hidden \
@@ -279,6 +297,7 @@ if [ -z "$MODE" ]; then
         build/bindings.o "$STATIC_LIB" "$RAYLIB_A"
         -L$CUDA_HOME/lib64 $CUDNN_LFLAG $NCCL_LFLAG
         "${WHEEL_RPATH_FLAGS[@]}"
+        "${EXTRA_LDFLAGS[@]}"
         -lcudart -lnccl -lnvidia-ml -lcublas -lcusolver -lcurand -lcudnn
         $OMP_LIB $LINK_OPT
         "${SHARED_LDFLAGS[@]}"
@@ -302,6 +321,7 @@ elif [ "$MODE" = "cpu" ]; then
     LINK_CMD=(
         ${CXX:-g++} -shared -fPIC -fopenmp
         build/bindings_cpu.o "$STATIC_LIB" "$RAYLIB_A"
+        "${EXTRA_LDFLAGS[@]}"
         -lm -lpthread $OMP_LIB $LINK_OPT
         "${SHARED_LDFLAGS[@]}"
         -o "$OUTPUT"

--- a/config/nethack.ini
+++ b/config/nethack.ini
@@ -1,0 +1,120 @@
+[base]
+env_name = nethack
+
+[vec]
+total_agents = 4096
+num_buffers = 2
+num_threads = 16
+seed = 73
+
+[env]
+# Reward shaping. Each coef is independently toggleable: set to 0 to disable
+# the term. See ocean/nethack/REWARDS.md for the recipe + future candidates.
+# CLI: --env.score-coef, --env.descent-coef, --env.scout-coef, --env.illegal-penalty
+score_coef = 0.01
+descent_coef = 10.0
+scout_coef = 0.1
+illegal_penalty = -0.1
+
+[policy]
+hidden_size = 512
+num_layers = 4
+expansion_factor = 2
+
+[train]
+gpus = 1
+seed = 42
+total_timesteps = 1443360107
+learning_rate = 0.00224872
+anneal_lr = 1
+min_lr_ratio = 0
+gamma = 0.99816
+gae_lambda = 0.696214
+replay_ratio = 2.2381
+clip_coef = 0.20
+vf_coef = 0.1
+vf_clip_coef = 0.01
+max_grad_norm = 1.14364
+ent_coef = 0.10
+beta1 = 0.981226
+beta2 = 0.994178
+eps = 1.82223e-06
+minibatch_size = 32768
+horizon = 256
+vtrace_rho_clip = 3.24229
+vtrace_c_clip = 3.95664
+prio_alpha = 1
+prio_beta0 = 0.555562
+env = 0
+
+[sweep]
+method = Random
+metric = depth
+goal = maximize
+downsample = 4
+max_runs = 2
+gpus = 1
+max_suggestion_cost = 1500
+
+[sweep.env.score_coef]
+distribution = log_normal
+min = 0.001
+mean = 0.01
+max = 0.1
+scale = auto
+
+[sweep.env.descent_coef]
+distribution = uniform
+min = 0.0
+mean = 10.0
+max = 50.0
+scale = auto
+
+[sweep.env.scout_coef]
+distribution = uniform
+min = 0.0
+mean = 0.1
+max = 2.0
+scale = auto
+
+[sweep.env.illegal_penalty]
+distribution = uniform
+min = -2.0
+mean = -0.5
+max = 0.0
+scale = auto
+
+[sweep.train.learning_rate]
+distribution = log_normal
+min = 0.0001
+mean = 0.002
+max = 0.01
+scale = auto
+
+[sweep.train.gamma]
+distribution = uniform
+min = 0.99
+mean = 0.998
+max = 0.9999
+scale = auto
+
+[sweep.train.gae_lambda]
+distribution = uniform
+min = 0.5
+mean = 0.7
+max = 0.99
+scale = auto
+
+[sweep.train.ent_coef]
+distribution = log_normal
+min = 0.001
+mean = 0.1
+max = 0.5
+scale = auto
+
+[sweep.train.max_grad_norm]
+distribution = uniform
+min = 0.1
+mean = 1.0
+max = 3.0
+scale = auto

--- a/ocean/nethack/README.md
+++ b/ocean/nethack/README.md
@@ -1,0 +1,261 @@
+# NetHack environment for PufferLib
+
+C-level NLE binding for the PufferLib RL framework. Each env owns a
+per-env `nle_ctx_t` holding all of NetHack's mutable game state, with a
+private 64 MB memory arena. `libnethack.so` is linked directly (no
+dlopen). Auto-dismiss for prompts, compile-time observation selection,
+reward shaping, multi-threaded OMP stepping.
+
+---
+
+## Full setup (from scratch on any HPC)
+
+### 1. Clone PufferLib + vendored NLE
+
+```bash
+git clone https://github.com/PufferAI/PufferLib.git && cd PufferLib
+git checkout 4.0
+
+# Clone the modified NLE into vendor/nle
+git clone https://github.com/liujonathan24/NetHack.git vendor/nle
+```
+
+### 2. Python environment
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[nethack]"    # installs pufferlib + nethack deps (torch, numpy, wandb, etc.)
+```
+
+If `[nethack]` extras aren't defined yet, use:
+```bash
+pip install -e .
+pip install bz2file           # if system libbz2 headers missing
+```
+
+### 3. System modules (cluster-specific)
+
+You need a C compiler (clang preferred, gcc works), CUDA toolkit, and
+an OpenMP runtime. On Princeton Della:
+
+```bash
+module load cudatoolkit/12.8 intel-oneapi/2024.2
+```
+
+On other clusters, find equivalents for:
+- **CUDA**: `nvcc` for GPU training backend
+- **OpenMP**: `libiomp5.so` (Intel) or `libgomp.so` (GCC) — needed at link and runtime
+- **clang** (optional but preferred): `build.sh` uses clang flags by default. Set `CC=gcc` if clang isn't available, but note `-ferror-limit` must be removed from `build.sh`.
+
+### 4. Build libnethack.so
+
+```bash
+# First-time only: configure cmake
+cd vendor/nle/src
+mkdir -p build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+cd ../../../..
+
+# Build (always from repo root)
+make -C vendor/nle/src/build nethack -j$(nproc)
+```
+
+Produces `vendor/nle/src/build/libnethack.so` and data files in
+`vendor/nle/src/build/dat/` (including `nhdat`).
+
+If cmake fails with missing `bz2`, install libbz2-dev
+(`apt install libbz2-dev` or `yum install bzip2-devel`).
+
+### 5. Build PufferLib C extension (_C.so)
+
+```bash
+bash build.sh nethack          # auto-detects CUDA; falls back to CPU
+```
+
+Produces `pufferlib/_C.cpython-*.so`. If you get linker errors about
+`-liomp5`, make sure the Intel OpenMP module is loaded.
+
+### 6. Set NETHACKDIR
+
+Point to the directory containing `nhdat`:
+
+```bash
+export NETHACKDIR=$(pwd)/vendor/nle/src/build/dat
+```
+
+### 7. Verify
+
+```bash
+# Quick training test (runs on login node if GPU available)
+puffer train nethack \
+    --vec.total-agents 64 --vec.num-buffers 1 --vec.num-threads 4 \
+    --train.gpus 1 --train.total-timesteps 1000000 --train.minibatch-size 64
+
+# Interactive play
+./live_view -i
+
+# Random agent viewer
+./live_view --random --steps 200
+```
+
+### 8. SLURM training
+
+```bash
+sbatch sweep_nethack.slurm     # hyperparameter sweep
+# or single run:
+puffer train nethack --wandb \
+    --vec.total-agents 4096 --vec.num-buffers 1 --vec.num-threads 16 \
+    --train.gpus 1 --train.total-timesteps 1000000000
+```
+
+### Rebuild after code changes
+
+```bash
+make -C vendor/nle/src/build nethack -j$(nproc)   # if vendor/nle changed
+bash build.sh nethack                               # always (relinks _C.so)
+```
+
+### Pulling NLE updates
+
+The modified NLE lives in a separate repo. To pull latest changes:
+
+```bash
+cd vendor/nle
+git pull origin main
+cd ../..
+make -C vendor/nle/src/build nethack -j$(nproc)
+bash build.sh nethack
+```
+
+To push NLE changes (after editing files under `vendor/nle/`):
+
+```bash
+cd vendor/nle
+git add -A && git commit -m "description of changes"
+git push origin main
+cd ../..
+```
+
+Note: `vendor/nle/` has its own `.git` — it is NOT tracked by the
+PufferLib repo. Add `vendor/nle` to PufferLib's `.gitignore` if it
+isn't already.
+
+### Troubleshooting
+
+| Error | Fix |
+|---|---|
+| `clang: command not found` | `module load llvm` or set `CC=gcc` |
+| `cannot find -liomp5` | `module load intel-oneapi/2024.2` (or equivalent) |
+| `libiomp5.so: cannot open shared object file` | Same module, also at runtime |
+| `cannot allocate memory in static TLS block` | Too many `__thread` vars — rebuild libnethack |
+| `NETHACKDIR is misconfigured` | `export NETHACKDIR=$(pwd)/vendor/nle/src/build/dat` |
+| `ZeroDivisionError` in train | Need `--train.gpus 1` (even on CPU-only, the CUDA build requires it) |
+| Core dump / segfault at T>1 | Check that libnethack.so was rebuilt after latest source changes |
+
+---
+
+## Observation (compile-time selectable, default = chars only)
+
+Each enabled field reserves a slice of a single flat `ByteTensor`
+observation buffer. Override defaults with `-DNETHACK_USE_<FIELD>=1` in
+build.sh's `EXTRA_CFLAGS`.
+
+| Field        | Default | Bytes/element | Total (one env)              |
+|--------------|--------:|--------------:|------------------------------|
+| `chars`      |    1    | 1             | 1,659                        |
+| `colors`     |    0    | 1             | 1,659                        |
+| `specials`   |    0    | 1             | 1,659                        |
+| `glyphs`     |    0    | 2 (le i16)    | 3,318                        |
+| `blstats`    |    0    | 4 (i32, trunc)| 108                          |
+| `message`    |    0    | 1             | 256                          |
+| `inv`        |    0    | 1 (letters+oclasses) | 110                   |
+
+`OBS_SIZE` is the sum of enabled fields.
+
+## Action space (18 actions)
+
+```
+ 0  N            8  N_RUN         16  >  (down)
+ 1  S            9  S_RUN         17  <  (up)
+ 2  W           10  W_RUN
+ 3  E           11  E_RUN
+ 4  NW          12  NW_RUN
+ 5  NE          13  NE_RUN
+ 6  SW          14  SW_RUN
+ 7  SE          15  SE_RUN
+```
+
+The 8 cardinal/intercardinal moves use vi-keys (kjhl ynbu). Long
+"run" versions are uppercase (KJHL YNBU).
+
+## Reward shaping (config-tunable via nethack.ini)
+
+```
+reward = score_coef    * (score - prev_score)          # game score delta
+       + descent_coef  * max(0, depth - prev_depth)    # new max depth bonus
+       + scout_coef    * (new_tile_this_level)          # exploration bonus
+       + illegal_penalty * (illegal_action)             # sub-prompt penalty
+```
+
+All coefficients are set in `config/nethack.ini` under `[env]`.
+
+## Auto-dismiss hook
+
+After each agent action, the harness inspects `misc[]`
+(`in_yn_function`, `in_getlin`, `xwaitingforspace`) plus a heuristic
+message-ends-in-`?` check:
+
+- `yn_function` prompts: auto-answered `y` (commit to the action)
+- `getlin` prompts: auto-dismissed with ESC
+- `--More--` / `xwaitforspace`: auto-dismissed with space/ESC
+
+Capped at `NETHACK_AUTODISMISS_MAX=64` iterations. Episodes also
+auto-reset after `NETHACK_MAX_EPISODE_STEPS=10000` steps.
+
+## Per-episode log entries
+
+| Key                | Meaning                                                |
+|--------------------|--------------------------------------------------------|
+| `perf` / `score`   | Final NetHack score                                    |
+| `depth`            | Final dungeon level                                    |
+| `episode_return`   | Sum of shaped reward                                   |
+| `episode_length`   | Number of c_steps                                      |
+| `valid_moves`      | c_steps where NetHack's turn counter advanced          |
+| `illegal_actions`  | c_steps where the agent triggered a sub-prompt         |
+| `new_tiles`        | Unique tiles entered this episode                      |
+
+## Standalone tools
+
+```bash
+# Live viewer (interactive play)
+NETHACKDIR=$(pwd)/vendor/nle/src/build/dat ./live_view -i
+
+# Live viewer (random agent)
+NETHACKDIR=$(pwd)/vendor/nle/src/build/dat ./live_view --random --steps 500
+
+# Live viewer (replay a recorded trajectory)
+NETHACKDIR=$(pwd)/vendor/nle/src/build/dat ./live_view --replay path/to/recording.bin
+```
+
+Build live_view from source:
+```bash
+clang -O2 -I vendor/nle/src/include -I vendor/nle/src/build/include \
+    -I vendor/nle/src/third_party/deboost.context/include \
+    -DDEFAULT_WINDOW_SYS=\"rl\" -DDLB -DNLE_ALLOW_SEEDING \
+    -DNLE_PER_ENV_FILES=1 -DNLE_PER_ENV_FLAGS=1 -DNLE_USE_ARENA_FREE=1 \
+    -DNLE_USE_TILES -DNOCLIPPING -DNOCWD_ASSUMPTIONS -DNOMAIL -DNOTPARMDECL \
+    -DNETHACK_USE_BLSTATS=1 \
+    ocean/nethack/live_view.c -o live_view \
+    -L./vendor/nle/src/build -lnethack -lm -lbz2 -lpthread \
+    -Wl,-rpath=$(pwd)/vendor/nle/src/build
+```
+
+## Performance
+
+| Configuration | SPS | Notes |
+|---|---|---|
+| N=512 T=4 (4M model) | 40K | GPU-bound (train=68%) |
+| N=4096 T=4 (4M model) | 128K | Balanced (env=66%, train=30%) |
+| N=4096 T=16 (4M model) | ~400K | More threads = more env throughput |
+| N=8192 T=64 B=2 (sweep) | ~1M | Full utilization with double-buffering |

--- a/ocean/nethack/binding.c
+++ b/ocean/nethack/binding.c
@@ -1,0 +1,42 @@
+#include "nethack.h"
+#define OBS_SIZE NETHACK_OBS_SIZE
+#define NUM_ATNS 1
+#define ACT_SIZES {NETHACK_NUM_ACTIONS}
+#define OBS_TENSOR_T ByteTensor
+
+#define Env Nethack
+#include "vecenv.h"
+
+// Read a float kwarg if present; otherwise keep the value already set in
+// init() (the per-term legacy default). This means config/nethack.ini can
+// safely omit a key — the env still works.
+static void nethack_read_coef(Dict* kwargs, const char* key, float* dst) {
+    DictItem* it = dict_get_unsafe(kwargs, key);
+    if (it != NULL) *dst = (float)it->value;
+}
+
+void my_init(Env* env, Dict* kwargs) {
+    env->num_agents = 1;
+    init(env);
+    // Reward-shaping coefficients (see ocean/nethack/REWARDS.md). All four
+    // are optional; defaults are baked in init(). To add a new coef:
+    //   1) Add `float my_coef;` to Nethack struct in nethack.h
+    //   2) Set its default in init()
+    //   3) Add a nethack_read_coef line here
+    //   4) Add `my_coef = <default>` to [env] in config/nethack.ini
+    nethack_read_coef(kwargs, "score_coef",      &env->score_coef);
+    nethack_read_coef(kwargs, "descent_coef",    &env->descent_coef);
+    nethack_read_coef(kwargs, "scout_coef",      &env->scout_coef);
+    nethack_read_coef(kwargs, "illegal_penalty", &env->illegal_penalty);
+}
+
+void my_log(Log* log, Dict* out) {
+    dict_set(out, "perf", log->perf);
+    dict_set(out, "score", log->score);
+    dict_set(out, "episode_return", log->episode_return);
+    dict_set(out, "episode_length", log->episode_length);
+    dict_set(out, "depth", log->depth);
+    dict_set(out, "valid_moves", log->valid_moves);
+    dict_set(out, "illegal_actions", log->illegal_actions);
+    dict_set(out, "new_tiles", log->new_tiles);
+}

--- a/ocean/nethack/live_view.c
+++ b/ocean/nethack/live_view.c
@@ -1,0 +1,416 @@
+/* live_view.c — interactive single-env NetHack viewer for debugging.
+ *
+ * Loads libnethack.so, starts one env with a seed, and steps it with
+ * either a recorded action stream, random actions, or interactive
+ * keystrokes from stdin. Each step is rendered to the terminal with
+ * ANSI colors driven by NetHack's colors[] grid, plus a sidebar
+ * showing blstats / message / inventory letters.
+ *
+ * Use cases:
+ *   1. Watch an env run with random actions to verify it's not stuck
+ *      (catches "agent always picks invalid action and dies in 50 steps"
+ *      class of bug):
+ *        ./live_view --random --steps 500 --seed 42
+ *   2. Replay a recorded action stream from a golden trajectory at a
+ *      slow rate:
+ *        ./live_view --replay golden_seed05_1k.bin --rate 5
+ *   3. Step interactively (one keystroke = one action):
+ *        ./live_view --interactive
+ *
+ * Build:
+ *   clang -O2 -Wall -std=gnu11 -I./vendor/nle/include -I./ocean/nethack \
+ *       ocean/nethack/live_view.c -o live_view -ldl -lpthread -lm
+ *
+ * Output ANSI escapes; pipe through `less -R` to scroll back through
+ * a no-pause run, or pipe through `vhs`/`asciinema` to record a demo.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <dlfcn.h>
+#include <time.h>
+#include <termios.h>
+#include <errno.h>
+#define NLE_ALLOW_SEEDING
+#include "nleobs.h"
+
+typedef struct nle_ctx nle_ctx_t;
+typedef nle_ctx_t *(*nle_start_fn)(nle_obs *, FILE *, nle_seeds_init_t *,
+                                   nle_settings *);
+typedef nle_ctx_t *(*nle_step_fn)(nle_ctx_t *, nle_obs *);
+typedef void (*nle_end_fn)(nle_ctx_t *);
+
+#define NH_ROWS 21
+#define NH_COLS 79
+#define NH_GRID (NH_ROWS * NH_COLS)
+
+#define DEFAULT_OPTIONS                                                       \
+    "name:Agent-mon-hum-neu-mal,"                                             \
+    "autopickup,color,disclose:+i +a +v +g +c +o,"                            \
+    "mention_walls,nobones,nocmdassist,nolegacy,nosparkle,"                   \
+    "pickup_burden:unencumbered,pickup_types:$?!/,"                           \
+    "runmode:teleport,showexp,showscore,time"
+
+/* NetHack's CLR_* match ANSI fg codes 30-37. CLR_BLACK is rendered bright. */
+static const char *ansi_fg[16] = {
+    "\x1b[1;30m", "\x1b[0;31m", "\x1b[0;32m", "\x1b[0;33m",
+    "\x1b[0;34m", "\x1b[0;35m", "\x1b[0;36m", "\x1b[0;37m",
+    "\x1b[1;30m", "\x1b[1;31m", "\x1b[1;32m", "\x1b[1;33m",
+    "\x1b[1;34m", "\x1b[1;35m", "\x1b[1;36m", "\x1b[1;37m",
+};
+#define ANSI_RESET "\x1b[0m"
+#define ANSI_CLEAR "\x1b[2J\x1b[H"
+
+/* 18-action default action set (NETHACK_ACTION_SET == 1) */
+static const int ACTION_TABLE[18] = {
+    'k', 'j', 'h', 'l', 'y', 'u', 'b', 'n',
+    'K', 'J', 'H', 'L', 'Y', 'U', 'B', 'N',
+    '.', 's',
+};
+#define NUM_ACTIONS 18
+
+static int make_vardir(const char *src, char *out, size_t cap)
+{
+    char tmpl[] = "/tmp/nle-live-XXXXXX";
+    char *d = mkdtemp(tmpl);
+    if (!d) return -1;
+    snprintf(out, cap, "%s", d);
+    char a[2048], b[2048];
+    snprintf(a, sizeof(a), "%s/nhdat", src);
+    snprintf(b, sizeof(b), "%s/nhdat", d);
+    if (symlink(a, b)) return -1;
+    const char *t[] = {"perm", "record", "logfile", "xlogfile"};
+    for (int i = 0; i < 4; i++) {
+        snprintf(b, sizeof(b), "%s/%s", d, t[i]);
+        int fd = open(b, O_CREAT | O_WRONLY, 0644);
+        if (fd >= 0) close(fd);
+    }
+    snprintf(b, sizeof(b), "%s/save", d);
+    mkdir(b, 0755);
+    return 0;
+}
+
+typedef struct {
+    nle_ctx_t *ctx;
+    nle_obs obs;
+    unsigned char chars[NH_GRID];
+    signed char colors[NH_GRID];
+    int misc[NLE_MISC_SIZE];
+    int internal[NLE_INTERNAL_SIZE];
+    long blstats[NLE_BLSTATS_SIZE];
+    int8_t message[256];
+    unsigned char inv_letters[NLE_INVENTORY_SIZE];
+    unsigned char inv_oclasses[NLE_INVENTORY_SIZE];
+    char vardir[256];
+    nle_settings settings;
+} Env;
+
+static void bind_obs(Env *e)
+{
+    memset(&e->obs, 0, sizeof(e->obs));
+    e->obs.chars = e->chars;
+    e->obs.colors = e->colors;
+    e->obs.misc = e->misc;
+    e->obs.internal = e->internal;
+    e->obs.blstats = e->blstats;
+    e->obs.message = (unsigned char *) e->message;
+    e->obs.inv_letters = e->inv_letters;
+    e->obs.inv_oclasses = e->inv_oclasses;
+}
+
+static long prev_score = 0;
+static int  prev_depth = 1;
+static int  visited_level = 0;
+static unsigned char visited[21 * 80 / 8 + 1];
+static float ep_return = 0.0f;
+static long ep_length  = 0;
+static long ep_valid   = 0;
+static long ep_illegal = 0;
+static long ep_tiles   = 0;
+static int  last_misc[3] = {0};
+
+static void render(Env *e, long step, int action, float reward)
+{
+    fputs(ANSI_CLEAR, stdout);
+    /* Header */
+    printf("step=%-6ld  action=%-3d ('%c')  reward=%+.3f  HP=%ld/%ld  T=%ld  Dlvl=%ld  Score=%ld\n",
+           step, action, (action >= 32 && action < 127) ? action : '?', reward,
+           e->blstats[NLE_BL_HP], e->blstats[NLE_BL_HPMAX],
+           e->blstats[NLE_BL_TIME], e->blstats[NLE_BL_DEPTH],
+           e->blstats[NLE_BL_SCORE]);
+    /* User stats (matches training Log struct) */
+    printf("ep_return=%.2f  ep_len=%ld  depth=%ld  score=%ld  "
+           "valid=%ld  illegal=%ld  tiles=%ld  "
+           "misc=[%d,%d,%d]\n",
+           ep_return, ep_length, e->blstats[NLE_BL_DEPTH],
+           e->blstats[NLE_BL_SCORE],
+           ep_valid, ep_illegal, ep_tiles,
+           last_misc[0], last_misc[1], last_misc[2]);
+    /* Message line */
+    printf("msg: \"%.*s\"\n", 79, (char *) e->message);
+    /* Chars grid w/ ANSI colors */
+    for (int r = 0; r < NH_ROWS; r++) {
+        int last_c = -2;
+        for (int c = 0; c < NH_COLS; c++) {
+            int color = e->colors[r * NH_COLS + c] & 0xF;
+            unsigned char ch = e->chars[r * NH_COLS + c];
+            if (color != last_c) {
+                fputs(ansi_fg[color], stdout);
+                last_c = color;
+            }
+            putchar(ch ? ch : ' ');
+        }
+        fputs(ANSI_RESET "\n", stdout);
+    }
+    /* Inventory letters */
+    printf("inv: ");
+    int any = 0;
+    for (int i = 0; i < NLE_INVENTORY_SIZE; i++) {
+        if (e->inv_letters[i]) {
+            printf("%c ", e->inv_letters[i]);
+            any = 1;
+        }
+    }
+    if (!any) fputs("(empty)", stdout);
+    putchar('\n');
+    fflush(stdout);
+}
+
+static int drain(Env *e, nle_step_fn fn_step)
+{
+    int max_iter = 200;
+    while (max_iter-- > 0 && e->obs.internal[3] != 0) {
+        e->obs.action = '\r';
+        e->ctx = fn_step(e->ctx, &e->obs);
+        if (e->obs.done) return -1;
+    }
+    return 0;
+}
+
+static void usage(void)
+{
+    fprintf(stderr,
+            "usage: live_view [options]\n"
+            "  --random          random actions (default)\n"
+            "  --interactive     read action keystrokes from stdin\n"
+            "  --steps N         number of steps (random mode only, default 500)\n"
+            "  --seed S          seed for RNG and env (default 42)\n"
+            "  --rate HZ         pause 1/HZ seconds between frames (default 4)\n"
+            "  --no-render       don't render (benchmark mode)\n"
+            "  --replay FILE     replay an action stream from a binary file\n"
+            "                    (uint32 actions, one per step)\n");
+    exit(2);
+}
+
+int main(int argc, char **argv)
+{
+    int mode_random = 1, mode_interactive = 0, mode_replay = 0;
+    int no_render = 0;
+    long steps = 500;
+    unsigned long seed = 42;
+    double rate = 4.0;
+    const char *replay_path = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--random")) {
+            mode_random = 1;
+            mode_interactive = 0;
+            mode_replay = 0;
+        } else if (!strcmp(argv[i], "--interactive")) {
+            mode_interactive = 1;
+            mode_random = 0;
+        } else if (!strcmp(argv[i], "--replay") && i + 1 < argc) {
+            replay_path = argv[++i];
+            mode_replay = 1;
+            mode_random = 0;
+        } else if (!strcmp(argv[i], "--steps") && i + 1 < argc) {
+            steps = atol(argv[++i]);
+        } else if (!strcmp(argv[i], "--seed") && i + 1 < argc) {
+            seed = strtoul(argv[++i], NULL, 0);
+        } else if (!strcmp(argv[i], "--rate") && i + 1 < argc) {
+            rate = atof(argv[++i]);
+        } else if (!strcmp(argv[i], "--no-render")) {
+            no_render = 1;
+        } else {
+            usage();
+        }
+    }
+
+    const char *libpath = getenv("NETHACK_LIBPATH");
+    if (!libpath) libpath = "./vendor/nle/src/build/libnethack.so";
+    const char *nhdir = getenv("NETHACKDIR");
+    if (!nhdir) nhdir = "vendor/nle/nethackdir";
+
+    void *h = dlopen(libpath, RTLD_NOW | RTLD_LOCAL);
+    if (!h) {
+        fprintf(stderr, "dlopen %s: %s\n", libpath, dlerror());
+        return 1;
+    }
+    nle_start_fn fn_start = (nle_start_fn) dlsym(h, "nle_start");
+    nle_step_fn fn_step = (nle_step_fn) dlsym(h, "nle_step");
+    nle_end_fn fn_end = (nle_end_fn) dlsym(h, "nle_end");
+    if (!fn_start || !fn_step || !fn_end) {
+        fprintf(stderr, "missing libnethack symbols\n");
+        return 1;
+    }
+
+    Env e = {0};
+    if (make_vardir(nhdir, e.vardir, sizeof(e.vardir))) {
+        fprintf(stderr, "vardir setup failed\n");
+        return 1;
+    }
+    bind_obs(&e);
+    memset(&e.settings, 0, sizeof(e.settings));
+    snprintf(e.settings.hackdir, sizeof(e.settings.hackdir), "%s", e.vardir);
+    snprintf(e.settings.scoreprefix, sizeof(e.settings.scoreprefix), "%s/",
+             e.vardir);
+    snprintf(e.settings.options, sizeof(e.settings.options), "%s",
+             DEFAULT_OPTIONS);
+    e.settings.spawn_monsters = 1;
+
+    nle_seeds_init_t s = {0};
+    s.seeds[0] = seed;
+    s.seeds[1] = seed ^ 0x9E3779B97F4A7C15UL;
+    e.ctx = fn_start(&e.obs, NULL, &s, &e.settings);
+    if (!e.ctx) {
+        fprintf(stderr, "nle_start failed\n");
+        return 1;
+    }
+    if (drain(&e, fn_step) < 0) {
+        fprintf(stderr, "drain failed\n");
+        return 1;
+    }
+
+    /* Replay stream */
+    int32_t *replay = NULL;
+    long replay_len = 0;
+    if (mode_replay) {
+        FILE *f = fopen(replay_path, "rb");
+        if (!f) {
+            fprintf(stderr, "fopen %s: %s\n", replay_path, strerror(errno));
+            return 1;
+        }
+        fseek(f, 0, SEEK_END);
+        long bytes = ftell(f);
+        fseek(f, 0, SEEK_SET);
+        replay_len = bytes / 4;
+        replay = malloc(bytes);
+        if (fread(replay, 4, replay_len, f) != (size_t) replay_len) {
+            fprintf(stderr, "short read on replay\n");
+            return 1;
+        }
+        fclose(f);
+        steps = replay_len;
+    }
+
+    /* Stash terminal mode for interactive */
+    struct termios oldt, newt;
+    if (mode_interactive) {
+        tcgetattr(STDIN_FILENO, &oldt);
+        newt = oldt;
+        newt.c_lflag &= ~(ICANON | ECHO);
+        tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+    }
+
+    unsigned r = (unsigned) seed;
+    struct timespec frame = {0, 0};
+    if (rate > 0 && !mode_interactive && !no_render) {
+        long ns = (long) (1e9 / rate);
+        frame.tv_sec = ns / 1000000000L;
+        frame.tv_nsec = ns % 1000000000L;
+    }
+
+    /* Render initial state before first input */
+    if (!no_render) {
+        render(&e, 0, 0, 0.0f);
+    }
+
+    for (long t = 0; t < steps; t++) {
+        int action;
+        if (mode_interactive) {
+            int ch = getchar();
+            if (ch == EOF || ch == 'Q') break;
+            action = ch;
+        } else if (mode_replay) {
+            action = replay[t];
+        } else {
+            r ^= r << 13;
+            r ^= r >> 17;
+            r ^= r << 5;
+            action = ACTION_TABLE[r % NUM_ACTIONS];
+        }
+        e.obs.action = action;
+        e.ctx = fn_step(e.ctx, &e.obs);
+        /* Auto-drain --More-- / xwaitforspace so level transitions
+         * and multi-line messages don't leave the display stale. */
+        /* Capture misc flags before drain clears them */
+        if (e.obs.misc) {
+            last_misc[0] = e.obs.misc[0];
+            last_misc[1] = e.obs.misc[1];
+            last_misc[2] = e.obs.misc[2];
+        }
+        /* Auto-drain yn prompts (answer 'y') and --More-- (send space) */
+        for (int drain = 0; drain < 16; drain++) {
+            int is_yn = e.obs.misc && e.obs.misc[0];
+            int is_xwait = e.obs.misc && e.obs.misc[2];
+            if (!is_yn && !is_xwait) break;
+            e.obs.action = is_yn ? 'y' : ' ';
+            e.ctx = fn_step(e.ctx, &e.obs);
+            if (e.obs.done) break;
+        }
+        /* Track user stats (mirrors c_step reward shaping) */
+        long score = e.blstats[NLE_BL_SCORE];
+        float reward = 0.01f * (float)(score - prev_score);
+        int depth = (int)e.blstats[NLE_BL_DEPTH];
+        if (depth > prev_depth) reward += 10.0f * (float)(depth - prev_depth);
+        if (depth != visited_level) {
+            memset(visited, 0, sizeof(visited));
+            visited_level = depth;
+        }
+        int px = (int)e.blstats[NLE_BL_X];
+        int py = (int)e.blstats[NLE_BL_Y];
+        if (px >= 0 && px < 80 && py >= 0 && py < 21) {
+            int bit = py * 80 + px;
+            if (!(visited[bit >> 3] & (1 << (bit & 7)))) {
+                visited[bit >> 3] |= (1 << (bit & 7));
+                ep_tiles++;
+                reward += 0.1f;
+            }
+        }
+        int was_illegal = last_misc[0] || last_misc[1];
+        if (was_illegal) { ep_illegal++; reward += -0.1f; }
+        else ep_valid++;
+        ep_return += reward;
+        ep_length++;
+        if (!e.obs.done) {
+            prev_score = score;
+            prev_depth = depth;
+        }
+        if (e.obs.done) {
+            prev_score = 0; prev_depth = 1; visited_level = 0;
+            memset(visited, 0, sizeof(visited));
+            ep_return = 0; ep_length = 0;
+            ep_valid = 0; ep_illegal = 0; ep_tiles = 0;
+        }
+        if (!no_render) {
+            render(&e, t + 1, action, reward);
+        }
+        if (e.obs.done) {
+            printf("\n*** Env done at step %ld (how_done=%d) ***\n", t,
+                   e.obs.how_done);
+            break;
+        }
+        if (frame.tv_nsec || frame.tv_sec) nanosleep(&frame, NULL);
+    }
+
+    if (mode_interactive) tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+    fn_end(e.ctx);
+    if (replay) free(replay);
+    return 0;
+}

--- a/ocean/nethack/nethack.c
+++ b/ocean/nethack/nethack.c
@@ -1,0 +1,285 @@
+#include <time.h>
+#include <unistd.h>
+#include <string.h>
+// For the trajectory recorder we want full obs so the log is useful.
+#define NETHACK_USE_BLSTATS 1
+#define NETHACK_USE_MESSAGE 1
+#define NETHACK_USE_COLORS  1
+#include "nethack.h"
+
+// Action index -> printable label for the trajectory log.
+// Matches NETHACK_ACTION_TABLE: k j h l y u b n  K J H L Y U B N  > < . s \r ESC ,
+static const char* NETHACK_ACTION_NAMES[NETHACK_NUM_ACTIONS] = {
+    "N","S","W","E","NW","NE","SW","SE",
+    "N_RUN","S_RUN","W_RUN","E_RUN","NW_RUN","NE_RUN","SW_RUN","SE_RUN",
+    "DOWN_STAIRS","UP_STAIRS","WAIT(.)","SEARCH(s)","MORE(\\r)","ESC","PICKUP(,)",
+};
+
+static double now_sec(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec + ts.tv_nsec * 1e-9;
+}
+
+static void run_interactive(int max_steps) {
+    Nethack env;
+    memset(&env, 0, sizeof(env));
+    env.num_agents = 1;
+    env.observations = (unsigned char*)calloc(NETHACK_OBS_SIZE, 1);
+    env.actions      = (float*)calloc(1, sizeof(float));
+    env.rewards      = (float*)calloc(1, sizeof(float));
+    env.terminals    = (float*)calloc(1, sizeof(float));
+
+    init(&env);
+    c_reset(&env);
+    c_render(&env);
+
+    srand((unsigned)time(NULL));
+    for (int t = 0; t < max_steps; t++) {
+        env.actions[0] = (float)(rand() % NETHACK_NUM_ACTIONS);
+        c_step(&env);
+        c_render(&env);
+        printf("step=%d action=%d reward=%.2f done=%.0f\n",
+               t, (int)env.actions[0], env.rewards[0], env.terminals[0]);
+        usleep(50 * 1000);
+    }
+    c_close(&env);
+    free(env.observations); free(env.actions); free(env.rewards); free(env.terminals);
+}
+
+static void run_benchmark(long steps, int policy) {
+    // policy: 0 = random, 1 = always wait '.' (action_idx 18)
+    Nethack env;
+    memset(&env, 0, sizeof(env));
+    env.num_agents = 1;
+    env.observations = (unsigned char*)calloc(NETHACK_OBS_SIZE, 1);
+    env.actions      = (float*)calloc(1, sizeof(float));
+    env.rewards      = (float*)calloc(1, sizeof(float));
+    env.terminals    = (float*)calloc(1, sizeof(float));
+
+    init(&env);
+    c_reset(&env);
+    srand(0xC0FFEE);
+    long episodes = 1;
+    double sum_reward = 0.0;
+
+    double t0 = now_sec();
+    for (long t = 0; t < steps; t++) {
+        env.actions[0] = (policy == 1) ? 18.0f : (float)(rand() % NETHACK_NUM_ACTIONS);
+        c_step(&env);
+        sum_reward += env.rewards[0];
+        if (env.terminals[0] > 0.5f) episodes++;
+    }
+    double dt = now_sec() - t0;
+
+    printf("steps=%ld  episodes=%ld  time=%.3fs  steps/sec=%.0f  sum_reward=%.1f\n",
+           steps, episodes, dt, steps / dt, sum_reward);
+    printf("  valid_moves=%ld (%.1f%%)  illegal_actions=%ld (%.1f%%)\n",
+           env.episode_valid_moves,
+           100.0 * env.episode_valid_moves / (double)steps,
+           env.episode_illegal_actions,
+           100.0 * env.episode_illegal_actions / (double)steps);
+#if NETHACK_USE_BLSTATS
+    printf("  final HP=%ld/%ld  AC=%ld  Dlvl=%ld  Score=%ld  GameTime=%ld\n",
+           env.blstats[NLE_BL_HP], env.blstats[NLE_BL_HPMAX],
+           env.blstats[NLE_BL_AC],
+           env.blstats[NLE_BL_DEPTH], env.blstats[NLE_BL_SCORE],
+           env.blstats[NLE_BL_TIME]);
+#endif
+
+    c_close(&env);
+    free(env.observations); free(env.actions); free(env.rewards); free(env.terminals);
+}
+
+// Dump one frame as plain text (chars grid + status + message + action label).
+static void dump_frame(FILE* f, Nethack* env, long step, int action_idx, float reward) {
+    fprintf(f, "=== step %ld | action=%s | reward=%+.2f | done=%.0f | in_normal_game=%d ===\n",
+            step, NETHACK_ACTION_NAMES[action_idx], reward,
+            env->terminals[0], env->obs.in_normal_game);
+#if NETHACK_USE_BLSTATS
+    fprintf(f, "HP %ld/%ld  AC %ld  Dlvl %ld  Score %ld  GameTime %ld  Hunger %ld\n",
+            env->blstats[NLE_BL_HP], env->blstats[NLE_BL_HPMAX],
+            env->blstats[NLE_BL_AC], env->blstats[NLE_BL_DEPTH],
+            env->blstats[NLE_BL_SCORE], env->blstats[NLE_BL_TIME],
+            env->blstats[NLE_BL_HUNGER]);
+#endif
+#if NETHACK_USE_MESSAGE
+    fprintf(f, "Msg: %.256s\n", env->message);
+#endif
+    for (int r = 0; r < NH_ROWS; r++) {
+        fputs("  |", f);
+        for (int c = 0; c < NH_COLS; c++) {
+            unsigned char ch = env->chars[r * NH_COLS + c];
+            fputc(ch >= 32 && ch < 127 ? ch : (ch == 0 ? ' ' : '?'), f);
+        }
+        fputs("|\n", f);
+    }
+    fputc('\n', f);
+}
+
+static void run_record(const char* path, long steps, int policy) {
+    FILE* f = (strcmp(path, "-") == 0) ? stdout : fopen(path, "w");
+    if (!f) { perror("fopen"); return; }
+
+    Nethack env; memset(&env, 0, sizeof(env));
+    env.num_agents = 1;
+    env.observations = (unsigned char*)calloc(NETHACK_OBS_SIZE, 1);
+    env.actions      = (float*)calloc(1, sizeof(float));
+    env.rewards      = (float*)calloc(1, sizeof(float));
+    env.terminals    = (float*)calloc(1, sizeof(float));
+    init(&env);
+    c_reset(&env);
+    dump_frame(f, &env, -1, 0, 0.0f);   // post-reset frame, "action" col is meaningless
+
+    srand(0xC0FFEE);
+    for (long t = 0; t < steps; t++) {
+        int action_idx = (policy == 1) ? 18 : (rand() % NETHACK_NUM_ACTIONS);
+        env.actions[0] = (float)action_idx;
+        c_step(&env);
+        dump_frame(f, &env, t, action_idx, env.rewards[0]);
+        if (env.terminals[0] > 0.5f) {
+            fprintf(f, "##### EPISODE END at step %ld #####\n\n", t);
+            break;
+        }
+    }
+    c_close(&env);
+    if (f != stdout) fclose(f);
+    free(env.observations); free(env.actions); free(env.rewards); free(env.terminals);
+}
+
+// policy: 0=random, 1=wait, 2=move-north (always 'k'), 3=safe cycle
+static int policy_action(int policy, long t) {
+    switch (policy) {
+        case 0:  return rand() % NETHACK_NUM_ACTIONS;
+        case 1:  return 18;                                 // WAIT '.'
+        case 2:  return 0;                                  // MOVE N 'k'
+        case 3: {
+            // Cycle through 4 cardinal moves only — never picks risky actions
+            // like '>' or ',' that trigger sub-prompts. Should keep character
+            // alive longer than random and never trigger illegal-action handling.
+            static const int safe[] = {0, 1, 2, 3};  // N S W E
+            return safe[t & 3];
+        }
+        default: return 18;
+    }
+}
+
+static void run_profile(const char* out_json, long steps, int policy, int seed) {
+    Nethack env; memset(&env, 0, sizeof(env));
+    env.num_agents = 1;
+    env.observations = (unsigned char*)calloc(NETHACK_OBS_SIZE, 1);
+    env.actions      = (float*)calloc(1, sizeof(float));
+    env.rewards      = (float*)calloc(1, sizeof(float));
+    env.terminals    = (float*)calloc(1, sizeof(float));
+
+    double t0 = now_sec();
+    init(&env);
+    c_reset(&env);
+    srand((unsigned)seed);
+
+    long episodes = 1;
+    double sum_reward = 0.0;
+    for (long t = 0; t < steps; t++) {
+        env.actions[0] = (float)policy_action(policy, t);
+        c_step(&env);
+        sum_reward += env.rewards[0];
+        if (env.terminals[0] > 0.5f) episodes++;
+    }
+    double dt = now_sec() - t0;
+
+    // Console summary
+    printf("profile complete: steps=%ld episodes=%ld wall=%.3fs sum_reward=%.1f\n",
+           steps, episodes, dt, sum_reward);
+
+    // JSON dump
+    FILE* f = (strcmp(out_json, "-") == 0) ? stdout : fopen(out_json, "w");
+    if (!f) { perror("open profile output"); }
+    else {
+        prof_dump_json(f, dt);
+        if (f != stdout) fclose(f);
+        printf("wrote %s\n", out_json);
+    }
+
+    c_close(&env);
+    free(env.observations); free(env.actions); free(env.rewards); free(env.terminals);
+}
+
+int main(int argc, char** argv) {
+    if (argc >= 2 && strcmp(argv[1], "profile") == 0) {
+        // Usage: ./nethack profile OUT_JSON [N_STEPS] [random|wait] [SEED]
+        const char* out = (argc >= 3) ? argv[2] : "profile.json";
+        long steps     = (argc >= 4) ? atol(argv[3]) : 100000;
+        int policy     = 0;
+        if (argc >= 5) {
+            if      (strcmp(argv[4], "wait")   == 0) policy = 1;
+            else if (strcmp(argv[4], "north")  == 0) policy = 2;
+            else if (strcmp(argv[4], "safe")   == 0) policy = 3;
+            else                                     policy = 0;
+        }
+        int seed       = (argc >= 6) ? atoi(argv[5]) : 0xC0FFEE;
+        run_profile(out, steps, policy, seed);
+        return 0;
+    }
+    if (argc >= 2 && strcmp(argv[1], "record") == 0) {
+        // Usage: ./nethack record OUTFILE [N_STEPS] [random|wait]
+        const char* path = (argc >= 3) ? argv[2] : "trajectory.txt";
+        long steps      = (argc >= 4) ? atol(argv[3]) : 100;
+        int policy      = (argc >= 5 && strcmp(argv[4], "wait") == 0) ? 1 : 0;
+        run_record(path, steps, policy);
+        return 0;
+    }
+    if (argc >= 2 && strcmp(argv[1], "bench") == 0) {
+        long steps = (argc >= 3) ? atol(argv[2]) : 100000;
+        int policy = (argc >= 4 && strcmp(argv[3], "wait") == 0) ? 1 : 0;
+        printf("policy=%s\n", policy ? "wait" : "random");
+        run_benchmark(steps, policy);
+    } else if (argc >= 2 && strcmp(argv[1], "resets") == 0) {
+        long n = (argc >= 3) ? atol(argv[2]) : 50;
+        Nethack env; memset(&env, 0, sizeof(env));
+        env.num_agents = 1;
+        env.observations = (unsigned char*)calloc(NETHACK_OBS_SIZE, 1);
+        env.actions      = (float*)calloc(1, sizeof(float));
+        env.rewards      = (float*)calloc(1, sizeof(float));
+        env.terminals    = (float*)calloc(1, sizeof(float));
+        init(&env);
+        c_reset(&env);  // warm-up not counted
+        double t0 = now_sec();
+        for (long i = 0; i < n; i++) c_reset(&env);
+        double dt = now_sec() - t0;
+        printf("resets=%ld  time=%.3fs  per_reset=%.2fms  resets/sec=%.0f\n",
+               n, dt, 1000.0 * dt / n, n / dt);
+        c_close(&env);
+        free(env.observations); free(env.actions); free(env.rewards); free(env.terminals);
+    } else if (argc >= 2 && strcmp(argv[1], "stepreset") == 0) {
+        // step+reset cycle test. Args: STEPS_PER_EPISODE NUM_RESETS
+        long steps_per = (argc >= 3) ? atol(argv[2]) : 100;
+        long n_resets  = (argc >= 4) ? atol(argv[3]) : 20;
+        Nethack env; memset(&env, 0, sizeof(env));
+        env.num_agents = 1;
+        env.observations = (unsigned char*)calloc(NETHACK_OBS_SIZE, 1);
+        env.actions      = (float*)calloc(1, sizeof(float));
+        env.rewards      = (float*)calloc(1, sizeof(float));
+        env.terminals    = (float*)calloc(1, sizeof(float));
+        init(&env);
+        c_reset(&env);
+        srand(0xC0FFEE);
+        double t0 = now_sec();
+        for (long r = 0; r < n_resets; r++) {
+            for (long t = 0; t < steps_per; t++) {
+                env.actions[0] = (float)(rand() % NETHACK_NUM_ACTIONS);
+                c_step(&env);
+            }
+            c_reset(&env);
+        }
+        double dt = now_sec() - t0;
+        long total = steps_per * n_resets;
+        printf("stepreset: %ld cycles x %ld steps = %ld steps  time=%.3fs  sps=%.0f\n",
+               n_resets, steps_per, total, dt, total / dt);
+        c_close(&env);
+        free(env.observations); free(env.actions); free(env.rewards); free(env.terminals);
+    } else {
+        int max_steps = (argc >= 2) ? atoi(argv[1]) : 50;
+        run_interactive(max_steps);
+    }
+    return 0;
+}

--- a/ocean/nethack/nethack.h
+++ b/ocean/nethack/nethack.h
@@ -1,0 +1,973 @@
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include "profile.h"
+
+#ifndef SYS_memfd_create
+#  ifdef __x86_64__
+#    define SYS_memfd_create 319
+#  endif
+#endif
+static inline int nethack_memfd_create(const char* name, unsigned int flags) {
+    return (int)syscall(SYS_memfd_create, name, flags);
+}
+
+// ---------------------------------------------------------------------------
+// NLE minimal API
+// ---------------------------------------------------------------------------
+// All per-env mutable state lives in nle_ctx_t. libnethack.so is linked
+// directly (no dlopen). Each env gets its own nle_ctx_t + private memory
+// arena; a thread-local pointer (current_nle_ctx) anchors field access.
+#define NLE_ALLOW_SEEDING 1
+#include "nleobs.h"
+
+typedef struct nle_ctx nle_ctx_t;
+typedef nle_ctx_t* (*nle_start_fn)(nle_obs*, FILE*, nle_seeds_init_t*, nle_settings*);
+typedef nle_ctx_t* (*nle_step_fn)(nle_ctx_t*, nle_obs*);
+typedef void       (*nle_end_fn)(nle_ctx_t*);
+
+// Fast-reset extension (see vendor/nle/src/src/nle_fast_reset.c).
+typedef void* (*nle_fr_snapshot_fn)(nle_ctx_t*);
+typedef void  (*nle_fr_restore_fn) (nle_ctx_t*, void*);
+typedef void  (*nle_fr_destroy_fn) (void*);
+
+// Direct linkage: libnethack.so symbols are resolved at link time, not via
+// dlopen. The wrapper retains env->fn_* function pointers for ABI stability,
+// but they're assigned from these externs — no runtime symbol lookup.
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern nle_ctx_t* nle_start(nle_obs*, FILE*, nle_seeds_init_t*, nle_settings*);
+extern nle_ctx_t* nle_step(nle_ctx_t*, nle_obs*);
+extern void       nle_end(nle_ctx_t*);
+extern void*      nle_fr_snapshot(nle_ctx_t*);
+extern void       nle_fr_restore(nle_ctx_t*, void*);
+extern void       nle_fr_destroy(void*);
+#ifdef __cplusplus
+}
+#endif
+
+// Build flag: -DNETHACK_FAST_RESET=1 enables the snapshot/restore path.
+// Default is OFF — the fast-reset machinery in
+// vendor/nle/src/src/nle_fast_reset.c is fundamentally unsafe for N>1
+// vecenv: nle_fr_restore memcpys back the SHARED bump-arena
+// (alloc.c:75 — "All envs share one arena") and libnethack.so's
+// .data/.bss segments. Under multi-env, that clobbers other envs' live
+// arena allocations and rewinds the bump pointer past their data,
+// producing 'double free in tcache 2' / 'munmap_chunk()' / SIGSEGV.
+// train_bench at N=64 (which uses slow-only resets via nle_end + nle_start)
+// runs 1M steps clean at 414K agg SPS, so slow-only is plenty fast.
+// To re-enable for single-env benchmarks: build with -DNETHACK_FAST_RESET=1.
+#ifndef NETHACK_FAST_RESET
+#define NETHACK_FAST_RESET 0
+#endif
+
+// ---------------------------------------------------------------------------
+// Geometry constants
+// ---------------------------------------------------------------------------
+#define NH_ROWS 21
+#define NH_COLS 79
+#define NH_GRID (NH_ROWS * NH_COLS)
+
+// ---------------------------------------------------------------------------
+// Compile-time observation selection
+// ---------------------------------------------------------------------------
+// Override any of these with -DNETHACK_USE_<FIELD>=0/1. Defaults: chars only.
+// Each enabled field reserves its own slice of the ByteTensor observation
+// buffer; disabled fields are not allocated, not bound, and NLE does not
+// write to them (NLE's fill_obs guards every field with `if (ptr) ...`).
+//
+// Field widths (bytes per element):
+//   chars     uint8     1
+//   colors    uint8     1
+//   specials  uint8     1
+//   glyphs    int16     2  (packed as little-endian)
+//   blstats   int64     4  (truncated to int32 to save space)
+//   message   uint8     1
+//   inv_letters / inv_oclasses  uint8  1  (size NLE_INVENTORY_SIZE)
+//
+// `inv` enables both inv_letters and inv_oclasses together (cheap pair).
+// inv_glyphs and inv_strs are deliberately omitted for v1 to keep the
+// observation a flat ByteTensor.
+
+#ifndef NETHACK_USE_CHARS
+#define NETHACK_USE_CHARS    1
+#endif
+#ifndef NETHACK_USE_COLORS
+#define NETHACK_USE_COLORS   0
+#endif
+#ifndef NETHACK_USE_SPECIALS
+#define NETHACK_USE_SPECIALS 0
+#endif
+#ifndef NETHACK_USE_GLYPHS
+#define NETHACK_USE_GLYPHS   0
+#endif
+#ifndef NETHACK_USE_BLSTATS
+#define NETHACK_USE_BLSTATS  0
+#endif
+#ifndef NETHACK_USE_MESSAGE
+#define NETHACK_USE_MESSAGE  0
+#endif
+#ifndef NETHACK_USE_INV
+#define NETHACK_USE_INV      0
+#endif
+
+// Auto-dismiss prompts (welcome screen, --More--, yes/no, getline) before
+// applying the agent's action, by inspecting misc[]={in_yn_function,
+// in_getlin, xwaitingforspace} on every step. These tiny buffers are
+// always allocated (~48 bytes) regardless of obs-field selection. Cap the
+// dismiss loop at NETHACK_AUTODISMISS_MAX iterations to avoid hanging on
+// pathological prompt chains.
+#ifndef NETHACK_AUTODISMISS
+#define NETHACK_AUTODISMISS 1
+#endif
+#ifndef NETHACK_AUTODISMISS_MAX
+#define NETHACK_AUTODISMISS_MAX 64
+#endif
+
+#ifndef NETHACK_MAX_EPISODE_STEPS
+#define NETHACK_MAX_EPISODE_STEPS 10000
+#endif
+
+// Penalty applied to the reward when the agent's action triggers a sub-prompt
+// (illegal/ambiguous action — e.g. "Apply what?" / "What direction?") that
+// we then have to ESC out of. Default -0.01 — small enough that legitimate
+// y/n confirmations during real play don't tank rewards.
+// Per-step reward shaping (compile-time tunable).
+//   reward = (score - prev_score)
+//          + NETHACK_DEPTH_BONUS  if went deeper this step
+//          + NETHACK_SCOUT_BONUS  if entered a previously-unvisited tile
+//          + NETHACK_ILLEGAL_PENALTY  if action triggered a sub-prompt
+#ifndef NETHACK_ILLEGAL_PENALTY
+#define NETHACK_ILLEGAL_PENALTY -0.5f      // -invalid_moves/2 per user spec
+#endif
+#ifndef NETHACK_SCOUT_BONUS
+#define NETHACK_SCOUT_BONUS      0.1f       // for each new tile visited
+#endif
+#ifndef NETHACK_DEPTH_BONUS
+#define NETHACK_DEPTH_BONUS      1.0f       // for each new dungeon level
+#endif
+
+#define NETHACK_SZ_CHARS    (NETHACK_USE_CHARS    * NH_GRID)
+#define NETHACK_SZ_COLORS   (NETHACK_USE_COLORS   * NH_GRID)
+#define NETHACK_SZ_SPECIALS (NETHACK_USE_SPECIALS * NH_GRID)
+#define NETHACK_SZ_GLYPHS   (NETHACK_USE_GLYPHS   * NH_GRID * 2)
+#define NETHACK_SZ_BLSTATS  (NETHACK_USE_BLSTATS  * NLE_BLSTATS_SIZE * 4)
+#define NETHACK_SZ_MESSAGE  (NETHACK_USE_MESSAGE  * NLE_MESSAGE_SIZE)
+#define NETHACK_SZ_INV      (NETHACK_USE_INV      * NLE_INVENTORY_SIZE * 2)
+
+#define NETHACK_OFF_CHARS    0
+#define NETHACK_OFF_COLORS   (NETHACK_OFF_CHARS    + NETHACK_SZ_CHARS)
+#define NETHACK_OFF_SPECIALS (NETHACK_OFF_COLORS   + NETHACK_SZ_COLORS)
+#define NETHACK_OFF_GLYPHS   (NETHACK_OFF_SPECIALS + NETHACK_SZ_SPECIALS)
+#define NETHACK_OFF_BLSTATS  (NETHACK_OFF_GLYPHS   + NETHACK_SZ_GLYPHS)
+#define NETHACK_OFF_MESSAGE  (NETHACK_OFF_BLSTATS  + NETHACK_SZ_BLSTATS)
+#define NETHACK_OFF_INV      (NETHACK_OFF_MESSAGE  + NETHACK_SZ_MESSAGE)
+#define NETHACK_OBS_SIZE     (NETHACK_OFF_INV      + NETHACK_SZ_INV)
+
+#if NETHACK_OBS_SIZE == 0
+#error "At least one NETHACK_USE_* field must be enabled."
+#endif
+
+// Compile-time action set selection.
+//   NETHACK_ACTION_SET == 0  (default, 23 actions) — full reduced set:
+//       8 compass + 8 long-compass + > < . s \r ESC ,
+//   NETHACK_ACTION_SET == 1  (18 actions) — drops the "rarely useful"
+//       keystrokes (`>`, `<`, `,`, `\r`, `ESC`) that early-training
+//       random play burns on no-op/menu states. Keeps movement + wait
+//       + search. Helps lift SPS during the high-reset-rate phase.
+#ifndef NETHACK_ACTION_SET
+#define NETHACK_ACTION_SET 0
+#endif
+
+#if NETHACK_ACTION_SET == 1
+#define NETHACK_NUM_ACTIONS 18
+static const int NETHACK_ACTION_TABLE[NETHACK_NUM_ACTIONS] = {
+    'k','j','h','l','y','u','b','n',
+    'K','J','H','L','Y','U','B','N',
+    '.','s',
+};
+#else
+#define NETHACK_NUM_ACTIONS 23
+static const int NETHACK_ACTION_TABLE[NETHACK_NUM_ACTIONS] = {
+    'k','j','h','l','y','u','b','n',
+    'K','J','H','L','Y','U','B','N',
+    '>','<','.','s','\r',27,',',
+};
+#endif
+
+#define NETHACK_DEFAULT_OPTIONS \
+    "name:Agent-mon-hum-neu-mal," \
+    "autopickup,color,disclose:+i +a +v +g +c +o," \
+    "mention_walls,nobones,nocmdassist,nolegacy,nosparkle," \
+    "pickup_burden:unencumbered,pickup_types:$?!/," \
+    "runmode:teleport,showexp,showscore,time," \
+    /* exp_039: disable bot() status renderer. The botl.c chain feeds
+     * iflags.status_updates -> bot_via_windowport ->
+     * eval_notify_windowport_field -> anything_to_s -> sprintf, eating
+     * ~5% of user CPU formatting a status line nothing reads. The agent
+     * gets stats via update_blstats() reading u.X / youmonst directly. */ \
+    "!status_updates"
+
+typedef struct Log {
+    float perf;
+    float score;
+    float episode_return;
+    float episode_length;
+    float depth;
+    float valid_moves;        // c_steps where the agent's action advanced NetHack's turn counter
+    float illegal_actions;    // c_steps where the agent's action hit a sub-prompt we had to ESC out of
+    float new_tiles;          // unique tiles entered this episode (sums over episodes via Log.n)
+    float n;
+} Log;
+
+typedef struct Nethack {
+    Log log;
+    unsigned char* observations;
+    float* actions;
+    float* rewards;
+    float* terminals;
+    int num_agents;
+
+    // Per-instance dynamic load of libnethack.so.
+    void* dl_handle;
+    int   dl_fd;
+    nle_start_fn fn_start;
+    nle_step_fn  fn_step;
+    nle_end_fn   fn_end;
+    nle_fr_snapshot_fn fn_fr_snapshot;  // NULL if patched lib not present
+    nle_fr_restore_fn  fn_fr_restore;
+    nle_fr_destroy_fn  fn_fr_destroy;
+    void* fr_snapshot;  // populated after first c_reset
+
+    // Lazy reset: c_reset sets this flag, c_step performs the actual reset.
+    // Guarantees reset and step run on the same OMP thread (NLE's coroutine
+    // captures the stack pointer; resetting on a different thread corrupts it).
+    int pending_reset;
+
+    // NLE state
+    nle_ctx_t* ctx;
+    nle_obs obs;
+    nle_settings settings;
+    char vardir[4096];
+
+    // Backing storage — only fields with USE_* enabled are actually allocated.
+    // Conditionally compile these to save memory.
+#if NETHACK_USE_GLYPHS
+    short          glyphs[NH_GRID];
+#endif
+#if NETHACK_USE_CHARS
+    unsigned char  chars[NH_GRID];
+#endif
+#if NETHACK_USE_COLORS
+    unsigned char  colors[NH_GRID];
+#endif
+#if NETHACK_USE_SPECIALS
+    unsigned char  specials[NH_GRID];
+#endif
+#if NETHACK_USE_BLSTATS
+    long           blstats[NLE_BLSTATS_SIZE];
+#endif
+#if NETHACK_USE_MESSAGE
+    unsigned char  message[NLE_MESSAGE_SIZE];
+#endif
+#if NETHACK_USE_INV
+    unsigned char  inv_letters[NLE_INVENTORY_SIZE];
+    unsigned char  inv_oclasses[NLE_INVENTORY_SIZE];
+#endif
+
+    // Always-allocated hook buffers (independent of obs selection).
+    // misc/internal: prompt-state flags for auto-dismiss
+    // blstats: lets us read NLE_BL_TIME to count valid moves
+    // message: scanned for '?' to catch single-key prompts (direction, item)
+    //          that NLE does not expose via the misc[] flags.
+    int           hook_misc[NLE_MISC_SIZE];
+    int           hook_internal[NLE_INTERNAL_SIZE];
+    long          hook_blstats[NLE_BLSTATS_SIZE];
+    unsigned char hook_message[NLE_MESSAGE_SIZE];
+
+    long episode_start_time;
+    long episode_valid_moves;
+    long episode_illegal_actions;
+    long episode_new_tiles;       // unique tiles entered this episode
+
+    // Exploration bitmap for the current dungeon level. Cleared on
+    // dungeon-level change. One bit per (row, col); 21*79 = 1659 bits,
+    // round up to 208 bytes.
+    unsigned char visited[(NH_GRID + 7) / 8];
+    int  visited_level;            // dungeon level the bitmap corresponds to
+
+    int tick;
+    long prev_score;
+    int prev_depth;
+    float episode_return;
+    int episode_length;
+    unsigned int rng;   // required by vecenv.h (seeded with env index)
+
+    // ----- Per-instance reward shaping coefficients -----
+    // Each reward term is independently toggleable: set its coef to 0.0 to
+    // disable. Set from kwargs in my_init (binding.c). Plumb through
+    // `[env]` in config/nethack.ini → CLI `--env.<key>` flags.
+    //
+    // reward = score_coef    * (score - prev_score)               [always >=0]
+    //        + descent_coef  * max(0, depth - prev_depth)         [descent only]
+    //        + scout_coef    * (1 if new tile this step else 0)
+    //        + illegal_pen   * (1 if action triggered sub-prompt else 0)
+    // Defaults below are also the fallbacks when the kwargs key is missing
+    // (so the build still runs if config/nethack.ini hasn't been updated).
+    float score_coef;       // default 0.01f  (R_SCORE)
+    float descent_coef;     // default 1.0f   (R_DESCENT)
+    float scout_coef;       // default NETHACK_SCOUT_BONUS (legacy)
+    float illegal_penalty;  // default NETHACK_ILLEGAL_PENALTY (legacy, negative)
+
+    // Per-env explicit RNG seed for nle_start. Without this, NetHack uses
+    // its own internal seeding and some seeds hit infinite loops in level
+    // generation (mklev/topologize). Seed bases known to work at N=32/64/96:
+    // 0x111, 0x222, 0xCAFEBEEF.  Set via NETHACK_SEED_BASE env var or default.
+    unsigned long seed_a;
+    unsigned long seed_b;
+} Nethack;
+
+// ---------------------------------------------------------------------------
+// Shared libnethack: DIRECT LINKAGE. No dlopen, no dlsym. The library is
+// linked at build time (-lnethack); all envs share the same code and use
+// per-env nle_ctx_t* for state. The migration in vendor/nle/src/* moved
+// every per-game global into nle_ctx_t, so a single shared library
+// supports N envs natively.
+// ---------------------------------------------------------------------------
+static int nethack_load_lib(Nethack* env) {
+    PROF_INIT_IF_NEEDED();
+    PROF_START(reload);
+    // No dlopen — symbols are resolved at link time. Just assign the
+    // function pointers so the rest of the wrapper code (env->fn_step etc.)
+    // continues to work unchanged.
+    env->dl_handle = (void*)1;  // non-NULL sentinel: "library is available"
+    env->dl_fd     = 0;
+    env->fn_start  = &nle_start;
+    env->fn_step   = &nle_step;
+    env->fn_end    = &nle_end;
+    env->fn_fr_snapshot = &nle_fr_snapshot;
+    env->fn_fr_restore  = &nle_fr_restore;
+    env->fn_fr_destroy  = &nle_fr_destroy;
+    PROF_END(reload, PROF_RESET_RELOAD);
+    return 0;
+}
+
+static void nethack_unload_lib(Nethack* env) {
+    // No per-env dlclose; the library handle is process-wide.
+    env->dl_handle = NULL;
+    env->dl_fd = 0;
+    env->fn_start = NULL; env->fn_step = NULL; env->fn_end = NULL;
+}
+
+// ---------------------------------------------------------------------------
+// Per-instance vardir (NetHack expects nhdat + a few touched files)
+// ---------------------------------------------------------------------------
+static void nethack_touch(const char* path) {
+    int fd = open(path, O_CREAT | O_WRONLY, 0644);
+    if (fd >= 0) close(fd);
+}
+
+static int nethack_make_vardir(const char* source_hackdir, char* out_buf, size_t out_cap) {
+    PROF_START(vardir);
+    char tmpl[] = "/tmp/nle-XXXXXX";
+    char* dir = mkdtemp(tmpl);
+    if (dir == NULL) return -1;
+    if ((size_t)snprintf(out_buf, out_cap, "%s", dir) >= out_cap) return -1;
+
+    char abs_source[4096];
+    if (source_hackdir[0] == '/') {
+        snprintf(abs_source, sizeof(abs_source), "%s", source_hackdir);
+    } else {
+        char cwd[2048];
+        if (getcwd(cwd, sizeof(cwd)) == NULL) return -1;
+        snprintf(abs_source, sizeof(abs_source), "%s/%s", cwd, source_hackdir);
+    }
+
+    char src[4096], dst[4096];
+    snprintf(src, sizeof(src), "%s/nhdat", abs_source);
+    snprintf(dst, sizeof(dst), "%s/nhdat", dir);
+
+    // Fail-fast: verify the source nhdat actually exists before creating the
+    // symlink. symlink(2) succeeds for dangling links, so without this check
+    // a broken NETHACKDIR (or a cwd-shifted relative default) surfaces 100ms
+    // later as a libnethack panic in init_dungeons("Cannot open dungeon
+    // description - 'dungeon'..."), which looks like a concurrency crash but
+    // is actually a config error. See exp_033_cluster_az/REDIAG.md.
+    char resolved[4096];
+    char cwd_dbg[2048] = "(unknown)";
+    getcwd(cwd_dbg, sizeof(cwd_dbg));
+    if (realpath(src, resolved) == NULL || access(resolved, R_OK) != 0) {
+        fprintf(stderr,
+                "nethack: NETHACKDIR is misconfigured.\n"
+                "  Expected to find nhdat at: %s\n"
+                "  (source_hackdir=\"%s\", cwd=\"%s\")\n"
+                "  realpath/access failed: %s\n"
+                "  Set NETHACKDIR to an ABSOLUTE path pointing at a directory\n"
+                "  containing nhdat (e.g. <repo>/vendor/nle/nethackdir).\n",
+                src, source_hackdir, cwd_dbg, strerror(errno));
+        exit(1);
+    }
+    if (symlink(src, dst) != 0) return -1;
+    const char* touched[] = {"perm", "record", "logfile", "xlogfile"};
+    for (size_t i = 0; i < 4; i++) {
+        snprintf(dst, sizeof(dst), "%s/%s", dir, touched[i]);
+        nethack_touch(dst);
+    }
+    snprintf(dst, sizeof(dst), "%s/save", dir);
+    mkdir(dst, 0755);
+    PROF_END(vardir, PROF_RESET_VARDIR);
+    return 0;
+}
+
+static void nethack_rm_vardir(const char* dir) {
+    if (dir == NULL || dir[0] == '\0') return;
+    char p[4096];
+    const char* files[] = {"nhdat", "perm", "record", "logfile", "xlogfile", "paniclog", "save"};
+    for (size_t i = 0; i < sizeof(files)/sizeof(files[0]); i++) {
+        snprintf(p, sizeof(p), "%s/%s", dir, files[i]);
+        if (i == 6) rmdir(p); else unlink(p);
+    }
+    rmdir(dir);
+}
+
+// ---------------------------------------------------------------------------
+// Bind obs pointers — only enabled fields, others stay NULL so NLE skips them
+// ---------------------------------------------------------------------------
+static void nethack_bind_obs(Nethack* env) {
+    nle_obs* o = &env->obs;
+    memset(o, 0, sizeof(*o));
+#if NETHACK_USE_CHARS
+    o->chars = env->chars;
+#endif
+#if NETHACK_USE_COLORS
+    o->colors = env->colors;
+#endif
+#if NETHACK_USE_SPECIALS
+    o->specials = env->specials;
+#endif
+#if NETHACK_USE_GLYPHS
+    o->glyphs = env->glyphs;
+#endif
+#if NETHACK_USE_BLSTATS
+    o->blstats = env->blstats;
+#endif
+#if NETHACK_USE_MESSAGE
+    o->message = env->message;
+#endif
+#if NETHACK_USE_INV
+    o->inv_letters  = env->inv_letters;
+    o->inv_oclasses = env->inv_oclasses;
+#endif
+    // Always bind misc/internal so the hook can read prompt-state flags
+    // independent of which obs fields the user selected. blstats/message are
+    // only bound to hook_* when the user opted them OUT of the obs tensor —
+    // otherwise they are already bound to env->{blstats,message} above.
+    o->misc     = env->hook_misc;
+    o->internal = env->hook_internal;
+#if !NETHACK_USE_BLSTATS
+    o->blstats  = env->hook_blstats;
+#endif
+#if !NETHACK_USE_MESSAGE
+    o->message  = env->hook_message;
+#endif
+}
+
+// Pointers we can always read for the hook, regardless of NETHACK_USE_*.
+static inline const unsigned char* nethack_msg(const Nethack* env) {
+#if NETHACK_USE_MESSAGE
+    return env->message;
+#else
+    return env->hook_message;
+#endif
+}
+
+// Read NetHack's current turn counter regardless of which obs fields are bound.
+static inline long nethack_current_time(const Nethack* env) {
+#if NETHACK_USE_BLSTATS
+    return env->blstats[NLE_BL_TIME];
+#else
+    return env->hook_blstats[NLE_BL_TIME];
+#endif
+}
+
+// Auto-dismiss: while NLE reports an active prompt (welcome/--More--/yn/getlin),
+// inject the appropriate dismiss keystroke until the game is back at the
+// main command prompt. counter_id distinguishes the calling site so the
+// profiler can attribute fn_step calls correctly. Returns # fn_step calls made.
+static int nethack_drain_prompts_cat(Nethack* env, ProfCounterId fn_step_counter) {
+    int n = 0;
+#if NETHACK_AUTODISMISS
+    for (int i = 0; i < NETHACK_AUTODISMISS_MAX; i++) {
+        int xwait = env->hook_misc[2];
+        int yn    = env->hook_misc[0];
+        int gl    = env->hook_misc[1];
+        if (!xwait && !yn && !gl) break;
+        if (xwait)      { env->obs.action = '\r'; PROF_COUNT(PROF_XWAIT_DRAIN, 1); }
+        else if (yn)    { env->obs.action = 27;   PROF_COUNT(PROF_MISC_YN_ESC, 1); }
+        else /* gl */   { env->obs.action = '\r'; PROF_COUNT(PROF_MISC_GETLIN_ESC, 1); }
+        env->ctx = env->fn_step(env->ctx, &env->obs);
+        n++;
+        PROF_COUNT(PROF_FN_STEPS_TOTAL, 1);
+        PROF_COUNT(fn_step_counter, 1);
+        if (env->obs.done) break;
+    }
+#endif
+    return n;
+}
+
+static void nethack_init_settings(Nethack* env) {
+    memset(&env->settings, 0, sizeof(env->settings));
+    const char* source = getenv("NETHACKDIR");
+    if (source == NULL) source = "./vendor/nle/nethackdir";
+
+    if (nethack_make_vardir(source, env->vardir, sizeof(env->vardir)) != 0) {
+        fprintf(stderr, "nethack: failed to create vardir from source=%s\n", source);
+        strncpy(env->settings.hackdir, source, sizeof(env->settings.hackdir) - 1);
+    } else {
+        strncpy(env->settings.hackdir, env->vardir, sizeof(env->settings.hackdir) - 1);
+    }
+    env->settings.scoreprefix[0] = '\0';
+    env->settings.spawn_monsters = 1;
+    env->settings.ttyrecname[0] = '\0';
+    strncpy(env->settings.options, NETHACK_DEFAULT_OPTIONS, sizeof(env->settings.options) - 1);
+    env->settings.wizkit[0] = '\0';
+}
+
+void init(Nethack* env) {
+    env->ctx = NULL;
+    env->tick = 0;
+    env->prev_score = 0;
+    env->prev_depth = 1;
+    env->episode_return = 0.0f;
+    env->episode_length = 0;
+    env->vardir[0] = '\0';
+    env->dl_handle = NULL; env->dl_fd = 0;
+    env->fn_fr_snapshot = NULL;
+    env->fn_fr_restore = NULL;
+    env->fn_fr_destroy = NULL;
+    env->fr_snapshot = NULL;
+
+    // Default reward shaping coefficients. Overridable from kwargs in my_init
+    // (binding.c) before any reset/step occurs. If a binding chooses not to
+    // populate these (e.g. standalone train_bench, replay_view), the defaults
+    // below preserve the legacy compile-time behavior for descent + scout +
+    // illegal, and use R_SCORE=0.01 per ocean/nethack/REWARDS.md.
+    env->score_coef      = 0.01f;
+    env->descent_coef    = NETHACK_DEPTH_BONUS;     // 1.0f
+    env->scout_coef      = NETHACK_SCOUT_BONUS;     // 0.1f
+    env->illegal_penalty = NETHACK_ILLEGAL_PENALTY; // -0.5f
+
+    // Pick per-env seeds derived from env->rng (vecenv sets this to env index)
+    // and a process-wide base. Same construction train_bench uses at N=64,
+    // which avoids the upstream mklev hang.
+    unsigned long base = 0xCAFEBEEFUL;
+    const char* sb = getenv("NETHACK_SEED_BASE");
+    if (sb) {
+        char* end = NULL;
+        unsigned long v = strtoul(sb, &end, 0);
+        if (end && end != sb) base = v;
+    }
+    env->seed_a = base + (unsigned long)env->rng;
+    env->seed_b = (base ^ 0x9E3779B97F4A7C15UL) + (unsigned long)env->rng;
+    // Don't load_lib here — c_reset will do it on first call. Avoids a
+    // redundant ~180 ms dlopen+nle_start before the user even resets.
+    nethack_init_settings(env);
+    nethack_bind_obs(env);
+}
+
+void c_close(Nethack* env) {
+    if (env->fr_snapshot && env->fn_fr_destroy) {
+        env->fn_fr_destroy(env->fr_snapshot);
+        env->fr_snapshot = NULL;
+    }
+    if (env->ctx != NULL && env->fn_end) {
+        env->fn_end(env->ctx);
+        env->ctx = NULL;
+    }
+    nethack_unload_lib(env);
+    nethack_rm_vardir(env->vardir);
+    env->vardir[0] = '\0';
+}
+
+// ---------------------------------------------------------------------------
+// Observation packing: copy enabled fields into the flat ByteTensor buffer
+// ---------------------------------------------------------------------------
+static void nethack_pack_obs(Nethack* env) {
+    unsigned char* o = env->observations;
+#if NETHACK_USE_CHARS
+    memcpy(o + NETHACK_OFF_CHARS, env->chars, NETHACK_SZ_CHARS);
+#endif
+#if NETHACK_USE_COLORS
+    memcpy(o + NETHACK_OFF_COLORS, env->colors, NETHACK_SZ_COLORS);
+#endif
+#if NETHACK_USE_SPECIALS
+    memcpy(o + NETHACK_OFF_SPECIALS, env->specials, NETHACK_SZ_SPECIALS);
+#endif
+#if NETHACK_USE_GLYPHS
+    memcpy(o + NETHACK_OFF_GLYPHS, env->glyphs, NETHACK_SZ_GLYPHS);
+#endif
+#if NETHACK_USE_BLSTATS
+    // Pack 27 longs as 27 int32s (truncate; NetHack stat values fit in i32).
+    int32_t* dst = (int32_t*)(o + NETHACK_OFF_BLSTATS);
+    for (int i = 0; i < NLE_BLSTATS_SIZE; i++) dst[i] = (int32_t)env->blstats[i];
+#endif
+#if NETHACK_USE_MESSAGE
+    memcpy(o + NETHACK_OFF_MESSAGE, env->message, NETHACK_SZ_MESSAGE);
+#endif
+#if NETHACK_USE_INV
+    memcpy(o + NETHACK_OFF_INV,                          env->inv_letters,  NLE_INVENTORY_SIZE);
+    memcpy(o + NETHACK_OFF_INV + NLE_INVENTORY_SIZE,     env->inv_oclasses, NLE_INVENTORY_SIZE);
+#endif
+}
+
+static void nethack_add_log(Nethack* env) {
+    env->log.perf            += (float)env->prev_score;
+    env->log.score           += (float)env->prev_score;
+    env->log.depth           += (float)env->prev_depth;
+    env->log.valid_moves     += (float)env->episode_valid_moves;
+    env->log.illegal_actions += (float)env->episode_illegal_actions;
+    env->log.new_tiles       += (float)env->episode_new_tiles;
+    env->log.episode_return  += env->episode_return;
+    env->log.episode_length  += env->episode_length;
+    env->log.n               += 1.0f;
+}
+
+// Per-episode bookkeeping reset (counters, exploration bitmap, obs pack).
+// Called by both the slow and fast c_reset paths.
+static void nethack_reset_bookkeeping(Nethack* env) {
+    env->tick = 0;
+    env->prev_score = 0;
+#if NETHACK_USE_BLSTATS
+    env->prev_depth = (int)env->blstats[NLE_BL_DEPTH];
+#else
+    env->prev_depth = 1;
+#endif
+    env->episode_return = 0.0f;
+    env->episode_length = 0;
+    env->episode_start_time = nethack_current_time(env);
+    env->episode_valid_moves = 0;
+    env->episode_illegal_actions = 0;
+    env->episode_new_tiles = 0;
+    memset(env->visited, 0, sizeof(env->visited));
+    env->visited_level = 0;
+    env->rewards[0] = 0.0f;
+    env->terminals[0] = 0.0f;
+    PROF_START(reset_obs_pack);
+    nethack_pack_obs(env);
+    PROF_END(reset_obs_pack, PROF_OBS_PACK);
+}
+
+// Slow path: dlopen + nle_start + drain welcome. Called on first c_reset
+// (and on every reset when NETHACK_FAST_RESET is disabled).
+//
+// The previous process-wide nethack_slow_reset_mu is removed.
+// All named hazards it guarded are now safe under concurrent c_reset:
+//   - choose_windows / windowprocs: idempotent CAS-guarded first-init-wins
+//     in vendor/nle/src/src/windows.c.
+//   - dlb_init / dlb_libs[]: idempotent CAS-guarded first-init-wins in
+//     vendor/nle/src/src/dlb.c.
+//   - nle_baseline: lazily allocated empty `struct nle_dungeon_save` whose
+//     save/load functions are no-ops; even a
+//     concurrent double-calloc only leaks one zero-filled blob.
+//   - init_artifacts memset of artidisco[]: artidisco is now per-env on
+//     nle_ctx_t (see previous commit).
+//   - All "many libnethack `.data` globals" called out in the original
+//     comment: now fully migrated. Every write reached from nle_start -> init_nle ->
+//     mainloop -> unixmain -> moveloop -> init_nethack / u_init /
+//     init_dungeons / init_objects / init_artifacts now targets a
+//     current_nle_ctx->s_* field (or a same-value-every-time process-shared
+//     register that is idempotent across envs).
+//
+// Removing the mutex restores concurrent reset: with N envs spread across
+// pthread workers, env i's c_reset no longer serializes against env j's.
+static void nethack_slow_reset(Nethack* env) {
+    PROF_START(nle_end);
+    if (env->ctx != NULL && env->fn_end) {
+        env->fn_end(env->ctx);
+        env->ctx = NULL;
+    }
+    if (env->dl_handle != NULL) {
+        nethack_unload_lib(env);
+    }
+    PROF_END(nle_end, PROF_RESET_NLE_END);
+
+    if (nethack_load_lib(env) != 0) {
+        fprintf(stderr, "nethack: failed to reload libnethack on reset\n");
+        return;
+    }
+    nethack_bind_obs(env);
+    env->obs.action = 0;
+    env->obs.done = 0;
+    env->obs.in_normal_game = 0;
+    env->obs.how_done = 0;
+
+    if (env->fn_start == NULL) {
+        fprintf(stderr, "nethack: fn_start is NULL — load_lib failed\n");
+        return;
+    }
+    PROF_START(nle_start);
+    // Advance the per-env LCG so each reset gets a fresh seed. Without
+    // explicit seeds, NetHack's internal randomness can land on level-gen
+    // seeds that infinite-loop in mklev/topologize. The LCG constants
+    // (Numerical Recipes / MMIX) are the same as train_bench.
+    env->seed_a = env->seed_a * 6364136223846793005UL + 1442695040888963407UL;
+    env->seed_b = env->seed_b * 6364136223846793005UL + 1442695040888963407UL;
+    nle_seeds_init_t seeds;
+    memset(&seeds, 0, sizeof(seeds));
+    seeds.seeds[0] = env->seed_a;
+    seeds.seeds[1] = env->seed_b;
+    seeds.reseed = 0;
+    env->ctx = env->fn_start(&env->obs, NULL, &seeds, &env->settings);
+    PROF_END(nle_start, PROF_RESET_NLE_START);
+
+    PROF_START(reset_drain);
+    nethack_drain_prompts_cat(env, PROF_FN_STEPS_RESET_DRAIN);
+    PROF_END(reset_drain, PROF_RESET_DRAIN);
+}
+
+static void nethack_do_reset(Nethack* env) {
+    PROF_INIT_IF_NEEDED();
+    PROF_START(reset_total);
+    PROF_COUNT(PROF_C_RESETS, 1);
+
+#if NETHACK_FAST_RESET
+    if (env->fr_snapshot && env->fn_fr_restore) {
+        env->fn_fr_restore(env->ctx, env->fr_snapshot);
+        nethack_bind_obs(env);
+        env->obs.done = 0;
+        env->obs.in_normal_game = 0;
+        env->obs.how_done = 0;
+        nethack_reset_bookkeeping(env);
+        PROF_END(reset_total, PROF_C_RESET_TOTAL);
+        return;
+    }
+#endif
+
+    nethack_slow_reset(env);
+
+#if NETHACK_FAST_RESET
+    if (env->fn_fr_snapshot && env->fr_snapshot == NULL && env->ctx) {
+        env->fr_snapshot = env->fn_fr_snapshot(env->ctx);
+        if (env->fr_snapshot == NULL) {
+            fprintf(stderr, "nethack: nle_fr_snapshot returned NULL; "
+                            "fast-reset will fall back to slow path\n");
+        }
+    } else if (env->fn_fr_snapshot == NULL && env->fr_snapshot == NULL) {
+        static int warned = 0;
+        if (!warned) {
+            fprintf(stderr, "nethack: NETHACK_FAST_RESET=1 but loaded "
+                            "libnethack.so does not export nle_fr_snapshot; "
+                            "falling back to slow path\n");
+            warned = 1;
+        }
+    }
+#endif
+
+    nethack_reset_bookkeeping(env);
+    PROF_END(reset_total, PROF_C_RESET_TOTAL);
+}
+
+void c_reset(Nethack* env) {
+    env->pending_reset = 1;
+}
+
+void c_step(Nethack* env) {
+    if (env->pending_reset) {
+        env->pending_reset = 0;
+        nethack_do_reset(env);
+    }
+    PROF_INIT_IF_NEEDED();
+    PROF_START(c_step_total);
+    PROF_COUNT(PROF_C_STEPS, 1);
+#if NETHACK_PROFILE
+    unsigned long fn_step_calls_before = g_prof.counters[PROF_FN_STEPS_TOTAL];
+#endif
+    int action_idx = (int)env->actions[0];
+    if (action_idx < 0) action_idx = 0;
+    if (action_idx >= NETHACK_NUM_ACTIONS) action_idx = NETHACK_NUM_ACTIONS - 1;
+    env->obs.action = NETHACK_ACTION_TABLE[action_idx];
+
+    long time_before = nethack_current_time(env);
+    PROF_START(agent_fn_step);
+    env->ctx = env->fn_step(env->ctx, &env->obs);
+    PROF_END(agent_fn_step, PROF_AGENT_FN_STEP);
+    PROF_COUNT(PROF_FN_STEPS_TOTAL, 1);
+    PROF_COUNT(PROF_FN_STEPS_AGENT, 1);
+
+    // Determine whether the agent's action landed in a sub-prompt:
+    //   (a) misc[] flags (yn / getlin) — strong signal
+    //   (b) message ends with '?' — catches single-key prompts NLE doesn't
+    //       expose via misc, e.g. "In what direction do you want to throw?",
+    //       "Apply what?", "What do you want to wield?". Legitimate game
+    //       messages ("It's a wall.", "You feel...") don't end in '?'.
+    int yn_or_getlin = (env->hook_misc[0] || env->hook_misc[1]);
+    int xwait        = env->hook_misc[2];
+    int msg_is_prompt = 0;
+    const unsigned char* msg = nethack_msg(env);
+    if (msg[0]) {
+        int end = 0;
+        while (end < NLE_MESSAGE_SIZE && msg[end]) end++;
+        // Trim trailing spaces.
+        while (end > 0 && msg[end-1] == ' ') end--;
+        if (end > 0 && msg[end-1] == '?') msg_is_prompt = 1;
+    }
+
+    int illegal = yn_or_getlin || msg_is_prompt;
+    PROF_START(post_drain);
+    if (illegal) {
+        // Auto-dismiss prompts the agent can't handle:
+        //   yn_function (misc[0]): answer 'y' — commit to the action the agent chose
+        //   getlin (misc[1]): ESC — can't type a string
+        //   --More-- / trailing '?': ESC
+        for (int i = 0; i < NETHACK_AUTODISMISS_MAX; i++) {
+            int is_yn   = env->hook_misc[0];
+            int is_getlin = env->hook_misc[1];
+            int is_xwait  = env->hook_misc[2];
+            int still_prompt = (is_yn || is_getlin || is_xwait);
+            if (!still_prompt) {
+                const unsigned char* m2 = nethack_msg(env);
+                int e = 0; while (e < NLE_MESSAGE_SIZE && m2[e]) e++;
+                while (e > 0 && m2[e-1] == ' ') e--;
+                if (e == 0 || m2[e-1] != '?') break;
+            }
+            env->obs.action = is_yn ? 'y' : 27;  // yn→yes, everything else→ESC
+            env->ctx = env->fn_step(env->ctx, &env->obs);
+            PROF_COUNT(PROF_FN_STEPS_TOTAL, 1);
+            PROF_COUNT(PROF_FN_STEPS_POST_DRAIN, 1);
+            PROF_COUNT(PROF_MSG_PROMPT_ESC, msg_is_prompt && !yn_or_getlin ? 1 : 0);
+            if (env->obs.done) break;
+        }
+        env->episode_illegal_actions++;
+        PROF_COUNT(PROF_ILLEGAL_ACTIONS, 1);
+    } else if (xwait) {
+        nethack_drain_prompts_cat(env, PROF_FN_STEPS_POST_DRAIN);
+    }
+    PROF_END(post_drain, PROF_POST_DRAIN);
+
+    long time_after = nethack_current_time(env);
+    if (time_after > time_before) {
+        env->episode_valid_moves++;
+        PROF_COUNT(PROF_VALID_MOVES, 1);
+    } else {
+        // No time advance: classify why.
+        if (illegal) {
+            PROF_COUNT(PROF_NOADV_PROMPT_DETECTED, 1);
+        } else {
+            // No prompt detected. Did NetHack at least show a message?
+            const unsigned char* m = nethack_msg(env);
+            if (m[0]) PROF_COUNT(PROF_NOADV_HAS_MSG, 1);
+            else      PROF_COUNT(PROF_NOADV_SILENT, 1);
+        }
+    }
+
+    env->tick++;
+    env->episode_length++;
+
+    long score = 0; int depth = env->prev_depth;
+    long px = 0, py = 0;
+#if NETHACK_USE_BLSTATS
+    score = env->blstats[NLE_BL_SCORE];
+    depth = (int)env->blstats[NLE_BL_DEPTH];
+    px = env->blstats[NLE_BL_X];
+    py = env->blstats[NLE_BL_Y];
+#else
+    score = env->hook_blstats[NLE_BL_SCORE];
+    depth = (int)env->hook_blstats[NLE_BL_DEPTH];
+    px = env->hook_blstats[NLE_BL_X];
+    py = env->hook_blstats[NLE_BL_Y];
+#endif
+    // ---- Reward shaping (each term independently toggleable) ----
+    // See ocean/nethack/REWARDS.md for the recipe to add more terms.
+    // score-delta term: positive whenever NetHack's score increases (kills,
+    // depth, gold pickup, etc.). Score is monotonic non-decreasing modulo
+    // some rare deaths/penalties; set score_coef=0 to disable entirely.
+    float reward = env->score_coef * (float)(score - env->prev_score);
+
+    // Depth-changed bonus + reset exploration bitmap.
+    if (depth != env->visited_level) {
+        memset(env->visited, 0, sizeof(env->visited));
+        env->visited_level = depth;
+    }
+    // Descent term: one-shot bonus on each new max-depth step (positive only
+    // — we never charge the agent for going back up, so it cannot game the
+    // signal by yo-yo'ing between levels via score-delta on score loss).
+    if (depth > env->prev_depth) reward += env->descent_coef * (float)(depth - env->prev_depth);
+
+    // Scout bonus: reward each new (row,col) entered this level.
+    // px is column (0..79), py is row (0..21). Clamp defensively.
+    if (px >= 0 && px < NH_COLS && py >= 0 && py < NH_ROWS) {
+        int bit_idx = (int)py * NH_COLS + (int)px;
+        unsigned char* b = &env->visited[bit_idx >> 3];
+        unsigned char mask = (unsigned char)(1 << (bit_idx & 7));
+        if (!(*b & mask)) {
+            *b |= mask;
+            reward += env->scout_coef;
+            env->episode_new_tiles++;
+        }
+    }
+
+    if (illegal) reward += env->illegal_penalty;
+    if (!env->obs.done) {
+        env->prev_score = score;
+        env->prev_depth = depth;
+    }
+
+    env->rewards[0] = reward;
+    env->episode_return += reward;
+
+    if (env->obs.done || env->episode_length >= NETHACK_MAX_EPISODE_STEPS) {
+        env->terminals[0] = 1.0f;
+        nethack_add_log(env);
+        PROF_START(obs_pack_done);
+        nethack_pack_obs(env);
+        PROF_END(obs_pack_done, PROF_OBS_PACK);
+        PROF_END(c_step_total, PROF_C_STEP_TOTAL);
+        PROF_FN_STEPS_PER_C_STEP(g_prof.counters[PROF_FN_STEPS_TOTAL] - fn_step_calls_before);
+        c_reset(env);
+        return;
+    }
+    env->terminals[0] = 0.0f;
+    PROF_START(obs_pack);
+    nethack_pack_obs(env);
+    PROF_END(obs_pack, PROF_OBS_PACK);
+    PROF_END(c_step_total, PROF_C_STEP_TOTAL);
+    PROF_FN_STEPS_PER_C_STEP(g_prof.counters[PROF_FN_STEPS_TOTAL] - fn_step_calls_before);
+}
+
+void c_render(Nethack* env) {
+    printf("\x1b[H\x1b[2J");
+#if NETHACK_USE_CHARS
+    for (int r = 0; r < NH_ROWS; r++) {
+        for (int c = 0; c < NH_COLS; c++) {
+            unsigned char ch = env->chars[r * NH_COLS + c];
+            putchar(ch ? ch : ' ');
+        }
+        putchar('\n');
+    }
+#else
+    printf("(chars obs disabled)\n");
+#endif
+#if NETHACK_USE_BLSTATS
+    printf("HP %ld/%ld  AC %ld  Dlvl %ld  Score %ld  T %ld\n",
+           env->blstats[NLE_BL_HP], env->blstats[NLE_BL_HPMAX],
+           env->blstats[NLE_BL_AC],
+           env->blstats[NLE_BL_DEPTH],
+           env->blstats[NLE_BL_SCORE],
+           env->blstats[NLE_BL_TIME]);
+#endif
+#if NETHACK_USE_MESSAGE
+    printf("Msg: %.*s\n", NLE_MESSAGE_SIZE, env->message);
+#endif
+    fflush(stdout);
+}

--- a/ocean/nethack/profile.h
+++ b/ocean/nethack/profile.h
@@ -1,0 +1,244 @@
+// Profiler for the NetHack env. Gated by -DNETHACK_PROFILE=1 so production
+// builds pay no cost.
+//
+// Design:
+//   * monotonic-clock nanoseconds, captured via clock_gettime(CLOCK_MONOTONIC)
+//   * one struct NethackProfile per env (typically singleton during profiling)
+//   * each metric tracks count + sum_ns + min/max + log2 histogram (24 buckets,
+//     covers 1ns .. 16s)
+//   * counters for fn_step calls (split agent vs drain vs reset-drain)
+//   * JSON dump via prof_dump_json(path)
+//
+// Zero allocation in the hot path; the profile struct is allocated once and
+// reused. Histograms are unsigned long, so 50M+ samples per bucket fit fine.
+
+#ifndef NETHACK_PROFILE_H
+#define NETHACK_PROFILE_H
+
+#include <time.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#ifndef NETHACK_PROFILE
+#define NETHACK_PROFILE 0
+#endif
+
+#define PROF_HIST_BUCKETS 24   // bucket k covers [2^k, 2^(k+1)) ns
+
+typedef struct ProfMetric {
+    const char* name;
+    unsigned long count;
+    unsigned long long sum_ns;
+    unsigned long long min_ns;   // 0 means unset
+    unsigned long long max_ns;
+    unsigned long      hist[PROF_HIST_BUCKETS];
+} ProfMetric;
+
+// Categories of c_step phases we time.
+typedef enum {
+    PROF_C_STEP_TOTAL,         // whole c_step
+    PROF_AGENT_FN_STEP,        // the one fn_step that consumes the agent action
+    PROF_POST_DRAIN,            // fn_step calls after the agent action (xwait or ESC)
+    PROF_OBS_PACK,             // memcpy obs fields into the tensor
+    PROF_C_RESET_TOTAL,        // whole c_reset
+    PROF_RESET_NLE_END,        // fn_end + dlclose
+    PROF_RESET_RELOAD,         // open + memfd_create + copy + dlopen + dlsym
+    PROF_RESET_VARDIR,         // mkdtemp + symlink + touch
+    PROF_RESET_NLE_START,      // fn_start (NetHack init + first yield)
+    PROF_RESET_DRAIN,          // welcome-screen drain after nle_start
+    PROF_METRIC_COUNT,
+} ProfMetricId;
+
+static const char* PROF_METRIC_NAMES[PROF_METRIC_COUNT] = {
+    "c_step_total",
+    "agent_fn_step",
+    "post_drain",
+    "obs_pack",
+    "c_reset_total",
+    "reset_nle_end",
+    "reset_reload",
+    "reset_vardir",
+    "reset_nle_start",
+    "reset_drain",
+};
+
+// Counters (simple long, no histogram).
+typedef enum {
+    PROF_FN_STEPS_TOTAL,       // every fn_step call regardless of phase
+    PROF_FN_STEPS_AGENT,
+    PROF_FN_STEPS_POST_DRAIN,
+    PROF_FN_STEPS_RESET_DRAIN,
+    PROF_C_STEPS,
+    PROF_C_RESETS,
+    PROF_VALID_MOVES,
+    PROF_ILLEGAL_ACTIONS,
+    PROF_MSG_PROMPT_ESC,        // ESCed due to message-ending '?'
+    PROF_MISC_YN_ESC,           // ESCed due to in_yn_function
+    PROF_MISC_GETLIN_ESC,       // ESCed due to in_getlin
+    PROF_XWAIT_DRAIN,           // \r sent to dismiss --More--
+    PROF_AGENT_FN_STEPS_PER_C_STEP_SUM,  // reserved
+    // No-time-advance diagnostics. After the agent's fn_step, if time did
+    // not advance, classify what we found:
+    PROF_NOADV_PROMPT_DETECTED, // misc flags or message-'?' -> illegal handled elsewhere
+    PROF_NOADV_HAS_MSG,         // no detected prompt, but a message was shown
+                                // (e.g. "It's a wall.", "There is nothing here.")
+    PROF_NOADV_SILENT,          // no prompt, no message — action was an outright no-op
+    PROF_COUNTER_COUNT,
+} ProfCounterId;
+
+static const char* PROF_COUNTER_NAMES[PROF_COUNTER_COUNT] = {
+    "fn_steps_total",
+    "fn_steps_agent",
+    "fn_steps_post_drain",
+    "fn_steps_reset_drain",
+    "c_steps",
+    "c_resets",
+    "valid_moves",
+    "illegal_actions",
+    "msg_prompt_esc",
+    "misc_yn_esc",
+    "misc_getlin_esc",
+    "xwait_drain",
+    "agent_fn_steps_sum",
+    "noadv_prompt_detected",
+    "noadv_has_msg",
+    "noadv_silent",
+};
+
+typedef struct NethackProfile {
+    ProfMetric metrics[PROF_METRIC_COUNT];
+    unsigned long long counters[PROF_COUNTER_COUNT];
+    unsigned long fn_steps_per_c_step_hist[PROF_HIST_BUCKETS];
+    int initialized;
+} NethackProfile;
+
+// Single global profile instance. We always allocate it (small: ~5KB) but the
+// hot-path macros below only touch it if NETHACK_PROFILE=1.
+static NethackProfile g_prof;
+
+static inline void prof_init(void) {
+    memset(&g_prof, 0, sizeof(g_prof));
+    for (int i = 0; i < PROF_METRIC_COUNT; i++) {
+        g_prof.metrics[i].name = PROF_METRIC_NAMES[i];
+        g_prof.metrics[i].min_ns = 0;
+    }
+    g_prof.initialized = 1;
+}
+
+static inline unsigned long long prof_now_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (unsigned long long)ts.tv_sec * 1000000000ull + (unsigned long long)ts.tv_nsec;
+}
+
+static inline int prof_log2_bucket(unsigned long long ns) {
+    if (ns == 0) return 0;
+    int b = 0;
+    while (ns >= 2 && b < PROF_HIST_BUCKETS - 1) { ns >>= 1; b++; }
+    return b;
+}
+
+static inline void prof_record(ProfMetricId id, unsigned long long ns) {
+    ProfMetric* m = &g_prof.metrics[id];
+    m->count++;
+    m->sum_ns += ns;
+    if (m->min_ns == 0 || ns < m->min_ns) m->min_ns = ns;
+    if (ns > m->max_ns) m->max_ns = ns;
+    m->hist[prof_log2_bucket(ns)]++;
+}
+
+static inline void prof_count(ProfCounterId id, unsigned long long n) {
+    g_prof.counters[id] += n;
+}
+
+static inline void prof_record_fn_steps_per_c_step(unsigned long n) {
+    g_prof.fn_steps_per_c_step_hist[prof_log2_bucket(n ? n : 1)]++;
+}
+
+// ---- gated macros for hot path ----
+#if NETHACK_PROFILE
+#define PROF_START(name) unsigned long long _pt_##name = prof_now_ns()
+#define PROF_END(name, id) prof_record(id, prof_now_ns() - _pt_##name)
+#define PROF_COUNT(id, n) prof_count(id, (unsigned long long)(n))
+#define PROF_FN_STEPS_PER_C_STEP(n) prof_record_fn_steps_per_c_step(n)
+#define PROF_INIT_IF_NEEDED() do { if (!g_prof.initialized) prof_init(); } while (0)
+#else
+#define PROF_START(name) ((void)0)
+#define PROF_END(name, id) ((void)0)
+#define PROF_COUNT(id, n) ((void)0)
+#define PROF_FN_STEPS_PER_C_STEP(n) ((void)0)
+#define PROF_INIT_IF_NEEDED() ((void)0)
+#endif
+
+// ---- JSON dump ----
+static void prof_dump_json(FILE* f, double wall_seconds) {
+    fprintf(f, "{\n");
+    fprintf(f, "  \"wall_seconds\": %.6f,\n", wall_seconds);
+    fprintf(f, "  \"counters\": {\n");
+    for (int i = 0; i < PROF_COUNTER_COUNT; i++) {
+        fprintf(f, "    \"%s\": %llu%s\n", PROF_COUNTER_NAMES[i],
+                g_prof.counters[i], (i == PROF_COUNTER_COUNT - 1) ? "" : ",");
+    }
+    fprintf(f, "  },\n");
+
+    // Derived
+    double secs = wall_seconds > 0 ? wall_seconds : 1.0;
+    fprintf(f, "  \"derived\": {\n");
+    fprintf(f, "    \"c_steps_per_sec\": %.1f,\n",
+            g_prof.counters[PROF_C_STEPS] / secs);
+    fprintf(f, "    \"valid_moves_per_sec\": %.1f,\n",
+            g_prof.counters[PROF_VALID_MOVES] / secs);
+    fprintf(f, "    \"valid_moves_per_c_step\": %.4f,\n",
+            g_prof.counters[PROF_C_STEPS] ?
+              (double)g_prof.counters[PROF_VALID_MOVES] / g_prof.counters[PROF_C_STEPS] : 0.0);
+    fprintf(f, "    \"illegal_per_c_step\": %.4f,\n",
+            g_prof.counters[PROF_C_STEPS] ?
+              (double)g_prof.counters[PROF_ILLEGAL_ACTIONS] / g_prof.counters[PROF_C_STEPS] : 0.0);
+    fprintf(f, "    \"fn_steps_per_c_step\": %.3f,\n",
+            g_prof.counters[PROF_C_STEPS] ?
+              (double)(g_prof.counters[PROF_FN_STEPS_AGENT] +
+                       g_prof.counters[PROF_FN_STEPS_POST_DRAIN]) /
+              g_prof.counters[PROF_C_STEPS] : 0.0);
+    fprintf(f, "    \"reset_p50_ms\": null,\n");
+    fprintf(f, "    \"ns_per_valid_move\": %.1f\n",
+            g_prof.counters[PROF_VALID_MOVES] ?
+              wall_seconds * 1e9 / g_prof.counters[PROF_VALID_MOVES] : 0.0);
+    fprintf(f, "  },\n");
+
+    fprintf(f, "  \"metrics\": {\n");
+    for (int i = 0; i < PROF_METRIC_COUNT; i++) {
+        ProfMetric* m = &g_prof.metrics[i];
+        double mean = m->count ? (double)m->sum_ns / m->count : 0.0;
+        fprintf(f, "    \"%s\": {", m->name);
+        fprintf(f, "\"count\": %lu, ", m->count);
+        fprintf(f, "\"sum_ns\": %llu, ", m->sum_ns);
+        fprintf(f, "\"mean_ns\": %.1f, ", mean);
+        fprintf(f, "\"min_ns\": %llu, ", m->min_ns);
+        fprintf(f, "\"max_ns\": %llu, ", m->max_ns);
+        fprintf(f, "\"hist\": [");
+        for (int b = 0; b < PROF_HIST_BUCKETS; b++) {
+            fprintf(f, "%lu%s", m->hist[b], (b == PROF_HIST_BUCKETS - 1) ? "" : ",");
+        }
+        fprintf(f, "]}%s\n", (i == PROF_METRIC_COUNT - 1) ? "" : ",");
+    }
+    fprintf(f, "  },\n");
+
+    fprintf(f, "  \"fn_steps_per_c_step_hist\": [");
+    for (int b = 0; b < PROF_HIST_BUCKETS; b++) {
+        fprintf(f, "%lu%s", g_prof.fn_steps_per_c_step_hist[b],
+                (b == PROF_HIST_BUCKETS - 1) ? "" : ",");
+    }
+    fprintf(f, "],\n");
+
+    fprintf(f, "  \"hist_buckets_ns\": [");
+    for (int b = 0; b < PROF_HIST_BUCKETS; b++) {
+        fprintf(f, "%llu%s", (1ull << b),
+                (b == PROF_HIST_BUCKETS - 1) ? "" : ",");
+    }
+    fprintf(f, "]\n");
+    fprintf(f, "}\n");
+}
+
+#endif // NETHACK_PROFILE_H

--- a/src/kernels.cu
+++ b/src/kernels.cu
@@ -350,6 +350,10 @@ __global__ void cast(unsigned char* __restrict__ dst,
     }
 }
 
+inline void cast_dispatch(precision_t* dst, const unsigned char* src, int n, cudaStream_t stream) {
+    cast<<<grid_size(n), BLOCK_SIZE, 0, stream>>>(dst, src, n);
+}
+
 void puf_copy(PrecisionTensor* dst, const PrecisionTensor* src, cudaStream_t stream) {
     assert(numel(dst->shape) == numel(src->shape) && "puf_copy: size mismatch");
     cudaMemcpyAsync(dst->data, src->data, numel(dst->shape) * sizeof(precision_t), cudaMemcpyDeviceToDevice, stream);


### PR DESCRIPTION
Native C binding for NetHack via a modified NLE that isolates all mutable state per-env. Achieves 100-300k training SPS at N=4096 T=16.

- ocean/nethack/ — env binding, reward shaping, prompt handling
- config/nethack.ini — training hyperparameters
- build.sh — auto-clones modified NLE from liujonathan24/NetHack, adds EXTRA_LDFLAGS plumbing
- src/kernels.cu — add cast_dispatch overload for ByteTensor obs (not sure if these are necessary or exactly why ByteTensor doesn't work with existing cast_dispatch)

Modified NLE: https://github.com/liujonathan24/NetHack
