### PR TITLE
[codex] Add Block Blast environment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -65,7 +65,7 @@ fi
 PLATFORM="$(uname -s)"
 if [ "$PLATFORM" = "Linux" ]; then
     RAYLIB_NAME='raylib-5.5_linux_amd64'
-    OMP_LIB=-lomp5
+    OMP_LIB=-lgomp
     OMP_CFLAGS=(-fopenmp)
     OMP_LDFLAGS=(-fopenmp "$OMP_LIB")
     SANITIZE_FLAGS=(-fsanitize=address,undefined,bounds,pointer-overflow,leak -fno-omit-frame-pointer)
@@ -79,8 +79,8 @@ else
         OMP_CFLAGS=(-I"$OMP_PREFIX/include" -Xclang -fopenmp)
         OMP_LDFLAGS=(-L"$OMP_PREFIX/lib" "$OMP_LIB")
     else
-        OMP_CFLAGS=(-Xclang -fopenmp)
-        OMP_LDFLAGS=("$OMP_LIB")
+        OMP_CFLAGS=()
+        OMP_LDFLAGS=()
     fi
     SANITIZE_FLAGS=()
     STANDALONE_LDFLAGS=(-framework Cocoa -framework IOKit -framework CoreVideo -framework OpenGL)
@@ -103,7 +103,15 @@ download() {
     echo "Downloading $name..."
     case "$url" in
         *.zip) curl -sL "$url" -o "$name.zip" && unzip -q "$name.zip" && rm "$name.zip" ;;
-        *)     curl -sL "$url" -o "$name.tar.gz" && tar xf "$name.tar.gz" && rm "$name.tar.gz" ;;
+        *)
+            curl -sL "$url" -o "$name.tar.gz"
+            if tar --help 2>&1 | grep -q -- '--no-same-owner'; then
+                tar --no-same-owner -xf "$name.tar.gz"
+            else
+                tar xf "$name.tar.gz"
+            fi
+            rm "$name.tar.gz"
+            ;;
     esac
 }
 
@@ -150,6 +158,10 @@ fi
 CPU_STUB_INCLUDE=()
 if [ "$MODE" = "cpu" ] && [ -d "$SRC_DIR/cpu_stubs" ]; then
     CPU_STUB_INCLUDE=(-I"$SRC_DIR/cpu_stubs")
+fi
+if [ "$MODE" = "cpu" ] && [ "$PLATFORM" != "Linux" ] && [ -z "$OMP_PREFIX" ]; then
+    OMP_CFLAGS=()
+    OMP_LDFLAGS=()
 fi
 
 NVCC_ENV_HOST_FLAGS=()
@@ -206,7 +218,17 @@ elif [ "$MODE" = "web" ]; then
 fi
 
 # Find cuDNN path
-CUDA_HOME=${CUDA_HOME:-${CUDA_PATH:-$(dirname "$(dirname "$(which nvcc)")")}}
+if [ -z "$CUDA_HOME" ]; then
+    if [ -n "$CUDA_PATH" ]; then
+        CUDA_HOME="$CUDA_PATH"
+    elif command -v nvcc >/dev/null 2>&1; then
+        CUDA_HOME="$(dirname "$(dirname "$(command -v nvcc)")")"
+    elif [ -d /usr/local/cuda ]; then
+        CUDA_HOME=/usr/local/cuda
+    elif [ -d /usr/local/cuda-12.4 ]; then
+        CUDA_HOME=/usr/local/cuda-12.4
+    fi
+fi
 CUDNN_IFLAG=""
 CUDNN_LFLAG=""
 for dir in /usr/local/cuda/include /usr/include; do
@@ -255,8 +277,13 @@ done
 export CCACHE_DIR="${CCACHE_DIR:-$HOME/.ccache}"
 export CCACHE_BASEDIR="$(pwd)"
 export CCACHE_COMPILERCHECK=content
-NVCC="ccache $CUDA_HOME/bin/nvcc"
-CC="${CC:-$(command -v ccache >/dev/null && echo 'ccache clang' || echo 'clang')}"
+if command -v ccache >/dev/null 2>&1; then
+    NVCC="ccache $CUDA_HOME/bin/nvcc"
+    CC="${CC:-ccache clang}"
+else
+    NVCC="$CUDA_HOME/bin/nvcc"
+    CC="${CC:-clang}"
+fi
 ARCH=${NVCC_ARCH:-native}
 
 PYTHON_INCLUDE=$("$PYTHON_BIN" -c "import sysconfig; print(sysconfig.get_path('include'))")

--- a/config/block_blast.ini
+++ b/config/block_blast.ini
@@ -1,0 +1,41 @@
+[base]
+env_name = block_blast
+
+[vec]
+total_agents = 8192
+num_buffers = 4
+num_threads = 16
+
+[env]
+max_steps = 512
+place_reward = 0.01
+line_reward = 2.0
+combo_reward = 0.35
+free_space_reward = 0.03
+mobility_reward = 0.12
+fill_penalty = 0.10
+no_clear_penalty = 0.03
+dead_space_penalty = 0.12
+fragmentation_penalty = 0.08
+low_mobility_penalty = 0.10
+low_mobility_threshold = 18
+invalid_penalty = -0.5
+terminal_penalty = 5.0
+
+[policy]
+hidden_size = 256
+num_layers = 4
+expansion_factor = 1
+
+[train]
+total_timesteps = 500_000_000
+learning_rate = 0.003
+gamma = 0.995
+gae_lambda = 0.90
+ent_coef = 0.01
+replay_ratio = 2.0
+minibatch_size = 65536
+horizon = 128
+
+[sweep]
+metric = score

