### PR TITLE
[bugfix] continuous action precision mismatch

### DIFF
--- a/src/pufferlib.cu
+++ b/src/pufferlib.cu
@@ -487,11 +487,13 @@ __global__ void sample_logits(
             float noise = curand_normal(&state);
             float action = mean + std * noise;
 
+            precision_t stored_action_p = from_float(action);
+            float stored_action = to_float(stored_action_p);
             // Log probability: -0.5 * ((action - mean) / std)^2 - 0.5 * log(2*pi) - log(std)
-            float normalized = (action - mean) / std;
+            float normalized = (stored_action - mean) / std;
             float log_prob = -0.5f * normalized * normalized - 0.5f * LOG_2PI - log_std;
 
-            actions[idx * num_atns + h] = from_float(action);
+            actions[idx * num_atns + h] = stored_action_p;
             total_log_prob += log_prob;
         }
     } else {


### PR DESCRIPTION
I think the best test that shows this improvement is an independent sweep before the fix, and then after the fix.

<img width="529" height="619" alt="image" src="https://github.com/user-attachments/assets/1bc51b76-4d9c-464d-8f4f-7cd18126c6ac" />

<img width="521" height="311" alt="image" src="https://github.com/user-attachments/assets/2c50def2-9694-4e86-b05b-046a674cba80" />

<img width="559" height="320" alt="image" src="https://github.com/user-attachments/assets/cc91dd5a-f931-4ff6-8ed5-c3c0ef9a263f" />



Basically; if precision_t was bf16/fp16, the sampled fp32 action gets rounded, and that messes with things downstream in PPO. I'm not sure exactly how PPO uses the ratio; but before this fix, if you did not change the policy, the logratio would be nonzero. As I understand it; if the policy did not change, this should be zero. With discrete actionspace, it does stay zero, but in continuous. it is does not. 

discrete doesn't have this problem because it uses integers. 