### PR TITLE
ensure sweeps use specified metric

### DIFF
--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -374,7 +374,7 @@ def _train(env_name, args, sweep_obj=None, result_queue=None, verbose=False):
             result_queue.put((args['gpu_id'], [match_score],
                 [metrics['uptime'][-1]], [metrics['agent_steps'][-1]]))
         else:
-            result_queue.put((args['gpu_id'], metrics['env/score'], metrics['uptime'], metrics['agent_steps']))
+            result_queue.put((args['gpu_id'], metrics[target_key], metrics['uptime'], metrics['agent_steps']))
 
 def train(env_name, args=None, gpus=None, **kwargs):
     args = args or load_config(env_name)


### PR DESCRIPTION
I'm running a sweep to ensure nothing else is broken, but currently sweeps force optimization of score even if something else is specified in the ini file.


_**The changes to breakout are just for proof of concept, not actually committed**_
When setting score = 0, and setting the metric to an equivalent value, sweeps collapse entirely.
<img width="1936" height="679" alt="All runs collapse to near 0 uptime" src="https://github.com/user-attachments/assets/99569f8e-93ca-4114-b8c2-c266d18aa39c" />
<img width="276" height="443" alt="Toy example of breakout with 0 score and metric as real score" src="https://github.com/user-attachments/assets/8cea8e9c-e320-4a5f-b8df-21e79dd2790f" />


In contrast, with the change, an incomplete sweep of only 50 runs (while also setting score = 0 and metric = real_score) results in much better results.
<img width="1940" height="600" alt="CleanShot 2026-05-27 at 01 36 12" src="https://github.com/user-attachments/assets/4549734f-d886-4eae-9a48-1b1f2358e125" />