--- a/ocean/block_blast/binding.c
+++ b/ocean/block_blast/binding.c
@@ -1,0 +1,71 @@
+#include "block_blast.h"
+
+#define OBS_SIZE BB_OBS_SIZE
+#define NUM_ATNS 1
+#define ACT_SIZES {BB_ACTIONS}
+#define OBS_TENSOR_T ByteTensor
+#define MY_ACTION_MASK BB_ACTIONS
+
+#define Env BlockBlast
+static inline void puffer_state_refresh(BlockBlast* env) { bb_compute_observations(env); }
+#include "vecenv.h"
+
+static inline int dict_get_int_default(Dict* kwargs, const char* key, int default_value) {
+    DictItem* item = dict_get_unsafe(kwargs, key);
+    if (item == NULL) {
+        return default_value;
+    }
+    return (int)item->value;
+}
+
+static inline float dict_get_float_default(Dict* kwargs, const char* key, float default_value) {
+    DictItem* item = dict_get_unsafe(kwargs, key);
+    if (item == NULL) {
+        return default_value;
+    }
+    return (float)item->value;
+}
+
+void my_init(Env* env, Dict* kwargs) {
+    env->num_agents = 1;
+    env->max_steps = dict_get_int_default(kwargs, "max_steps", 512);
+    env->place_reward = dict_get_float_default(kwargs, "place_reward", 0.01f);
+    env->line_reward = dict_get_float_default(kwargs, "line_reward", 1.0f);
+    env->combo_reward = dict_get_float_default(kwargs, "combo_reward", 0.15f);
+    env->free_space_reward = dict_get_float_default(kwargs, "free_space_reward", 0.03f);
+    env->mobility_reward = dict_get_float_default(kwargs, "mobility_reward", 0.04f);
+    env->fill_penalty = dict_get_float_default(kwargs, "fill_penalty", 0.05f);
+    env->no_clear_penalty = dict_get_float_default(kwargs, "no_clear_penalty", 0.01f);
+    env->dead_space_penalty = dict_get_float_default(kwargs, "dead_space_penalty", 0.0f);
+    env->fragmentation_penalty = dict_get_float_default(kwargs, "fragmentation_penalty", 0.0f);
+    env->low_mobility_penalty = dict_get_float_default(kwargs, "low_mobility_penalty", 0.0f);
+    env->low_mobility_threshold = dict_get_int_default(kwargs, "low_mobility_threshold", 12);
+    env->invalid_penalty = dict_get_float_default(kwargs, "invalid_penalty", -0.5f);
+    env->terminal_penalty = dict_get_float_default(kwargs, "terminal_penalty", 1.0f);
+}
+
+void my_log(Log* log, Dict* out) {
+    dict_set(out, "perf", log->perf);
+    dict_set(out, "score", log->score);
+    dict_set(out, "episode_return", log->episode_return);
+    dict_set(out, "episode_length", log->episode_length);
+    dict_set(out, "lines_cleared", log->lines_cleared);
+    dict_set(out, "clears", log->clears);
+    dict_set(out, "placements", log->placements);
+    dict_set(out, "invalid_actions", log->invalid_actions);
+    dict_set(out, "board_fill", log->board_fill);
+    dict_set(out, "available_moves", log->available_moves);
+    dict_set(out, "avg_board_fill", log->avg_board_fill);
+    dict_set(out, "avg_available_moves", log->avg_available_moves);
+    dict_set(out, "dead_space", log->dead_space);
+    dict_set(out, "empty_components", log->empty_components);
+    dict_set(out, "largest_empty_region", log->largest_empty_region);
+    dict_set(out, "avg_dead_space", log->avg_dead_space);
+    dict_set(out, "avg_empty_components", log->avg_empty_components);
+    dict_set(out, "avg_largest_empty_region", log->avg_largest_empty_region);
+    dict_set(out, "avg_min_slot_moves", log->avg_min_slot_moves);
+    dict_set(out, "low_mobility_steps", log->low_mobility_steps);
+    dict_set(out, "game_over", log->game_over);
+    dict_set(out, "max_combo", log->max_combo);
+    dict_set(out, "survived_max_steps", log->survived_max_steps);
+}

--- a/ocean/block_blast/block_blast.c
+++ b/ocean/block_blast/block_blast.c
@@ -1,0 +1,88 @@
+#include <stdio.h>
+#include <time.h>
+#include "block_blast.h"
+
+static BlockBlast* g_env = NULL;
+
+static void demo_cleanup(void) {
+    if (g_env == NULL) {
+        return;
+    }
+    free(g_env->observations);
+    free(g_env->actions);
+    free(g_env->rewards);
+    free(g_env->terminals);
+    free(g_env->action_mask);
+    c_close(g_env);
+    g_env = NULL;
+}
+
+static int random_legal_action(BlockBlast* env) {
+    int legal_count = 0;
+    for (int i = 0; i < BB_ACTIONS; i++) {
+        legal_count += env->action_mask[i] != 0;
+    }
+    if (legal_count <= 0) {
+        return 0;
+    }
+
+    int pick = (int)(rand_r(&env->rng) % (unsigned int)legal_count);
+    for (int i = 0; i < BB_ACTIONS; i++) {
+        if (env->action_mask[i] == 0) {
+            continue;
+        }
+        if (pick == 0) {
+            return i;
+        }
+        pick--;
+    }
+    return 0;
+}
+
+int main(void) {
+    BlockBlast env = {
+        .num_agents = 1,
+        .rng = (unsigned int)time(NULL),
+        .max_steps = 512,
+        .place_reward = 0.01f,
+        .line_reward = 1.0f,
+        .combo_reward = 0.15f,
+        .free_space_reward = 0.03f,
+        .mobility_reward = 0.04f,
+        .fill_penalty = 0.05f,
+        .no_clear_penalty = 0.01f,
+        .dead_space_penalty = 0.0f,
+        .fragmentation_penalty = 0.0f,
+        .low_mobility_penalty = 0.0f,
+        .low_mobility_threshold = 12,
+        .invalid_penalty = -0.5f,
+        .terminal_penalty = 1.0f,
+    };
+
+    g_env = &env;
+    atexit(demo_cleanup);
+
+    env.observations = (unsigned char*)calloc(BB_OBS_SIZE, sizeof(unsigned char));
+    env.actions = (float*)calloc(1, sizeof(float));
+    env.rewards = (float*)calloc(1, sizeof(float));
+    env.terminals = (float*)calloc(1, sizeof(float));
+    env.action_mask = (unsigned char*)calloc(BB_ACTIONS, sizeof(unsigned char));
+
+    c_reset(&env);
+
+    while (!WindowShouldClose()) {
+        if (IsKeyPressed(KEY_SPACE)) {
+            env.actions[0] = (float)random_legal_action(&env);
+            c_step(&env);
+        } else if (IsKeyDown(KEY_ENTER)) {
+            env.actions[0] = (float)random_legal_action(&env);
+            c_step(&env);
+        } else if (IsKeyPressed(KEY_R)) {
+            c_reset(&env);
+        }
+        c_render(&env);
+    }
+
+    demo_cleanup();
+    return 0;
+}

