### PR TITLE
reset recurrent state after cudagraph warmup

### DIFF
--- a/src/pufferlib.cu
+++ b/src/pufferlib.cu
@@ -2091,6 +2091,11 @@ std::unique_ptr<PuffeRL> create_pufferl_impl(HypersT& hypers,
         }
         cudaMemset(pufferl->rng_offset_puf.data, 0,
             numel(pufferl->rng_offset_puf.shape) * sizeof(long));
+        for (int bank = 0; bank < 1 + pufferl->num_frozen_banks; bank++) {
+            PrecisionTensor* bs = (bank == 0) ? pufferl->buffer_states
+                                              : pufferl->frozen_banks[bank - 1].buffer_states;
+            for (int b = 0; b < num_buffers; b++) puf_zero(&bs[b], pufferl->default_stream);
+        }
         cudaDeviceSynchronize();
 
         pufferl->epoch = 0;


### PR DESCRIPTION
i had parity issues between CUDA trained models and local Metal evals and noticed this. we restore all kinds of state but not recurrent for some reason. could be intentional but i'm not aware of a reason

this can be repro'd on breakout with default config for example where reading buffer_states[0] after construction shows 98304/131072 bytes nonzero. this PR makes that 0/131072

it's +5 lines for something CUDA to CUDA users will never feel but it affected me so might as well PR