--- a/ocean/block_blast/block_blast.h
+++ b/ocean/block_blast/block_blast.h
@@ -1,0 +1,644 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include "raylib.h"
+
+#define BB_SIZE 8
+#define BB_CELLS (BB_SIZE * BB_SIZE)
+#define BB_SLOTS 3
+#define BB_PIECE_GRID 5
+#define BB_PIECE_OBS (BB_SLOTS * BB_PIECE_GRID * BB_PIECE_GRID)
+#define BB_OBS_SIZE (BB_CELLS + BB_PIECE_OBS + BB_SLOTS)
+#define BB_ACTIONS (BB_SLOTS * BB_CELLS)
+#define BB_MAX_PIECE_CELLS 9
+#define BB_NUM_PIECES 30
+
+typedef struct {
+    float perf;
+    float score;
+    float episode_return;
+    float episode_length;
+    float lines_cleared;
+    float clears;
+    float placements;
+    float invalid_actions;
+    float board_fill;
+    float available_moves;
+    float avg_board_fill;
+    float avg_available_moves;
+    float dead_space;
+    float empty_components;
+    float largest_empty_region;
+    float avg_dead_space;
+    float avg_empty_components;
+    float avg_largest_empty_region;
+    float avg_min_slot_moves;
+    float low_mobility_steps;
+    float game_over;
+    float max_combo;
+    float survived_max_steps;
+    float n;
+} Log;
+
+typedef struct {
+    int dummy;
+} State;
+
+typedef struct {
+    int cell_size;
+    int gap;
+    int last_slot;
+    int last_row;
+    int last_col;
+} Client;
+
+typedef struct {
+    int count;
+    int row[BB_MAX_PIECE_CELLS];
+    int col[BB_MAX_PIECE_CELLS];
+    int height;
+    int width;
+} BlockPiece;
+
+typedef struct {
+    Log log;
+    unsigned char* observations;
+    float* actions;
+    float* rewards;
+    float* terminals;
+    unsigned char* action_mask;
+    int num_agents;
+    unsigned int rng;
+    State state;
+
+    int max_steps;
+    float place_reward;
+    float line_reward;
+    float combo_reward;
+    float free_space_reward;
+    float mobility_reward;
+    float fill_penalty;
+    float no_clear_penalty;
+    float dead_space_penalty;
+    float fragmentation_penalty;
+    float low_mobility_penalty;
+    int low_mobility_threshold;
+    float invalid_penalty;
+    float terminal_penalty;
+
+    unsigned char board[BB_CELLS];
+    int pieces[BB_SLOTS];
+    unsigned char active[BB_SLOTS];
+    int steps;
+    int score;
+    int lines_cleared;
+    int clears;
+    int placements;
+    int invalid_actions;
+    int combo;
+    int max_combo;
+    float episode_return;
+    float board_fill_sum;
+    float available_moves_sum;
+    float dead_space_sum;
+    float empty_components_sum;
+    float largest_empty_region_sum;
+    float min_slot_moves_sum;
+    int low_mobility_steps;
+    int mobility_samples;
+    Client* client;
+} BlockBlast;
+
+typedef struct {
+    int empty_cells;
+    int components;
+    int largest_region;
+    int small_region_cells;
+} EmptyStats;
+
+static const BlockPiece BB_PIECES[BB_NUM_PIECES] = {
+    {1, {0}, {0}, 1, 1},
+    {2, {0, 0}, {0, 1}, 1, 2},
+    {2, {0, 1}, {0, 0}, 2, 1},
+    {3, {0, 0, 0}, {0, 1, 2}, 1, 3},
+    {3, {0, 1, 2}, {0, 0, 0}, 3, 1},
+    {4, {0, 0, 0, 0}, {0, 1, 2, 3}, 1, 4},
+    {4, {0, 1, 2, 3}, {0, 0, 0, 0}, 4, 1},
+    {5, {0, 0, 0, 0, 0}, {0, 1, 2, 3, 4}, 1, 5},
+    {5, {0, 1, 2, 3, 4}, {0, 0, 0, 0, 0}, 5, 1},
+    {4, {0, 0, 1, 1}, {0, 1, 0, 1}, 2, 2},
+    {9, {0, 0, 0, 1, 1, 1, 2, 2, 2}, {0, 1, 2, 0, 1, 2, 0, 1, 2}, 3, 3},
+    {6, {0, 0, 0, 1, 1, 1}, {0, 1, 2, 0, 1, 2}, 2, 3},
+    {6, {0, 0, 1, 1, 2, 2}, {0, 1, 0, 1, 0, 1}, 3, 2},
+    {3, {0, 1, 1}, {0, 0, 1}, 2, 2},
+    {3, {0, 0, 1}, {0, 1, 0}, 2, 2},
+    {3, {0, 0, 1}, {0, 1, 1}, 2, 2},
+    {3, {0, 1, 1}, {1, 0, 1}, 2, 2},
+    {5, {0, 1, 2, 2, 2}, {0, 0, 0, 1, 2}, 3, 3},
+    {5, {0, 0, 0, 1, 2}, {0, 1, 2, 0, 0}, 3, 3},
+    {5, {0, 0, 0, 1, 2}, {0, 1, 2, 2, 2}, 3, 3},
+    {5, {0, 1, 2, 2, 2}, {2, 2, 0, 1, 2}, 3, 3},
+    {4, {0, 0, 0, 1}, {0, 1, 2, 1}, 2, 3},
+    {4, {0, 1, 1, 2}, {1, 0, 1, 1}, 3, 2},
+    {4, {0, 1, 1, 1}, {1, 0, 1, 2}, 2, 3},
+    {4, {0, 1, 1, 2}, {0, 0, 1, 0}, 3, 2},
+    {4, {0, 0, 1, 1}, {0, 1, 1, 2}, 2, 3},
+    {4, {0, 0, 1, 1}, {1, 2, 0, 1}, 2, 3},
+    {4, {0, 1, 1, 2}, {0, 0, 1, 1}, 3, 2},
+    {4, {0, 1, 1, 2}, {1, 0, 1, 0}, 3, 2},
+    {5, {0, 1, 1, 1, 2}, {1, 0, 1, 2, 1}, 3, 3},
+};
+
+static const Color BB_BG = {6, 24, 24, 255};
+static const Color BB_GRID = {23, 57, 58, 255};
+static const Color BB_CELL = {66, 180, 255, 255};
+static const Color BB_CELL_2 = {86, 211, 146, 255};
+static const Color BB_TEXT = {241, 241, 241, 255};
+static const Color BB_GHOST = {255, 204, 64, 255};
+static const Color BB_BAD = {231, 76, 60, 255};
+
+static inline int bb_min(int a, int b) { return a < b ? a : b; }
+static inline int bb_max(int a, int b) { return a > b ? a : b; }
+static inline int bb_idx(int row, int col) { return row * BB_SIZE + col; }
+static inline float bb_rand_unit(BlockBlast* env) {
+    return (float)rand_r(&env->rng) / (float)RAND_MAX;
+}
+
+static inline int bb_piece_fits(BlockBlast* env, int piece_id, int row, int col) {
+    if (piece_id < 0 || piece_id >= BB_NUM_PIECES) return 0;
+    const BlockPiece* p = &BB_PIECES[piece_id];
+    if (row < 0 || col < 0 || row + p->height > BB_SIZE || col + p->width > BB_SIZE) return 0;
+    for (int i = 0; i < p->count; i++) {
+        int r = row + p->row[i];
+        int c = col + p->col[i];
+        if (env->board[bb_idx(r, c)] != 0) return 0;
+    }
+    return 1;
+}
+
+static inline int bb_has_any_legal(BlockBlast* env) {
+    for (int slot = 0; slot < BB_SLOTS; slot++) {
+        if (!env->active[slot]) continue;
+        int piece = env->pieces[slot];
+        for (int row = 0; row < BB_SIZE; row++) {
+            for (int col = 0; col < BB_SIZE; col++) {
+                if (bb_piece_fits(env, piece, row, col)) return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+static inline int bb_write_action_mask(BlockBlast* env) {
+    int legal = 0;
+    if (env->action_mask == NULL) return bb_has_any_legal(env);
+    memset(env->action_mask, 0, BB_ACTIONS * sizeof(unsigned char));
+    for (int slot = 0; slot < BB_SLOTS; slot++) {
+        if (!env->active[slot]) continue;
+        int piece = env->pieces[slot];
+        for (int row = 0; row < BB_SIZE; row++) {
+            for (int col = 0; col < BB_SIZE; col++) {
+                int action = slot * BB_CELLS + bb_idx(row, col);
+                if (bb_piece_fits(env, piece, row, col)) {
+                    env->action_mask[action] = 255;
+                    legal++;
+                }
+            }
+        }
+    }
+    return legal > 0;
+}
+
+static inline void bb_draw_piece_tray(BlockBlast* env) {
+    for (int slot = 0; slot < BB_SLOTS; slot++) {
+        env->pieces[slot] = rand_r(&env->rng) % BB_NUM_PIECES;
+        env->active[slot] = 1;
+    }
+}
+
+static inline int bb_all_slots_used(BlockBlast* env) {
+    for (int i = 0; i < BB_SLOTS; i++) {
+        if (env->active[i]) return 0;
+    }
+    return 1;
+}
+
+static inline int bb_count_occupied(BlockBlast* env) {
+    int count = 0;
+    for (int i = 0; i < BB_CELLS; i++) count += env->board[i] != 0;
+    return count;
+}
+
+static inline int bb_slot_available_moves(BlockBlast* env, int slot) {
+    if (slot < 0 || slot >= BB_SLOTS || !env->active[slot]) return 0;
+    int count = 0;
+    int piece = env->pieces[slot];
+    for (int row = 0; row < BB_SIZE; row++) {
+        for (int col = 0; col < BB_SIZE; col++) {
+            count += bb_piece_fits(env, piece, row, col);
+        }
+    }
+    return count;
+}
+
+static inline int bb_available_moves(BlockBlast* env) {
+    int count = 0;
+    for (int slot = 0; slot < BB_SLOTS; slot++) {
+        count += bb_slot_available_moves(env, slot);
+    }
+    return count;
+}
+
+static inline int bb_min_active_slot_moves(BlockBlast* env) {
+    int min_moves = BB_ACTIONS;
+    int active_count = 0;
+    for (int slot = 0; slot < BB_SLOTS; slot++) {
+        if (!env->active[slot]) continue;
+        int moves = bb_slot_available_moves(env, slot);
+        min_moves = bb_min(min_moves, moves);
+        active_count++;
+    }
+    return active_count > 0 ? min_moves : 0;
+}
+
+static inline EmptyStats bb_empty_stats(BlockBlast* env) {
+    EmptyStats stats = {0};
+    unsigned char visited[BB_CELLS] = {0};
+    int queue[BB_CELLS];
+
+    for (int start = 0; start < BB_CELLS; start++) {
+        if (env->board[start] != 0 || visited[start]) continue;
+
+        int head = 0;
+        int tail = 0;
+        int region = 0;
+        visited[start] = 1;
+        queue[tail++] = start;
+
+        while (head < tail) {
+            int idx = queue[head++];
+            int row = idx / BB_SIZE;
+            int col = idx % BB_SIZE;
+            region++;
+
+            const int dr[4] = {-1, 1, 0, 0};
+            const int dc[4] = {0, 0, -1, 1};
+            for (int k = 0; k < 4; k++) {
+                int nr = row + dr[k];
+                int nc = col + dc[k];
+                if (nr < 0 || nr >= BB_SIZE || nc < 0 || nc >= BB_SIZE) continue;
+                int ni = bb_idx(nr, nc);
+                if (env->board[ni] != 0 || visited[ni]) continue;
+                visited[ni] = 1;
+                queue[tail++] = ni;
+            }
+        }
+
+        stats.empty_cells += region;
+        stats.components++;
+        stats.largest_region = bb_max(stats.largest_region, region);
+        if (region <= 3) {
+            stats.small_region_cells += region;
+        }
+    }
+
+    return stats;
+}
+
+static inline void bb_compute_observations(BlockBlast* env) {
+    int offset = 0;
+    for (int i = 0; i < BB_CELLS; i++) {
+        env->observations[offset++] = env->board[i] ? 255 : 0;
+    }
+    for (int slot = 0; slot < BB_SLOTS; slot++) {
+        unsigned char active = env->active[slot] ? 255 : 0;
+        unsigned char piece_obs[BB_PIECE_GRID * BB_PIECE_GRID] = {0};
+        if (env->active[slot]) {
+            const BlockPiece* p = &BB_PIECES[env->pieces[slot]];
+            for (int i = 0; i < p->count; i++) {
+                piece_obs[p->row[i] * BB_PIECE_GRID + p->col[i]] = 255;
+            }
+        }
+        memcpy(env->observations + offset, piece_obs, sizeof(piece_obs));
+        offset += BB_PIECE_GRID * BB_PIECE_GRID;
+        env->observations[BB_CELLS + BB_PIECE_OBS + slot] = active;
+    }
+    bb_write_action_mask(env);
+}
+
+static inline void bb_reset_game(BlockBlast* env) {
+    memset(env->board, 0, sizeof(env->board));
+    env->steps = 0;
+    env->score = 0;
+    env->lines_cleared = 0;
+    env->clears = 0;
+    env->placements = 0;
+    env->invalid_actions = 0;
+    env->combo = 0;
+    env->max_combo = 0;
+    env->episode_return = 0.0f;
+    env->board_fill_sum = 0.0f;
+    env->available_moves_sum = 0.0f;
+    env->dead_space_sum = 0.0f;
+    env->empty_components_sum = 0.0f;
+    env->largest_empty_region_sum = 0.0f;
+    env->min_slot_moves_sum = 0.0f;
+    env->low_mobility_steps = 0;
+    env->mobility_samples = 0;
+    if (env->client != NULL) {
+        env->client->last_slot = -1;
+        env->client->last_row = -1;
+        env->client->last_col = -1;
+    }
+    bb_draw_piece_tray(env);
+}
+
+static inline int bb_place_piece(BlockBlast* env, int slot, int row, int col) {
+    if (slot < 0 || slot >= BB_SLOTS || !env->active[slot]) return 0;
+    int piece_id = env->pieces[slot];
+    if (!bb_piece_fits(env, piece_id, row, col)) return 0;
+    const BlockPiece* p = &BB_PIECES[piece_id];
+    for (int i = 0; i < p->count; i++) {
+        int r = row + p->row[i];
+        int c = col + p->col[i];
+        env->board[bb_idx(r, c)] = (unsigned char)(1 + (slot % 2));
+    }
+    env->active[slot] = 0;
+    if (env->client != NULL) {
+        env->client->last_slot = slot;
+        env->client->last_row = row;
+        env->client->last_col = col;
+    }
+    return p->count;
+}
+
+static inline int bb_clear_lines(BlockBlast* env, int* cleared_cells) {
+    unsigned char full_rows[BB_SIZE] = {0};
+    unsigned char full_cols[BB_SIZE] = {0};
+    int lines = 0;
+    *cleared_cells = 0;
+
+    for (int row = 0; row < BB_SIZE; row++) {
+        int full = 1;
+        for (int col = 0; col < BB_SIZE; col++) {
+            if (env->board[bb_idx(row, col)] == 0) {
+                full = 0;
+                break;
+            }
+        }
+        if (full) {
+            full_rows[row] = 1;
+            lines++;
+        }
+    }
+
+    for (int col = 0; col < BB_SIZE; col++) {
+        int full = 1;
+        for (int row = 0; row < BB_SIZE; row++) {
+            if (env->board[bb_idx(row, col)] == 0) {
+                full = 0;
+                break;
+            }
+        }
+        if (full) {
+            full_cols[col] = 1;
+            lines++;
+        }
+    }
+
+    if (lines == 0) return 0;
+
+    for (int row = 0; row < BB_SIZE; row++) {
+        for (int col = 0; col < BB_SIZE; col++) {
+            int idx = bb_idx(row, col);
+            if ((full_rows[row] || full_cols[col]) && env->board[idx] != 0) {
+                env->board[idx] = 0;
+                (*cleared_cells)++;
+            }
+        }
+    }
+
+    env->lines_cleared += lines;
+    env->clears++;
+    env->combo++;
+    env->max_combo = bb_max(env->max_combo, env->combo);
+    return lines;
+}
+
+static inline void bb_write_log(BlockBlast* env, int game_over, int survived_max_steps) {
+    env->log.score += env->score;
+    env->log.perf += env->score / 1000.0f;
+    env->log.episode_return += env->episode_return;
+    env->log.episode_length += env->steps;
+    env->log.lines_cleared += env->lines_cleared;
+    env->log.clears += env->clears;
+    env->log.placements += env->placements;
+    env->log.invalid_actions += env->invalid_actions;
+    env->log.board_fill += (float)bb_count_occupied(env) / (float)BB_CELLS;
+    env->log.available_moves += bb_available_moves(env);
+    EmptyStats final_empty = bb_empty_stats(env);
+    env->log.dead_space +=
+        (float)(final_empty.empty_cells - final_empty.largest_region) / (float)BB_CELLS;
+    env->log.empty_components += final_empty.components;
+    env->log.largest_empty_region += final_empty.largest_region;
+    if (env->mobility_samples > 0) {
+        env->log.avg_board_fill += env->board_fill_sum / (float)env->mobility_samples;
+        env->log.avg_available_moves += env->available_moves_sum / (float)env->mobility_samples;
+        env->log.avg_dead_space += env->dead_space_sum / (float)env->mobility_samples;
+        env->log.avg_empty_components +=
+            env->empty_components_sum / (float)env->mobility_samples;
+        env->log.avg_largest_empty_region +=
+            env->largest_empty_region_sum / (float)env->mobility_samples;
+        env->log.avg_min_slot_moves += env->min_slot_moves_sum / (float)env->mobility_samples;
+    }
+    env->log.low_mobility_steps += env->low_mobility_steps;
+    env->log.game_over += game_over;
+    env->log.max_combo += env->max_combo;
+    env->log.survived_max_steps += survived_max_steps;
+    env->log.n += 1.0f;
+}
+
+static inline void c_reset(BlockBlast* env) {
+    env->rewards[0] = 0.0f;
+    env->terminals[0] = 0.0f;
+    bb_reset_game(env);
+    bb_compute_observations(env);
+}
+
+static inline void c_step(BlockBlast* env) {
+    int action = (int)env->actions[0];
+    int slot = action / BB_CELLS;
+    int cell = action % BB_CELLS;
+    int row = cell / BB_SIZE;
+    int col = cell % BB_SIZE;
+    int cleared_cells = 0;
+    int lines = 0;
+    int placed = 0;
+    int terminal = 0;
+    int survived_max_steps = 0;
+    float reward = 0.0f;
+
+    env->terminals[0] = 0.0f;
+    if (action < 0 || action >= BB_ACTIONS) {
+        placed = 0;
+    } else {
+        placed = bb_place_piece(env, slot, row, col);
+    }
+
+    if (placed <= 0) {
+        env->invalid_actions++;
+        reward = env->invalid_penalty;
+        env->combo = 0;
+    } else {
+        env->placements++;
+        env->steps++;
+        lines = bb_clear_lines(env, &cleared_cells);
+        if (lines > 0) {
+            int line_score = 10 * lines * lines + cleared_cells;
+            env->score += placed + line_score + env->combo * 2;
+            reward += env->place_reward * (float)placed;
+            reward += env->line_reward * (float)(lines * lines);
+            reward += env->combo_reward * (float)env->combo;
+        } else {
+            env->combo = 0;
+            env->score += placed;
+            reward += env->place_reward * (float)placed;
+            reward -= env->no_clear_penalty;
+        }
+
+        if (bb_all_slots_used(env)) {
+            bb_draw_piece_tray(env);
+        }
+
+        int legal_moves = bb_available_moves(env);
+        int min_slot_moves = bb_min_active_slot_moves(env);
+        EmptyStats empty = bb_empty_stats(env);
+        float fill = (float)bb_count_occupied(env) / (float)BB_CELLS;
+        float dead_space =
+            (float)(empty.empty_cells - empty.largest_region) / (float)BB_CELLS;
+        float fragmentation =
+            empty.components > 1 ? (float)(empty.components - 1) / (float)BB_SIZE : 0.0f;
+        float low_mobility = 0.0f;
+        if (legal_moves < env->low_mobility_threshold) {
+            low_mobility = (float)(env->low_mobility_threshold - legal_moves)
+                / (float)bb_max(env->low_mobility_threshold, 1);
+            env->low_mobility_steps++;
+        }
+        env->board_fill_sum += fill;
+        env->available_moves_sum += (float)legal_moves;
+        env->dead_space_sum += dead_space;
+        env->empty_components_sum += (float)empty.components;
+        env->largest_empty_region_sum += (float)empty.largest_region;
+        env->min_slot_moves_sum += (float)min_slot_moves;
+        env->mobility_samples++;
+        reward += env->free_space_reward * (1.0f - fill);
+        reward += env->mobility_reward * ((float)legal_moves / (float)BB_ACTIONS);
+        reward -= env->fill_penalty * fill * fill;
+        reward -= env->dead_space_penalty * dead_space;
+        reward -= env->fragmentation_penalty * fragmentation;
+        reward -= env->low_mobility_penalty * low_mobility;
+
+        if (env->steps >= env->max_steps) {
+            terminal = 1;
+            survived_max_steps = 1;
+            reward += 2.0f;
+        } else if (!bb_has_any_legal(env)) {
+            terminal = 1;
+            reward -= env->terminal_penalty;
+        }
+    }
+
+    env->rewards[0] = reward;
+    env->episode_return += reward;
+
+    if (terminal) {
+        env->terminals[0] = 1.0f;
+        bb_write_log(env, !survived_max_steps, survived_max_steps);
+        bb_reset_game(env);
+        env->rewards[0] = reward;
+    }
+
+    bb_compute_observations(env);
+}
+
+static inline void c_close(BlockBlast* env) {
+    if (env->client != NULL) {
+        if (IsWindowReady()) CloseWindow();
+        free(env->client);
+        env->client = NULL;
+    }
+}
+
+static inline Client* bb_make_client(void) {
+    Client* client = (Client*)calloc(1, sizeof(Client));
+    client->cell_size = 56;
+    client->gap = 5;
+    client->last_slot = -1;
+    client->last_row = -1;
+    client->last_col = -1;
+    InitWindow(720, 540, "PufferLib Block Blast");
+    SetTargetFPS(12);
+    return client;
+}
+
+static inline void bb_draw_board(BlockBlast* env, int x0, int y0, int cell, int gap) {
+    for (int row = 0; row < BB_SIZE; row++) {
+        for (int col = 0; col < BB_SIZE; col++) {
+            int x = x0 + col * cell;
+            int y = y0 + row * cell;
+            unsigned char value = env->board[bb_idx(row, col)];
+            DrawRectangle(x, y, cell - gap, cell - gap, BB_GRID);
+            if (value != 0) {
+                DrawRectangle(x + 3, y + 3, cell - gap - 6, cell - gap - 6,
+                    value == 1 ? BB_CELL : BB_CELL_2);
+            }
+        }
+    }
+}
+
+static inline void bb_draw_piece_preview(BlockBlast* env, int slot, int x0, int y0) {
+    const int small = 18;
+    const int gap = 3;
+    DrawText(TextFormat("%d", slot + 1), x0, y0 - 22, 18, BB_TEXT);
+    if (!env->active[slot]) {
+        DrawText("used", x0 + 26, y0 - 22, 16, BB_GRID);
+        return;
+    }
+    const BlockPiece* p = &BB_PIECES[env->pieces[slot]];
+    for (int i = 0; i < p->count; i++) {
+        int x = x0 + p->col[i] * small;
+        int y = y0 + p->row[i] * small;
+        DrawRectangle(x, y, small - gap, small - gap, slot % 2 == 0 ? BB_CELL : BB_CELL_2);
+    }
+}
+
+static inline void c_render(BlockBlast* env) {
+    if (IsWindowReady() && (WindowShouldClose() || IsKeyPressed(KEY_ESCAPE))) {
+        c_close(env);
+        exit(0);
+    }
+    if (env->client == NULL) env->client = bb_make_client();
+
+    BeginDrawing();
+    ClearBackground(BB_BG);
+    bb_draw_board(env, 28, 46, env->client->cell_size, env->client->gap);
+    DrawText("Block Blast", 28, 12, 24, BB_TEXT);
+    DrawText(TextFormat("Score %d", env->score), 520, 44, 22, BB_TEXT);
+    DrawText(TextFormat("Step %d/%d", env->steps, env->max_steps), 520, 74, 18, BB_TEXT);
+    DrawText(TextFormat("Lines %d", env->lines_cleared), 520, 100, 18, BB_TEXT);
+    DrawText(TextFormat("Moves %d", bb_available_moves(env)), 520, 126, 18, BB_TEXT);
+    for (int slot = 0; slot < BB_SLOTS; slot++) {
+        bb_draw_piece_preview(env, slot, 520, 190 + slot * 104);
+    }
+    if (env->client->last_slot >= 0) {
+        DrawText(TextFormat("Last: piece %d at %d,%d",
+            env->client->last_slot + 1, env->client->last_row, env->client->last_col),
+            28, 502, 18, BB_GHOST);
+    }
+    if (!bb_has_any_legal(env)) {
+        DrawText("No legal moves", 520, 480, 20, BB_BAD);
+    }
+    EndDrawing();
+}

--- a/ocean/block_blast/cpu_stubs/cuda_runtime_api.h
+++ b/ocean/block_blast/cpu_stubs/cuda_runtime_api.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int cudaError_t;
+typedef int cudaMemcpyKind;
+typedef struct CUstream_st* cudaStream_t;
+
+enum {
+    cudaMemcpyHostToDevice = 1,
+    cudaMemcpyDeviceToHost = 2,
+    cudaHostAllocPortable = 1,
+};
+
+cudaError_t cudaHostAlloc(void** ptr, size_t size, unsigned int flags);
+cudaError_t cudaMalloc(void** ptr, size_t size);
+cudaError_t cudaMemcpy(void* dst, const void* src, size_t count, cudaMemcpyKind kind);
+cudaError_t cudaMemcpyAsync(
+    void* dst, const void* src, size_t count, cudaMemcpyKind kind, cudaStream_t stream);
+cudaError_t cudaMemset(void* ptr, int value, size_t count);
+cudaError_t cudaFree(void* ptr);
+cudaError_t cudaFreeHost(void* ptr);
+cudaError_t cudaSetDevice(int device);
+cudaError_t cudaDeviceSynchronize(void);
+cudaError_t cudaStreamSynchronize(cudaStream_t stream);
+cudaError_t cudaStreamCreateWithFlags(cudaStream_t* stream, unsigned int flags);
+cudaError_t cudaStreamQuery(cudaStream_t stream);
+const char* cudaGetErrorString(cudaError_t error);
+
+#ifdef __cplusplus
+}
+#endif

--- a/ocean/block_blast/cpu_stubs/omp.h
+++ b/ocean/block_blast/cpu_stubs/omp.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/src/bindings.cu
+++ b/src/bindings.cu
@@ -114,7 +114,7 @@ pybind11::dict puf_eval_log(pybind11::object pufferl_obj) {
     pybind11::dict env_dict;
     // Capacity 64 to fit chess's per-bank hist_score_bank/hist_n_bank entries
     // (16 keys across 8 banks) on top of base env-log fields.
-    Dict* env_out = create_dict(64);
+    Dict* env_out = create_dict(128);
     static_vec_eval_log(pufferl.vec, env_out);
     for (int i = 0; i < env_out->size; i++) {
         env_dict[env_out->items[i].key] = env_out->items[i].value;
@@ -381,7 +381,7 @@ void cpu_vec_step_py(VecEnv& ve, long long actions_ptr) {
 }
 
 py::dict vec_log(VecEnv& ve) {
-    Dict* out = create_dict(32);
+    Dict* out = create_dict(128);
     static_vec_log(ve.vec, out);
     py::dict result;
     for (int i = 0; i < out->size; i++) {

--- a/src/bindings_cpu.cpp
+++ b/src/bindings_cpu.cpp
@@ -229,7 +229,7 @@ static void cpu_vec_step_py(VecEnv& ve, long long actions_ptr) {
 }
 
 static py::dict vec_log(VecEnv& ve) {
-    Dict* out = create_dict(32);
+    Dict* out = create_dict(128);
     static_vec_log(ve.vec, out);
     py::dict result;
     for (int i = 0; i < out->size; i++)
@@ -265,6 +265,8 @@ PYBIND11_MODULE(_C, m) {
         .def_readonly("obs_elem_size", &VecEnv::obs_elem_size)
         .def_property_readonly("gpu", [](VecEnv&) { return 0; })
         .def_property_readonly("obs_ptr", [](VecEnv& ve) { return (long long)ve.vec->observations.data; })
+        .def_property_readonly("action_mask_ptr", [](VecEnv& ve) { return (long long)ve.vec->action_mask; })
+        .def_property_readonly("action_mask_size", [](VecEnv& ve) { return ve.vec->action_mask_size; })
         .def_property_readonly("rewards_ptr", [](VecEnv& ve) { return (long long)ve.vec->rewards; })
         .def_property_readonly("terminals_ptr", [](VecEnv& ve) { return (long long)ve.vec->terminals; })
         .def("reset", &vec_reset)

--- a/src/pufferlib.cu
+++ b/src/pufferlib.cu
@@ -385,7 +385,7 @@ typedef struct {
 Dict* log_environments_impl(PuffeRL& pufferl) {
     // Capacity raised from 32 to 64 to accommodate chess's per-bank
     // hist_score_bank_<b> / hist_n_bank_<b> entries (16 keys for 8 banks).
-    Dict* out = create_dict(64);
+    Dict* out = create_dict(128);
     static_vec_log(pufferl.vec, out);
     return out;
 }

--- a/tools/render_block_blast_policy.py
+++ b/tools/render_block_blast_policy.py
@@ -1,0 +1,168 @@
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import pufferlib.pufferl as pufferl
+from pufferlib import _C, torch_pufferl
+
+
+def configure_args(args, hidden_size, max_steps):
+    args["slowly"] = True
+    args["reset_state"] = False
+    args["vec"]["total_agents"] = 1
+    args["vec"]["num_buffers"] = 1
+    args["vec"]["num_threads"] = 1
+    args["train"]["horizon"] = 1
+    args["train"]["minibatch_size"] = 1
+    args["train"]["total_timesteps"] = 1
+    args["policy"]["hidden_size"] = hidden_size
+    if max_steps is not None:
+        args["env"]["max_steps"] = max_steps
+    return args
+
+
+def native_bin_to_torch_state(raw_path, policy):
+    raw = np.fromfile(raw_path, dtype=np.float32)
+    state = policy.state_dict()
+
+    hidden = state["encoder.encoder.weight"].shape[0]
+    obs = state["encoder.encoder.weight"].shape[1]
+    actions = state["decoder.decoder.weight"].shape[0]
+    layers = len([k for k in state if k.startswith("network.layers.")])
+
+    expected = hidden * obs + (actions + 1) * hidden + layers * (3 * hidden * hidden)
+    if raw.size != expected:
+        raise RuntimeError(f"raw checkpoint has {raw.size} floats, expected {expected}")
+
+    idx = 0
+    new_state = {}
+
+    n = hidden * obs
+    new_state["encoder.encoder.weight"] = torch.from_numpy(
+        raw[idx:idx + n].reshape(hidden, obs).copy())
+    idx += n
+    new_state["encoder.encoder.bias"] = torch.zeros_like(state["encoder.encoder.bias"])
+
+    n = (actions + 1) * hidden
+    fused_decoder = raw[idx:idx + n].reshape(actions + 1, hidden)
+    idx += n
+    new_state["decoder.decoder.weight"] = torch.from_numpy(fused_decoder[:actions].copy())
+    new_state["decoder.decoder.bias"] = torch.zeros_like(state["decoder.decoder.bias"])
+    new_state["decoder.value_function.weight"] = torch.from_numpy(
+        fused_decoder[actions:actions + 1].copy())
+    new_state["decoder.value_function.bias"] = torch.zeros_like(
+        state["decoder.value_function.bias"])
+
+    for layer in range(layers):
+        key = f"network.layers.{layer}.weight"
+        n = state[key].numel()
+        new_state[key] = torch.from_numpy(raw[idx:idx + n].reshape(state[key].shape).copy())
+        idx += n
+
+    policy.load_state_dict(new_state)
+
+
+def masked_action(logits, mask, sampled):
+    masked_logits = logits.clone()
+    masked_logits[mask == 0] = -1e9
+    if sampled:
+        action, _, _ = torch_pufferl.sample_logits(masked_logits)
+        return action.to(dtype=torch.float32).contiguous()
+    return torch.argmax(masked_logits, dim=-1, keepdim=True).to(dtype=torch.float32).contiguous()
+
+
+def decode_action(action):
+    action = int(action)
+    slot = action // 64
+    cell = action % 64
+    row = cell // 8
+    col = cell % 8
+    return slot, row, col
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--checkpoint",
+        default="downloads/block_blast_latest/block_blast_1781365132432_0000000499122176.bin",
+    )
+    parser.add_argument("--hidden-size", type=int, default=256)
+    parser.add_argument("--max-steps", type=int, default=None)
+    parser.add_argument("--sampled", action="store_true")
+    parser.add_argument("--delay", type=float, default=0.16)
+    parser.add_argument("--steps", type=int, default=0)
+    parser.add_argument("--no-render", action="store_true")
+    parser.add_argument("--print-actions", action="store_true")
+    args_cli = parser.parse_args()
+
+    checkpoint = Path(args_cli.checkpoint)
+    if not checkpoint.exists():
+        raise FileNotFoundError(checkpoint)
+
+    argv = sys.argv
+    sys.argv = [argv[0]]
+    try:
+        args = pufferl.load_config("block_blast")
+    finally:
+        sys.argv = argv
+
+    args = configure_args(args, args_cli.hidden_size, args_cli.max_steps)
+    vec = _C.create_vec(args, 0)
+    vec.reset()
+    vec.log()
+
+    if vec.action_mask_size <= 0:
+        raise RuntimeError("block_blast action mask is not exposed by this _C build")
+
+    policy = torch_pufferl.load_policy(args, vec)
+    native_bin_to_torch_state(checkpoint, policy)
+    policy.eval()
+    state = policy.initial_state(1, "cpu")
+
+    mode = "sampled" if args_cli.sampled else "greedy"
+    print(f"Rendering {checkpoint} ({mode})")
+    if args_cli.no_render:
+        print("Render disabled for smoke test.")
+    else:
+        print("Close the Raylib window or press Esc to stop.")
+
+    step = 0
+    try:
+        if not args_cli.no_render:
+            vec.render(0)
+        while True:
+            obs = torch_pufferl._cpu_tensor(vec.obs_ptr, (1, vec.obs_size), torch.uint8)
+            mask = torch_pufferl._cpu_tensor(
+                vec.action_mask_ptr, (1, vec.action_mask_size), torch.uint8)
+            with torch.no_grad():
+                logits, _, state = policy.forward_eval(obs, state)
+                action = masked_action(logits, mask, args_cli.sampled)
+
+            vec.cpu_step(action.data_ptr())
+            step += 1
+
+            rewards = torch_pufferl._cpu_tensor(vec.rewards_ptr, (1,), torch.float32)
+            terminals = torch_pufferl._cpu_tensor(vec.terminals_ptr, (1,), torch.float32)
+            if args_cli.print_actions:
+                slot, row, col = decode_action(action.item())
+                print(
+                    f"step={step:04d} slot={slot} row={row} col={col} "
+                    f"reward={rewards[0].item():.3f} terminal={int(terminals[0].item())}"
+                )
+            if not args_cli.no_render:
+                vec.render(0)
+                time.sleep(args_cli.delay)
+            if terminals[0].item() > 0.0:
+                state = policy.initial_state(1, "cpu")
+            if args_cli.steps > 0 and step >= args_cli.steps:
+                break
+    finally:
+        vec.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a native Block Blast-style Ocean environment with action masking and Raylib rendering
- Add Block Blast training config and local policy renderer
- Increase env log dictionary capacity and expose CPU action mask pointers needed for local visualization
- Make build.sh more robust on macOS and RunPod Linux builds

## Validation
- PYTHON=/Users/alan/PufferLib-5.0/.venv/bin/python ./build.sh block_blast --cpu
- PYTHONPATH=. .venv/bin/python smoke test: env=block_blast obs=142 mask=192 invalid_actions=0
