### PR TITLE
Custom CUDA implementation of a Gaussian Process for the sweep

### DIFF
--- a/pufferlib/gp_torch.py
+++ b/pufferlib/gp_torch.py
@@ -1,0 +1,140 @@
+"""
+Drop-in replacement for GPyTorch exact GP training, CUDA implementation only.
+"""
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from pufferlib import _C
+
+class _MLLFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, params, backend):
+        ctx.backend = backend
+        return params.new_tensor(backend.log_marginal_likelihood)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        grads = torch.tensor(ctx.backend.mll_grad(),
+                             dtype=grad_output.dtype, device=grad_output.device)
+        return grad_output * grads, None
+
+
+def _np32(x):
+    if isinstance(x, torch.Tensor):
+        x = x.detach().cpu().numpy()
+    return np.ascontiguousarray(x, dtype=np.float32)
+
+
+class GaussianProcess(nn.Module):
+    def __init__(self, dim, capacity,
+                 lengthscale=1.0, outputscale=1.0, noise=1e-2, offset=1.0,
+                 use_cuda=True):
+        super().__init__()
+        self._backend = _C.GaussianProcess(dim=dim, capacity=capacity,
+                                lengthscale=lengthscale, outputscale=outputscale,
+                                noise=noise, offset=offset)
+        self.raw_lengthscale = nn.Parameter(
+            torch.tensor(np.asarray(self._backend.raw_lengthscale), dtype=torch.float64))
+        self.raw_outputscale = nn.Parameter(
+            torch.tensor(self._backend.raw_outputscale, dtype=torch.float64))
+        self.raw_noise = nn.Parameter(
+            torch.tensor(self._backend.raw_noise, dtype=torch.float64))
+        self.raw_offset = nn.Parameter(
+            torch.tensor(self._backend.raw_offset, dtype=torch.float64))
+
+    @property
+    def lengthscale(self):
+        return np.asarray(self._backend.lengthscale)
+
+    @property
+    def outputscale(self): return self._backend.outputscale
+
+    @property
+    def noise(self): return self._backend.noise
+
+    @property
+    def offset(self): return self._backend.offset
+
+    @property
+    def log_marginal_likelihood(self): return self._backend.log_marginal_likelihood
+
+    @property
+    def lengthscale_range(self):
+        ells = self.lengthscale
+        return float(np.min(ells)), float(np.max(ells))
+
+    @property
+    def n(self):        return self._backend.n
+
+    @property
+    def dim(self):      return self._backend.dim
+
+    @property
+    def capacity(self): return self._backend.capacity
+
+    def fit(self, X, y):
+        self._sync()
+        self._backend.fit(_np32(X), _np32(y))
+
+    def recompute(self):
+        self._sync()
+        self._backend.recompute()
+
+    def mll(self, recompute=True):
+        self._sync()
+        if recompute:
+            self._backend.recompute()
+        params = torch.cat([self.raw_lengthscale,
+                            self.raw_outputscale.unsqueeze(0),
+                            self.raw_noise.unsqueeze(0),
+                            self.raw_offset.unsqueeze(0)])
+        return _MLLFunction.apply(params, self._backend)
+
+    def predict(self, Xs):
+        self._sync()
+        means, vars_ = self._backend.predict(_np32(Xs))
+        return torch.from_numpy(means), torch.from_numpy(vars_)
+
+    def eval(self):
+        result = super().eval()
+        if hasattr(self, '_backend'):
+            self._sync()
+            self._backend.recompute()
+        return result
+
+    def save(self, path):
+        self._sync()
+        self._backend.save(path)
+
+    @classmethod
+    def load(cls, path, extra_cap=0, use_cuda=True):
+        obj = cls.__new__(cls)
+        nn.Module.__init__(obj)
+        obj._backend = _C.GaussianProcess.load(path, extra_cap)
+        obj.raw_lengthscale = nn.Parameter(
+            torch.tensor(np.asarray(obj._backend.raw_lengthscale), dtype=torch.float64))
+        obj.raw_outputscale = nn.Parameter(
+            torch.tensor(obj._backend.raw_outputscale, dtype=torch.float64))
+        obj.raw_noise = nn.Parameter(
+            torch.tensor(obj._backend.raw_noise, dtype=torch.float64))
+        obj.raw_offset = nn.Parameter(
+            torch.tensor(obj._backend.raw_offset, dtype=torch.float64))
+        return obj
+
+    def __repr__(self):
+        ells = self.lengthscale
+        if len(ells) == 1:
+            ell_s = f"{ells[0]:.3g}"
+        else:
+            ell_s = f"[{np.min(ells):.3g}..{np.max(ells):.3g}]"
+        return (f"<GaussianProcess dim={self.dim} n={self.n} cap={self.capacity} "
+                f"ell={ell_s} sf={self.outputscale:.3g} "
+                f"noise={self.noise:.3g}>")
+
+    def _sync(self):
+        self._backend.raw_lengthscale = self.raw_lengthscale.detach().cpu().numpy().astype(np.float32)
+        self._backend.raw_outputscale = float(self.raw_outputscale.item())
+        self._backend.raw_noise       = float(self.raw_noise.item())
+        self._backend.raw_offset      = float(self.raw_offset.item())

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -146,7 +146,8 @@ def _params_from_puffer_sweep(sweep_config, only_include=None):
 
     for name, param in sweep_config.items():
         if name in ('method', 'metric', 'metric_distribution', 'goal', 'downsample', 'use_gpu', 'prune_pareto',
-                    'sweep_only', 'max_suggestion_cost', 'early_stop_quantile', 'gpus', 'max_runs'):
+                    'sweep_only', 'max_suggestion_cost', 'early_stop_quantile', 'gpus', 'max_runs',
+                    'match_enemy_model_path', 'match_num_games', 'match_enemy_hidden_size', 'match_enemy_num_layers'):
             continue
 
         assert isinstance(param, dict), f'Param {name} is not a dict'

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -9,17 +9,12 @@ import numpy as np
 import pufferlib
 
 import torch
-import gpytorch
-from gpytorch.models import ExactGP
-from gpytorch.likelihoods import GaussianLikelihood
-from gpytorch.kernels import MaternKernel, PolynomialKernel, ScaleKernel, AdditiveKernel
-from gpytorch.means import ConstantMean
-from gpytorch.mlls import ExactMarginalLogLikelihood
-from gpytorch.priors import LogNormalPrior
 from scipy.optimize import minimize
 from scipy.stats.qmc import Sobol
 from scipy.spatial import KDTree
 from sklearn.linear_model import LogisticRegression
+
+from pufferlib.gp_torch import GaussianProcess
 
 EPSILON = 1e-6
 
@@ -397,53 +392,41 @@ class ParetoGenetic:
         return False
 
 
-class ExactGPModel(ExactGP):
-    def __init__(self, train_x, train_y, likelihood, x_dim):
-        super(ExactGPModel, self).__init__(train_x, train_y, likelihood)
-        self.mean_module = ConstantMean()
-        # Matern 3/2 kernel (equivalent to Pyro's Matern32)
-        matern_kernel = MaternKernel(nu=1.5, ard_num_dims=x_dim)
+_NOISE_PRIOR_MU    = math.log(1e-2)  # LogNormal prior on noise, from HEBO
+_NOISE_PRIOR_SIGMA = 0.5
 
-        # NOTE: setting this constraint changes GP behavior, including the lengthscale
-        # even though the lengthscale is well within the range ... Commenting out for now.
-        # lengthscale_constraint = gpytorch.constraints.Interval(0.01, 10.0)
-        # matern_kernel = MaternKernel(nu=1.5, ard_num_dims=x_dim, lengthscale_constraint=lengthscale_constraint)
+def _noise_log_prior(raw_noise_param):
+    # LogNormal(mu, sigma) prior in constrained space, with softplus change-of-variables.
+    # log p(raw) = log p_lognormal(softplus(raw) + lb) + log softplus_grad(raw)
+    noise      = torch.nn.functional.softplus(raw_noise_param) + 1e-4
+    log_noise  = torch.log(noise)
+    log_p      = -0.5 * ((log_noise - _NOISE_PRIOR_MU) / _NOISE_PRIOR_SIGMA) ** 2 \
+                 - log_noise - math.log(_NOISE_PRIOR_SIGMA)
+    log_jac    = -torch.log1p(torch.exp(-raw_noise_param))  # log sigmoid = log softplus_grad
+    return log_p + log_jac
 
-        linear_kernel = PolynomialKernel(power=1)
-        self.covar_module = ScaleKernel(AdditiveKernel(linear_kernel, matern_kernel))
 
-    def forward(self, x):
-        mean_x = self.mean_module(x)
-        covar_x = self.covar_module(x)
-        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
+def _fit_gp(gp_model, optimizer, train_x, train_y, training_iter=50):
+    if isinstance(train_x, torch.Tensor):
+        train_x = train_x.cpu().numpy()
+    if isinstance(train_y, torch.Tensor):
+        train_y = train_y.cpu().numpy()
 
-    @property
-    def lengthscale_range(self):
-        # Get lengthscale from MaternKernel
-        lengthscale = self.covar_module.base_kernel.kernels[1].lengthscale.tolist()[0]
-        return min(lengthscale), max(lengthscale)
-
-def train_gp_model(model, likelihood, mll, optimizer, train_x, train_y, training_iter=50):
-    model.train()
-    likelihood.train()
-    model.set_train_data(inputs=train_x, targets=train_y, strict=False)
+    gp_model.train()
+    gp_model.fit(train_x, train_y)
 
     loss = None
     for _ in range(training_iter):
         try:
             optimizer.zero_grad()
-            output = model(train_x)
-            loss = -mll(output, train_y)
+            loss = -gp_model.mll() - _noise_log_prior(gp_model.raw_noise)
             loss.backward()
             optimizer.step()
             loss = loss.detach()
-
-        except gpytorch.utils.errors.NotPSDError:
-            # It's rare but it does happen. Hope it's a transient issue.
+        except Exception:
             break
 
-    model.eval()
-    likelihood.eval()
+    gp_model.eval()
     return loss.item() if loss is not None else 0
 
 
@@ -593,36 +576,24 @@ class Protein:
         self.stop_threshold_model = RobustLogCostModel(quantile=sweep_config['early_stop_quantile'])
         self.upper_cost_threshold = -np.inf
 
-        # Use 64 bit for GP regression
-        with default_tensor_dtype(torch.float64):
-            # Params taken from HEBO: https://arxiv.org/abs/2012.03826
-            noise_prior = LogNormalPrior(math.log(1e-2), 0.5)
+        # Score GP
+        self.gp_score = GaussianProcess(dim=self.hyperparameters.num, capacity=self.gp_max_obs, use_cuda=_use_gpu)
+        self.score_opt = torch.optim.Adam(self.gp_score.parameters(), lr=self.gp_learning_rate, amsgrad=True)
 
-            # Create dummy data for model initialization on the selected device
-            dummy_x = torch.ones((1, self.hyperparameters.num), device=self.device)
-            dummy_y = torch.zeros(1, device=self.device)
-            # Score GP
-            self.likelihood_score = GaussianLikelihood(noise_prior=deepcopy(noise_prior)).to(self.device)
-            self.gp_score = ExactGPModel(dummy_x, dummy_y, self.likelihood_score, self.hyperparameters.num).to(self.device)
-            self.mll_score = ExactMarginalLogLikelihood(self.likelihood_score, self.gp_score).to(self.device)
-            self.score_opt = torch.optim.Adam(self.gp_score.parameters(), lr=self.gp_learning_rate, amsgrad=True)
+        # Cost GP
+        self.gp_cost = GaussianProcess(dim=self.hyperparameters.num, capacity=self.gp_max_obs, use_cuda=_use_gpu)
+        self.cost_opt = torch.optim.Adam(self.gp_cost.parameters(), lr=self.gp_learning_rate, amsgrad=True)
 
-            # Cost GP
-            self.likelihood_cost = GaussianLikelihood(noise_prior=deepcopy(noise_prior)).to(self.device)
-            self.gp_cost = ExactGPModel(dummy_x, dummy_y, self.likelihood_cost, self.hyperparameters.num).to(self.device)
-            self.mll_cost = ExactMarginalLogLikelihood(self.likelihood_cost, self.gp_cost).to(self.device)
-            self.cost_opt = torch.optim.Adam(self.gp_cost.parameters(), lr=self.gp_learning_rate, amsgrad=True)
-
-            # Buffers for GP training and inference
-            self.gp_params_buffer = torch.empty(self.gp_max_obs, self.hyperparameters.num, device=self.device)
-            self.gp_score_buffer = torch.empty(self.gp_max_obs, device=self.device)
-            self.gp_cost_buffer = torch.empty(self.gp_max_obs, device=self.device)
-            self.infer_batch_buffer = torch.empty(self.infer_batch_size, self.hyperparameters.num, device=self.device)
+        # Buffers for GP training and inference
+        self.gp_params_buffer = torch.empty(self.gp_max_obs, self.hyperparameters.num, dtype=torch.float64, device=self.device)
+        self.gp_score_buffer = torch.empty(self.gp_max_obs, dtype=torch.float64, device=self.device)
+        self.gp_cost_buffer = torch.empty(self.gp_max_obs, dtype=torch.float64, device=self.device)
+        self.infer_batch_buffer = torch.empty(self.infer_batch_size, self.hyperparameters.num, dtype=torch.float64, device=self.device)
 
     def to(self, device):
         self.device = torch.device(device)
-        for attr in ('gp_score', 'gp_cost', 'likelihood_score', 'likelihood_cost',
-                     'mll_score', 'mll_cost', 'gp_params_buffer', 'gp_score_buffer',
+        for attr in ('gp_score', 'gp_cost',
+                     'gp_params_buffer', 'gp_score_buffer',
                      'gp_cost_buffer', 'infer_batch_buffer'):
             setattr(self, attr, getattr(self, attr).to(self.device))
         for opt in (self.score_opt, self.cost_opt):
@@ -714,10 +685,8 @@ class Protein:
         log_c_norm_tensor = self.gp_cost_buffer[:num_sampled]
         log_c_norm_tensor.copy_(torch.from_numpy(log_c_norm))
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", gpytorch.utils.warnings.NumericalWarning)
-            score_loss = train_gp_model(self.gp_score, self.likelihood_score, self.mll_score, self.score_opt, params_tensor, y_norm_tensor, training_iter=self.gp_training_iter)
-            cost_loss = train_gp_model(self.gp_cost, self.likelihood_cost, self.mll_cost, self.cost_opt, params_tensor, log_c_norm_tensor, training_iter=self.gp_training_iter)
+        score_loss = _fit_gp(self.gp_score, self.score_opt, params_tensor, y_norm_tensor, training_iter=self.gp_training_iter)
+        cost_loss  = _fit_gp(self.gp_cost, self.cost_opt, params_tensor, log_c_norm_tensor, training_iter=self.gp_training_iter)
 
         return score_loss, cost_loss
 
@@ -819,30 +788,25 @@ class Protein:
         # Batch predictions to avoid GPU OOM for large number of suggestions
         gp_y_norm_list, gp_log_c_norm_list = [], []
 
-        with torch.no_grad(), gpytorch.settings.fast_pred_var(), warnings.catch_warnings():
-            warnings.simplefilter("ignore", gpytorch.utils.warnings.NumericalWarning)
-
-            # Create a reusable buffer on the device to avoid allocating a huge tensor
+        with torch.no_grad():
             for i in range(0, len(suggestions), self.infer_batch_size):
                 batch_numpy = suggestions[i:i+self.infer_batch_size]
                 current_batch_size = len(batch_numpy)
 
-                # Use a slice of the buffer if the current batch is smaller
                 batch_tensor = self.infer_batch_buffer[:current_batch_size]
                 batch_tensor.copy_(torch.from_numpy(batch_numpy))
 
                 try:
                     # Score and cost prediction
-                    pred_y_mean = self.likelihood_score(self.gp_score(batch_tensor)).mean.cpu()
-                    pred_c_mean = self.likelihood_cost(self.gp_cost(batch_tensor)).mean.cpu()
-
+                    pred_y_mean, _ = self.gp_score.predict(batch_tensor)
+                    pred_c_mean, _ = self.gp_cost.predict(batch_tensor)
                 except RuntimeError:
                     # Handle numerical errors during GP prediction
-                    pred_y_mean, pred_c_mean = torch.zeros(current_batch_size)
+                    pred_y_mean = torch.zeros(current_batch_size, dtype=torch.float64)
+                    pred_c_mean = torch.zeros(current_batch_size, dtype=torch.float64)
 
-                gp_y_norm_list.append(pred_y_mean.cpu())
-                gp_log_c_norm_list.append(pred_c_mean.cpu())
-
+                gp_y_norm_list.append(pred_y_mean)
+                gp_log_c_norm_list.append(pred_c_mean)
                 del pred_y_mean, pred_c_mean
 
         # Concatenate results from all batches

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -590,6 +590,22 @@ class Protein:
         self.gp_cost_buffer = torch.empty(self.gp_max_obs, dtype=torch.float64, device=self.device)
         self.infer_batch_buffer = torch.empty(self.infer_batch_size, self.hyperparameters.num, dtype=torch.float64, device=self.device)
 
+    _CUDA_ATTRS = ('gp_score', 'gp_cost', 'score_opt', 'cost_opt',
+                    'gp_params_buffer', 'gp_score_buffer',
+                    'gp_cost_buffer', 'infer_batch_buffer')
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        for attr in self._CUDA_ATTRS:
+            state.pop(attr, None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        for attr in self._CUDA_ATTRS:
+            if attr not in self.__dict__:
+                self.__dict__[attr] = None
+
     def to(self, device):
         self.device = torch.device(device)
         for attr in ('gp_score', 'gp_cost',

--- a/src/bindings.cu
+++ b/src/bindings.cu
@@ -4,6 +4,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 #include "pufferlib.cu"
+#include "gp_cuda.cu"
 
 #define _PUFFER_STRINGIFY(x) #x
 #define PUFFER_STRINGIFY(x) _PUFFER_STRINGIFY(x)
@@ -465,6 +466,157 @@ std::unique_ptr<PuffeRL> create_pufferl(py::dict args) {
     return pufferl;
 }
 
+// ---------------------------------------------------------------------------
+// CUDA GP wrapper
+// ---------------------------------------------------------------------------
+
+using gp_arr = py::array_t<float, py::array::c_style | py::array::forcecast>;
+
+class PyGP {
+    GaussianProcess *gp_;
+
+    void check() const {
+        if (!gp_) throw std::runtime_error("GaussianProcess object is invalid");
+    }
+
+    static int check_X(py::buffer_info &buf, int dim) {
+        if (buf.ndim == 1) {
+            if (dim != 1) throw std::invalid_argument("1-D X requires dim=1");
+            return (int)buf.shape[0];
+        }
+        if (buf.ndim == 2) {
+            if ((int)buf.shape[1] != dim)
+                throw std::invalid_argument(
+                    "X has " + std::to_string(buf.shape[1]) +
+                    " cols, expected " + std::to_string(dim));
+            return (int)buf.shape[0];
+        }
+        throw std::invalid_argument("X must be 1-D or 2-D");
+    }
+
+public:
+    PyGP(int dim, int capacity,
+           float lengthscale, float outputscale, float noise, float offset)
+        : gp_(gp_create(dim, capacity,
+                          gp_kernel_matern32_linear(dim, lengthscale, outputscale, offset),
+                          noise))
+    {
+        if (!gp_) throw std::runtime_error("gp_create failed");
+    }
+    explicit PyGP(GaussianProcess *raw) : gp_(raw) {}
+    ~PyGP() { if (gp_) gp_destroy(gp_); }
+    PyGP(const PyGP &)            = delete;
+    PyGP &operator=(const PyGP &) = delete;
+    PyGP(PyGP &&o) noexcept : gp_(o.gp_) { o.gp_ = nullptr; }
+    PyGP &operator=(PyGP &&o) noexcept {
+        if (gp_) gp_destroy(gp_); gp_ = o.gp_; o.gp_ = nullptr; return *this;
+    }
+
+    void fit(gp_arr X, gp_arr y) {
+        check();
+        auto xbuf = X.request(), ybuf = y.request();
+        int n = check_X(xbuf, gp_->dim);
+        if ((int)ybuf.shape[0] != n) throw std::invalid_argument("X and y length mismatch");
+        int rc = gp_fit(gp_, (const float *)xbuf.ptr, (const float *)ybuf.ptr, n, 0);
+        if (rc == -1) throw std::runtime_error("n exceeds capacity");
+        if (rc == -2) throw std::runtime_error("Cholesky factorisation failed");
+    }
+    void recompute() { check(); gp_recompute(gp_, 0); }
+
+    py::tuple predict(gp_arr X, bool noise = false) {
+        check();
+        auto buf = X.request();
+        int m = check_X(buf, gp_->dim);
+        auto means = py::array_t<float>(m);
+        auto vars  = py::array_t<float>(m);
+        gp_predict(gp_, (const float *)buf.ptr,
+                     (float *)means.request().ptr,
+                     (float *)vars.request().ptr, m, 0);
+        if (noise) {
+            float sn = gp_get_noise(gp_);
+            float *vp = (float *)vars.request().ptr;
+            for (int i = 0; i < m; i++) vp[i] += sn;
+        }
+        return py::make_tuple(means, vars);
+    }
+
+    float log_marginal_likelihood() const { check(); return gp_marginal_log_likelihood(gp_); }
+
+    py::tuple mll_grad() const {
+        check();
+        int np = gp_->kernel->n_params, d = gp_->dim;
+        float d_raw_noise;
+        std::vector<float> kg((size_t)np);
+        gp_mll_grad(gp_, &d_raw_noise, kg.data(), 0);
+        py::list lst;
+        for (int i = 0; i < d; i++) lst.append(kg[i]);
+        lst.append(kg[np - 2]);
+        lst.append(d_raw_noise);
+        lst.append(kg[np - 1]);
+        return py::tuple(lst);
+    }
+
+    py::array_t<float> lengthscale() const {
+        check(); int d = gp_->dim;
+        py::array_t<float> res(d);
+        auto buf = res.mutable_unchecked<1>();
+        for (int i = 0; i < d; i++) buf(i) = gp_kernel_get_lengthscale(gp_->kernel, i);
+        return res;
+    }
+    float outputscale() const { check(); return gp_kernel_get_outputscale(gp_->kernel); }
+    float gp_noise()    const { check(); return gp_get_noise(gp_); }
+    float offset()      const { check(); return gp_kernel_get_offset(gp_->kernel); }
+
+    void set_lengthscale(gp_arr v) {
+        check(); auto buf = v.request();
+        if ((int)buf.shape[0] != gp_->dim)
+            throw std::invalid_argument("wrong lengthscale size: expected " + std::to_string(gp_->dim));
+        const float *p = (const float *)buf.ptr;
+        for (int i = 0; i < gp_->dim; i++) gp_kernel_set_lengthscale(gp_->kernel, i, p[i]);
+    }
+    void set_outputscale(float v) { check(); gp_kernel_set_outputscale(gp_->kernel, v); }
+    void set_gp_noise   (float v) { check(); gp_set_noise(gp_, v); }
+    void set_offset     (float v) { check(); gp_kernel_set_offset(gp_->kernel, v); }
+
+    py::array_t<float> raw_lengthscale() const {
+        check(); int d = gp_->dim;
+        py::array_t<float> res(d);
+        auto buf = res.mutable_unchecked<1>();
+        for (int i = 0; i < d; i++) buf(i) = gp_->kernel->raw_params[i];
+        return res;
+    }
+    float raw_outputscale() const { check(); return gp_->kernel->raw_params[gp_->kernel->n_params - 2]; }
+    float raw_noise()       const { check(); return gp_->raw_noise; }
+    float raw_offset()      const { check(); return gp_->kernel->raw_params[gp_->kernel->n_params - 1]; }
+
+    void set_raw_lengthscale(gp_arr v) {
+        check(); auto buf = v.request();
+        if ((int)buf.shape[0] != gp_->dim)
+            throw std::invalid_argument("wrong lengthscale size: expected " + std::to_string(gp_->dim));
+        const float *p = (const float *)buf.ptr;
+        for (int i = 0; i < gp_->dim; i++) gp_->kernel->raw_params[i] = p[i];
+    }
+    void set_raw_outputscale(float v) { check(); gp_->kernel->raw_params[gp_->kernel->n_params - 2] = v; }
+    void set_raw_noise      (float v) { check(); gp_->raw_noise = v; }
+    void set_raw_offset     (float v) { check(); gp_->kernel->raw_params[gp_->kernel->n_params - 1] = v; }
+
+    int   n()               const { check(); return gp_->n; }
+    int   dim()             const { check(); return gp_->dim; }
+    int   capacity()        const { check(); return gp_->cap; }
+    float dedup_threshold() const { check(); return gp_->dedup_threshold; }
+    void set_dedup_threshold(float v) { check(); gp_->dedup_threshold = v; }
+
+    void save(const std::string &path) const {
+        check();
+        if (gp_save(gp_, path.c_str()) != 0) throw std::runtime_error("save failed: " + path);
+    }
+    static PyGP load(const std::string &path, int extra_cap = 0) {
+        GaussianProcess *raw = gp_load(path.c_str(), extra_cap);
+        if (!raw) throw std::runtime_error("load failed: " + path);
+        return PyGP(raw);
+    }
+};
+
 PYBIND11_MODULE(_C, m) {
     // Multi-GPU: generate NCCL unique ID (call on rank 0, pass bytes to all ranks)
     m.def("get_nccl_id", []() {
@@ -630,5 +782,92 @@ PYBIND11_MODULE(_C, m) {
         .def_readonly("last_log_time", &PuffeRL::last_log_time)
         .def("num_params", [](PuffeRL& self) -> int64_t {
             return numel(self.master_weights.shape);
+        });
+
+    // CUDA GP regression
+    py::class_<PyGP>(m, "GaussianProcess")
+        .def(py::init<int, int, float, float, float, float>(),
+             py::arg("dim"), py::arg("capacity"),
+             py::arg("lengthscale") = 1.0,
+             py::arg("outputscale") = 1.0,
+             py::arg("noise")       = 1e-2,
+             py::arg("offset")      = 1.0)
+        .def("fit",       &PyGP::fit,       py::arg("X"), py::arg("y"))
+        .def("recompute", &PyGP::recompute)
+        .def("predict",   &PyGP::predict,   py::arg("X"), py::arg("noise") = false)
+        .def("mll_grad",  &PyGP::mll_grad)
+        .def_property("lengthscale", &PyGP::lengthscale, &PyGP::set_lengthscale)
+        .def_property("outputscale", &PyGP::outputscale, &PyGP::set_outputscale)
+        .def_property("noise",       &PyGP::gp_noise,    &PyGP::set_gp_noise)
+        .def_property("offset",      &PyGP::offset,      &PyGP::set_offset)
+        .def_property("raw_lengthscale",  &PyGP::raw_lengthscale, &PyGP::set_raw_lengthscale)
+        .def_property("raw_outputscale",  &PyGP::raw_outputscale, &PyGP::set_raw_outputscale)
+        .def_property("raw_noise",        &PyGP::raw_noise,       &PyGP::set_raw_noise)
+        .def_property("raw_offset",       &PyGP::raw_offset,      &PyGP::set_raw_offset)
+        .def_property_readonly("log_marginal_likelihood", &PyGP::log_marginal_likelihood)
+        .def_property_readonly("n",        &PyGP::n)
+        .def_property_readonly("dim",      &PyGP::dim)
+        .def_property_readonly("capacity", &PyGP::capacity)
+        .def_property("dedup_threshold",   &PyGP::dedup_threshold, &PyGP::set_dedup_threshold)
+        .def("save",        &PyGP::save, py::arg("path"))
+        .def_static("load", &PyGP::load, py::arg("path"), py::arg("extra_cap") = 0)
+        .def(py::pickle(
+            [](const PyGP &g) {
+                py::dict state;
+                state["dim"] = g.dim();
+                state["capacity"] = g.capacity();
+                state["dedup_threshold"] = g.dedup_threshold();
+                state["raw_noise"] = g.raw_noise();
+                state["raw_lengthscale"] = g.raw_lengthscale();
+                state["raw_outputscale"] = g.raw_outputscale();
+                state["raw_offset"] = g.raw_offset();
+                if (g.n() > 0) {
+                    char tmppath[] = "/tmp/pufferlib_gp_XXXXXX";
+                    int fd = mkstemp(tmppath);
+                    if (fd < 0) throw std::runtime_error("pickle: mkstemp failed");
+                    close(fd);
+                    try { g.save(std::string(tmppath)); }
+                    catch (...) { remove(tmppath); throw; }
+                    FILE *fp = fopen(tmppath, "rb");
+                    if (!fp) { remove(tmppath); throw std::runtime_error("pickle: fopen failed"); }
+                    fseek(fp, 0, SEEK_END); long sz = ftell(fp); fseek(fp, 0, SEEK_SET);
+                    std::string buf((size_t)sz, '\0');
+                    fread(&buf[0], 1, (size_t)sz, fp); fclose(fp); remove(tmppath);
+                    state["data"] = py::bytes(buf.data(), (size_t)sz);
+                }
+                return state;
+            },
+            [](py::dict state) {
+                int dim = state["dim"].cast<int>();
+                int cap = state["capacity"].cast<int>();
+                float dedup = state["dedup_threshold"].cast<float>();
+                if (state.contains("data")) {
+                    py::bytes blob = state["data"].cast<py::bytes>();
+                    const char *ptr = PyBytes_AS_STRING(blob.ptr());
+                    Py_ssize_t len = PyBytes_GET_SIZE(blob.ptr());
+                    char tmppath[] = "/tmp/pufferlib_gp_XXXXXX";
+                    int fd = mkstemp(tmppath);
+                    if (fd < 0) throw std::runtime_error("unpickle: mkstemp failed");
+                    ssize_t written = write(fd, ptr, (size_t)len); close(fd);
+                    if (written != len) { remove(tmppath); throw std::runtime_error("unpickle: write failed"); }
+                    int n; memcpy(&n, ptr + 8, sizeof(int));
+                    int extra_cap = cap > n ? cap - n : 0;
+                    PyGP gp(nullptr);
+                    try { gp = PyGP::load(std::string(tmppath), extra_cap); }
+                    catch (...) { remove(tmppath); throw; }
+                    remove(tmppath); gp.set_dedup_threshold(dedup); return gp;
+                }
+                PyGP gp(dim, cap, 1.0f, 1.0f, 1e-2f, 1.0f);
+                gp.set_raw_noise(state["raw_noise"].cast<float>());
+                gp.set_raw_lengthscale(state["raw_lengthscale"].cast<gp_arr>());
+                gp.set_raw_outputscale(state["raw_outputscale"].cast<float>());
+                gp.set_raw_offset(state["raw_offset"].cast<float>());
+                gp.set_dedup_threshold(dedup); return gp;
+            }
+        ))
+        .def("__repr__", [](const PyGP &g) {
+            return "<GaussianProcess dim=" + std::to_string(g.dim()) +
+                   " n=" + std::to_string(g.n()) +
+                   " cap=" + std::to_string(g.capacity()) + ">";
         });
 }

--- a/src/gp_cuda.cu
+++ b/src/gp_cuda.cu
@@ -17,88 +17,52 @@
 
 #include "gp_cuda_kernel.cu"
 
-#define CUSOLVER_CHECK(call)                                                  \
-    do {                                                                      \
-        cusolverStatus_t _s = (call);                                         \
-        if (_s != CUSOLVER_STATUS_SUCCESS) {                                  \
-            fprintf(stderr, "cuSOLVER error %s:%d: %d\n", __FILE__, __LINE__, \
-                (int)_s);                                                     \
-            abort();                                                          \
-        }                                                                     \
-    } while (0)
-
-// -- GaussianProcess struct
-// -------------------------------------------------------------
+// clang-format off
+static inline void _cusolver_check(cusolverStatus_t s, const char* f, int l) {
+    if (s != CUSOLVER_STATUS_SUCCESS) { fprintf(stderr, "cuSOLVER error %s:%d: %d\n", f, l, (int)s); abort(); }
+}
+#define CUSOLVER_CHECK(call) _cusolver_check((call), __FILE__, __LINE__)
+// clang-format on
 
 typedef struct {
     int dim, n, cap;
-    float* d_X;
-    float* d_y;
-    float* d_L;
-    float* d_alpha;
-    float* d_work;
+    float *d_X;
+    float *d_y;
+    float *d_L;
+    float *d_alpha;
+    float *d_work;
     int lwork;
-    int* d_info;
+    int *d_info;
     float raw_noise;
     float dedup_threshold;
     cublasHandle_t cublas;
     cusolverDnHandle_t cusolver;
-    GPKernel* kernel;
+    GPKernel *kernel;
 } GaussianProcess;
 
-GaussianProcess* gp_create(int dim, int cap, GPKernel* kernel, float noise);
-void gp_destroy(GaussianProcess* gp);
-float gp_get_noise(const GaussianProcess* gp);
-void gp_set_noise(GaussianProcess* gp, float v);
-int gp_fit(GaussianProcess* gp, const float* X, const float* y, int n,
-    cudaStream_t stream);
-int gp_recompute(GaussianProcess* gp, cudaStream_t stream);
-void gp_predict(const GaussianProcess* gp, const float* Xs, float* means,
-    float* vars, int m, cudaStream_t stream);
-float gp_marginal_log_likelihood(const GaussianProcess* gp);
-void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
-    float* kernel_grads, cudaStream_t stream);
-int gp_save(const GaussianProcess* gp, const char* path);
-GaussianProcess* gp_load(const char* path, int extra_cap);
-
-// -- utility device kernels --------------------------------------------------
-
-__global__ void gp_k_add_diag(float* A, int n, float val)
-{
+__global__ void gp_k_add_diag(float *A, int n, float val) {
     int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         A[(size_t)i * (n + 1)] += val;
 }
 
-__global__ void gp_k_extract_diag(const float* A, float* d, int n)
-{
+__global__ void gp_k_extract_diag(const float *A, float *d, int n) {
     int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         d[i] = A[(size_t)i * (n + 1)];
 }
 
-__global__ void gp_k_col_sqnorms(const float* V, float* sqnorms, int n, int m)
-{
+__global__ void gp_k_var_from_chol(float *vars, const float *V, int n, int m) {
     int j = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (j >= m)
         return;
     float sq = 0.0;
-    const float* col = V + (size_t)j * n;
+    const float *col = V + (size_t)j * n;
     for (int i = 0; i < n; i++)
         sq += col[i] * col[i];
-    sqnorms[j] = sq;
-}
-
-__global__ void gp_k_var_subtract(float* vars, const float* sqnorms, int m)
-{
-    int j = blockIdx.x * BLOCK_SIZE + threadIdx.x;
-    if (j >= m)
-        return;
-    float v = vars[j] - sqnorms[j];
+    float v = vars[j] - sq;
     vars[j] = v > 0.0 ? v : 0.0;
 }
-
-// -- host-side near-duplicate filter -----------------------------------------
 
 #define KD_LEAF 16
 
@@ -107,25 +71,23 @@ typedef struct {
     float split_val;
 } KDNode;
 typedef struct {
-    const float* X;
+    const float *X;
     int n, dim, n_nodes;
-    int* idx;
-    KDNode* nodes;
+    int *idx;
+    KDNode *nodes;
 } KDTree;
 
 static int g_kd_split_dim, g_kd_d;
-static const float* g_kd_X;
+static const float *g_kd_X;
 
-static int kd_cmp_fn(const void* a, const void* b)
-{
-    float va = g_kd_X[*(const int*)a * g_kd_d + g_kd_split_dim];
-    float vb = g_kd_X[*(const int*)b * g_kd_d + g_kd_split_dim];
+static int kd_cmp_fn(const void *a, const void *b) {
+    float va = g_kd_X[*(const int *)a * g_kd_d + g_kd_split_dim];
+    float vb = g_kd_X[*(const int *)b * g_kd_d + g_kd_split_dim];
     return (va > vb) - (va < vb);
 }
 
-static void kd_build(KDTree* t, int node, int lo, int hi)
-{
-    KDNode* nd = &t->nodes[node];
+static void kd_build(KDTree *t, int node, int lo, int hi) {
+    KDNode *nd = &t->nodes[node];
     nd->lo = lo;
     nd->hi = hi;
     nd->left = nd->right = -1;
@@ -163,31 +125,18 @@ static void kd_build(KDTree* t, int node, int lo, int hi)
     kd_build(t, rn, mid, hi);
 }
 
-static KDTree kd_create(const float* X, int n, int dim)
-{
-    KDTree t;
-    t.X = X;
-    t.n = n;
-    t.dim = dim;
-    t.n_nodes = 1;
-    t.idx = (int*)malloc(n * sizeof(int));
-    t.nodes = (KDNode*)malloc(2 * n * sizeof(KDNode));
+static KDTree kd_create(const float *X, int n, int dim) {
+    KDTree t = {.X = X, .n = n, .dim = dim, .n_nodes = 1};
+    t.idx = (int *)malloc(n * sizeof(int));
+    t.nodes = (KDNode *)malloc(2 * n * sizeof(KDNode));
     for (int i = 0; i < n; i++)
         t.idx[i] = i;
     kd_build(&t, 0, 0, n);
     return t;
 }
 
-static void kd_destroy(KDTree* t)
-{
-    free(t->idx);
-    free(t->nodes);
-}
-
-static void kd_query_ball(const KDTree* t, int node, const float* q, float r,
-    float r2, int* out, int* cnt)
-{
-    const KDNode* nd = &t->nodes[node];
+static void kd_query_ball(const KDTree *t, int node, const float *q, float r, float r2, int *out, int *cnt) {
+    const KDNode *nd = &t->nodes[node];
     if (nd->split_dim < 0) {
         for (int i = nd->lo; i < nd->hi; i++) {
             int p = t->idx[i];
@@ -208,9 +157,7 @@ static void kd_query_ball(const KDTree* t, int node, const float* q, float r,
         kd_query_ball(t, nd->right, q, r, r2, out, cnt);
 }
 
-static int gp_filter_near_duplicates(const float* X, int n, int dim,
-    float threshold, int* kept_indices)
-{
+static int gp_filter_near_duplicates(const float *X, int n, int dim, float threshold, int *kept_indices) {
     if (n <= 0)
         return 0;
     if (n == 1) {
@@ -219,8 +166,8 @@ static int gp_filter_near_duplicates(const float* X, int n, int dim,
     }
 
     KDTree tree = kd_create(X, n, dim);
-    int* keep = (int*)malloc(n * sizeof(int));
-    int* nearby = (int*)malloc(n * sizeof(int));
+    int *keep = (int *)malloc(n * sizeof(int));
+    int *nearby = (int *)malloc(n * sizeof(int));
     float r2 = threshold * threshold;
     for (int i = 0; i < n; i++)
         keep[i] = 1;
@@ -242,26 +189,16 @@ static int gp_filter_near_duplicates(const float* X, int n, int dim,
 
     free(nearby);
     free(keep);
-    kd_destroy(&tree);
+    free(tree.idx);
+    free(tree.nodes);
     return count;
 }
 
-// -- hyperparameter access ---------------------------------------------------
+float gp_get_noise(const GaussianProcess *gp) { return softplus(gp->raw_noise); }
+void gp_set_noise(GaussianProcess *gp, float v) { gp->raw_noise = inv_softplus(v); }
 
-float gp_get_noise(const GaussianProcess* gp)
-{
-    return softplus(gp->raw_noise);
-}
-void gp_set_noise(GaussianProcess* gp, float v)
-{
-    gp->raw_noise = inv_softplus(v);
-}
-
-// -- lifecycle ---------------------------------------------------------------
-
-GaussianProcess* gp_create(int dim, int cap, GPKernel* kernel, float noise)
-{
-    GaussianProcess* gp = (GaussianProcess*)calloc(1, sizeof(GaussianProcess));
+GaussianProcess *gp_create(int dim, int cap, GPKernel *kernel, float noise) {
+    GaussianProcess *gp = (GaussianProcess *)calloc(1, sizeof(GaussianProcess));
     gp->dim = dim;
     gp->cap = cap;
     gp->kernel = kernel;
@@ -276,8 +213,7 @@ GaussianProcess* gp_create(int dim, int cap, GPKernel* kernel, float noise)
     return gp;
 }
 
-void gp_destroy(GaussianProcess* gp)
-{
+void gp_destroy(GaussianProcess *gp) {
     if (!gp)
         return;
     cudaFree(gp->d_X);
@@ -293,55 +229,33 @@ void gp_destroy(GaussianProcess* gp)
     free(gp);
 }
 
-// -- internal helpers --------------------------------------------------------
-
-static int run_potrf(GaussianProcess* gp, float* d_K, int n,
-    cudaStream_t stream)
-{
+static int run_potrf(GaussianProcess *gp, float *d_K, int n, cudaStream_t stream) {
     CUSOLVER_CHECK(cusolverDnSetStream(gp->cusolver, stream));
     int lwork = 0;
-    CUSOLVER_CHECK(cusolverDnSpotrf_bufferSize(
-        gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K, n, &lwork));
+    CUSOLVER_CHECK(cusolverDnSpotrf_bufferSize(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K, n, &lwork));
     if (lwork > gp->lwork) {
         cudaFree(gp->d_work);
         CUDA_CHECK(cudaMalloc(&gp->d_work, (size_t)lwork * sizeof(float)));
         gp->lwork = lwork;
     }
-    CUSOLVER_CHECK(cusolverDnSpotrf(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K,
-        n, gp->d_work, gp->lwork, gp->d_info));
-
+    CUSOLVER_CHECK(
+        cusolverDnSpotrf(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K, n, gp->d_work, gp->lwork, gp->d_info));
     int h_info;
-    CUDA_CHECK(cudaMemcpyAsync(&h_info, gp->d_info, sizeof(int),
-        cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaMemcpyAsync(&h_info, gp->d_info, sizeof(int), cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaStreamSynchronize(stream));
     return h_info;
 }
 
-static void solve_alpha(GaussianProcess* gp, const float* d_L, int n,
-    float* d_alpha, cudaStream_t stream)
-{
-    CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
-    CUBLAS_CHECK(cublasStrsv(gp->cublas, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
-        CUBLAS_DIAG_NON_UNIT, n, d_L, n, d_alpha, 1));
-    CUBLAS_CHECK(cublasStrsv(gp->cublas, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_T,
-        CUBLAS_DIAG_NON_UNIT, n, d_L, n, d_alpha, 1));
-}
-
-// -- training ----------------------------------------------------------------
-
-int gp_recompute(GaussianProcess* gp, cudaStream_t stream)
-{
+int gp_recompute(GaussianProcess *gp, cudaStream_t stream) {
     int n = gp->n;
     if (n == 0)
         return 0;
 
-    gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp),
-        gp->d_L, stream);
+    gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp), gp->d_L, stream);
 
     int info = run_potrf(gp, gp->d_L, n, stream);
     if (info != 0) {
-        gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp),
-            gp->d_L, stream);
+        gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp), gp->d_L, stream);
         gp_k_add_diag<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(gp->d_L, n, 1e-8);
         CUDA_CHECK(cudaGetLastError());
         info = run_potrf(gp, gp->d_L, n, stream);
@@ -349,86 +263,65 @@ int gp_recompute(GaussianProcess* gp, cudaStream_t stream)
             return -2;
     }
 
-    CUDA_CHECK(cudaMemcpyAsync(gp->d_alpha, gp->d_y, (size_t)n * sizeof(float),
-        cudaMemcpyDeviceToDevice, stream));
-    solve_alpha(gp, gp->d_L, n, gp->d_alpha, stream);
+    CUDA_CHECK(cudaMemcpyAsync(gp->d_alpha, gp->d_y, (size_t)n * sizeof(float), cudaMemcpyDeviceToDevice, stream));
+    CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
+    CUBLAS_CHECK(cublasStrsv(gp->cublas, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N, CUBLAS_DIAG_NON_UNIT, n, gp->d_L, n,
+                             gp->d_alpha, 1));
+    CUBLAS_CHECK(cublasStrsv(gp->cublas, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_T, CUBLAS_DIAG_NON_UNIT, n, gp->d_L, n,
+                             gp->d_alpha, 1));
     return 0;
 }
 
-int gp_fit(GaussianProcess* gp, const float* X, const float* y, int n,
-    cudaStream_t stream)
-{
+int gp_fit(GaussianProcess *gp, const float *X, const float *y, int n, cudaStream_t stream) {
     if (n > gp->cap)
         return -1;
 
     if (gp->dedup_threshold > 0.0 && n > 1) {
-        int* idx = (int*)malloc(n * sizeof(int));
+        int *idx = (int *)malloc(n * sizeof(int));
         int n_kept = gp_filter_near_duplicates(X, n, gp->dim, gp->dedup_threshold, idx);
-        float* X_c = (float*)malloc((size_t)n_kept * gp->dim * sizeof(float));
-        float* y_c = (float*)malloc((size_t)n_kept * sizeof(float));
+        float *X_c = (float *)malloc((size_t)n_kept * gp->dim * sizeof(float));
+        float *y_c = (float *)malloc((size_t)n_kept * sizeof(float));
         for (int i = 0; i < n_kept; i++) {
             memcpy(&X_c[i * gp->dim], &X[idx[i] * gp->dim], gp->dim * sizeof(float));
             y_c[i] = y[idx[i]];
         }
         free(idx);
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X_c,
-            (size_t)n_kept * gp->dim * sizeof(float),
-            cudaMemcpyHostToDevice, stream));
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y_c, (size_t)n_kept * sizeof(float),
-            cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(
+            cudaMemcpyAsync(gp->d_X, X_c, (size_t)n_kept * gp->dim * sizeof(float), cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y_c, (size_t)n_kept * sizeof(float), cudaMemcpyHostToDevice, stream));
         free(X_c);
         free(y_c);
         gp->n = n_kept;
     } else {
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X, (size_t)n * gp->dim * sizeof(float),
-            cudaMemcpyHostToDevice, stream));
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y, (size_t)n * sizeof(float),
-            cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X, (size_t)n * gp->dim * sizeof(float), cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y, (size_t)n * sizeof(float), cudaMemcpyHostToDevice, stream));
         gp->n = n;
     }
     return gp_recompute(gp, stream);
 }
 
-// -- prediction --------------------------------------------------------------
-
-static void predict_dev(const GaussianProcess* gp, const float* d_Xte,
-    float* d_means, float* d_vars, int m,
-    cudaStream_t stream)
-{
+static void predict_dev(const GaussianProcess *gp, const float *d_Xte, float *d_means, float *d_vars, int m,
+                        cudaStream_t stream) {
     int n = gp->n, d = gp->dim;
     const float one = 1.0, zero = 0.0;
     CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
 
-    float* d_Ks;
+    float *d_Ks;
     CUDA_CHECK(cudaMallocAsync(&d_Ks, (size_t)n * m * sizeof(float), stream));
     gp->kernel->build_Ks(gp->kernel, gp->d_X, d_Xte, n, m, d, d_Ks, stream);
-
-    CUBLAS_CHECK(cublasSgemv(gp->cublas, CUBLAS_OP_T, n, m, &one, d_Ks, n,
-        gp->d_alpha, 1, &zero, d_means, 1));
+    CUBLAS_CHECK(cublasSgemv(gp->cublas, CUBLAS_OP_T, n, m, &one, d_Ks, n, gp->d_alpha, 1, &zero, d_means, 1));
 
     if (d_vars) {
         gp->kernel->build_kself_batch(gp->kernel, d_Xte, m, d, d_vars, stream);
-
-        CUBLAS_CHECK(cublasStrsm(
-            gp->cublas, CUBLAS_SIDE_LEFT, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
-            CUBLAS_DIAG_NON_UNIT, n, m, &one, gp->d_L, n, d_Ks, n));
-        float* d_sqnorms;
-        CUDA_CHECK(cudaMallocAsync(&d_sqnorms, (size_t)m * sizeof(float), stream));
-        gp_k_col_sqnorms<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_Ks, d_sqnorms, n,
-            m);
+        CUBLAS_CHECK(cublasStrsm(gp->cublas, CUBLAS_SIDE_LEFT, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
+                                 CUBLAS_DIAG_NON_UNIT, n, m, &one, gp->d_L, n, d_Ks, n));
+        gp_k_var_from_chol<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_vars, d_Ks, n, m);
         CUDA_CHECK(cudaGetLastError());
-        gp_k_var_subtract<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_vars, d_sqnorms,
-            m);
-        CUDA_CHECK(cudaGetLastError());
-        CUDA_CHECK(cudaFreeAsync(d_sqnorms, stream));
     }
-
     CUDA_CHECK(cudaFreeAsync(d_Ks, stream));
 }
 
-void gp_predict(const GaussianProcess* gp, const float* Xs, float* means,
-    float* vars, int m, cudaStream_t stream)
-{
+void gp_predict(const GaussianProcess *gp, const float *Xs, float *means, float *vars, int m, cudaStream_t stream) {
     int n = gp->n;
     if (n == 0) {
         for (int j = 0; j < m; j++) {
@@ -439,11 +332,9 @@ void gp_predict(const GaussianProcess* gp, const float* Xs, float* means,
         return;
     }
 
-    float* d_Xte;
-    CUDA_CHECK(
-        cudaMallocAsync(&d_Xte, (size_t)m * gp->dim * sizeof(float), stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_Xte, Xs, (size_t)m * gp->dim * sizeof(float),
-        cudaMemcpyHostToDevice, stream));
+    float *d_Xte;
+    CUDA_CHECK(cudaMallocAsync(&d_Xte, (size_t)m * gp->dim * sizeof(float), stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_Xte, Xs, (size_t)m * gp->dim * sizeof(float), cudaMemcpyHostToDevice, stream));
 
     float *d_means, *d_vars = NULL;
     CUDA_CHECK(cudaMallocAsync(&d_means, (size_t)m * sizeof(float), stream));
@@ -452,39 +343,31 @@ void gp_predict(const GaussianProcess* gp, const float* Xs, float* means,
 
     predict_dev(gp, d_Xte, d_means, d_vars, m, stream);
     CUDA_CHECK(cudaFreeAsync(d_Xte, stream));
-
-    CUDA_CHECK(cudaMemcpyAsync(means, d_means, (size_t)m * sizeof(float),
-        cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaMemcpyAsync(means, d_means, (size_t)m * sizeof(float), cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaFreeAsync(d_means, stream));
     if (vars) {
-        CUDA_CHECK(cudaMemcpyAsync(vars, d_vars, (size_t)m * sizeof(float),
-            cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK(cudaMemcpyAsync(vars, d_vars, (size_t)m * sizeof(float), cudaMemcpyDeviceToHost, stream));
         CUDA_CHECK(cudaFreeAsync(d_vars, stream));
     }
     CUDA_CHECK(cudaStreamSynchronize(stream));
 }
 
-// -- likelihood and gradients ------------------------------------------------
-
-float gp_marginal_log_likelihood(const GaussianProcess* gp)
-{
+float gp_marginal_log_likelihood(const GaussianProcess *gp) {
     int n = gp->n;
     if (n == 0)
         return 0.0;
 
     CUBLAS_CHECK(cublasSetStream(gp->cublas, 0));
     float data_fit;
-    CUBLAS_CHECK(
-        cublasSdot(gp->cublas, n, gp->d_y, 1, gp->d_alpha, 1, &data_fit));
+    CUBLAS_CHECK(cublasSdot(gp->cublas, n, gp->d_y, 1, gp->d_alpha, 1, &data_fit));
 
-    float* d_diag;
+    float *d_diag;
     CUDA_CHECK(cudaMalloc(&d_diag, (size_t)n * sizeof(float)));
     gp_k_extract_diag<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(gp->d_L, d_diag, n);
     CUDA_CHECK(cudaGetLastError());
 
-    float* h_diag = (float*)malloc(n * sizeof(float));
-    CUDA_CHECK(cudaMemcpy(h_diag, d_diag, (size_t)n * sizeof(float),
-        cudaMemcpyDeviceToHost));
+    float *h_diag = (float *)malloc(n * sizeof(float));
+    CUDA_CHECK(cudaMemcpy(h_diag, d_diag, (size_t)n * sizeof(float), cudaMemcpyDeviceToHost));
     CUDA_CHECK(cudaFree(d_diag));
 
     float log_det = 0.0;
@@ -495,9 +378,7 @@ float gp_marginal_log_likelihood(const GaussianProcess* gp)
     return (-0.5 * data_fit - log_det - 0.5 * n * log(2.0 * M_PI)) / n;
 }
 
-void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
-    float* kernel_grads, cudaStream_t stream)
-{
+void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_grads, cudaStream_t stream) {
     int n = gp->n;
     if (n == 0) {
         if (d_raw_noise)
@@ -511,19 +392,16 @@ void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
     CUSOLVER_CHECK(cusolverDnSetStream(gp->cusolver, stream));
     CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
 
-    float* d_Kinv;
+    float *d_Kinv;
     CUDA_CHECK(cudaMallocAsync(&d_Kinv, (size_t)n * n * sizeof(float), stream));
     CUDA_CHECK(cudaMemsetAsync(d_Kinv, 0, (size_t)n * n * sizeof(float), stream));
     gp_k_add_diag<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_Kinv, n, 1.0);
     CUDA_CHECK(cudaGetLastError());
-
-    CUSOLVER_CHECK(cusolverDnSpotrs(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, n,
-        gp->d_L, n, d_Kinv, n, gp->d_info));
+    CUSOLVER_CHECK(cusolverDnSpotrs(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, n, gp->d_L, n, d_Kinv, n, gp->d_info));
 
     if (d_raw_noise) {
         float term1, term2;
-        CUBLAS_CHECK(
-            cublasSdot(gp->cublas, n, gp->d_alpha, 1, gp->d_alpha, 1, &term1));
+        CUBLAS_CHECK(cublasSdot(gp->cublas, n, gp->d_alpha, 1, gp->d_alpha, 1, &term1));
         CUBLAS_CHECK(cublasSasum(gp->cublas, n, d_Kinv, n + 1, &term2));
         *d_raw_noise = 0.5 * (term1 - term2) * softplus_grad(gp->raw_noise) / n;
     }
@@ -531,50 +409,39 @@ void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
     if (kernel_grads) {
         for (int i = 0; i < gp->kernel->n_params; i++)
             kernel_grads[i] = 0.0;
-        gp->kernel->mll_grad(gp->kernel, gp->d_X, n, gp->dim, gp->cublas, stream,
-            gp->d_alpha, d_Kinv, kernel_grads);
+        gp->kernel->mll_grad(gp->kernel, gp->d_X, n, gp->dim, gp->cublas, stream, gp->d_alpha, d_Kinv, kernel_grads);
         for (int i = 0; i < gp->kernel->n_params; i++)
             kernel_grads[i] /= n;
     }
-
     CUDA_CHECK(cudaFreeAsync(d_Kinv, stream));
 }
 
-// -- kernel registry for gp_load ---------------------------------------------
-
 typedef struct {
-    const char* tag;
-    GPKernel* (*make)(float*, int);
+    const char *tag;
+    GPKernel *(*make)(float *, int);
 } KernelFactory;
 
-static GPKernel* kf_matern32lin(float* rp, int np)
-{
+static GPKernel *kf_matern32lin(float *rp, int np) {
     int dim = np - 2;
-    GPKernel* k = gp_kernel_matern32_linear(dim, 1.0, 1.0, 1.0);
+    GPKernel *k = gp_kernel_matern32_linear(dim, 1.0, 1.0, 1.0);
     memcpy(k->raw_params, rp, (size_t)np * sizeof(float));
     return k;
 }
 
-static const KernelFactory kernel_registry[] = {
-    { GP_KERNEL_TAG_MATERN32_LINEAR, kf_matern32lin }, { NULL, NULL }
-};
+static const KernelFactory kernel_registry[] = {{GP_KERNEL_TAG_MATERN32_LINEAR, kf_matern32lin}, {NULL, NULL}};
 
-static GPKernel* kernel_from_tag(const char* tag, float* rp, int np)
-{
+static GPKernel *kernel_from_tag(const char *tag, float *rp, int np) {
     for (int i = 0; kernel_registry[i].tag; i++)
         if (memcmp(tag, kernel_registry[i].tag, 4) == 0)
             return kernel_registry[i].make(rp, np);
     return NULL;
 }
 
-// -- save / load -------------------------------------------------------------
-
-int gp_save(const GaussianProcess* gp, const char* path)
-{
+int gp_save(const GaussianProcess *gp, const char *path) {
     if (gp->n == 0)
         return -1;
     CUDA_CHECK(cudaDeviceSynchronize());
-    FILE* f = fopen(path, "wb");
+    FILE *f = fopen(path, "wb");
     if (!f)
         return -1;
 
@@ -587,44 +454,27 @@ int gp_save(const GaussianProcess* gp, const char* path)
     fwrite(&np, sizeof(int), 1, f);
     fwrite(gp->kernel->raw_params, sizeof(float), np, f);
 
-    float* h_X = (float*)malloc((size_t)n * dim * sizeof(float));
-    float* h_y = (float*)malloc((size_t)n * sizeof(float));
-    float* h_L = (float*)malloc((size_t)n * n * sizeof(float));
-    float* h_alpha = (float*)malloc((size_t)n * sizeof(float));
-    CUDA_CHECK(cudaMemcpy(h_X, gp->d_X, (size_t)n * dim * sizeof(float),
-        cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(h_y, gp->d_y, (size_t)n * sizeof(float),
-        cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(h_L, gp->d_L, (size_t)n * n * sizeof(float),
-        cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(h_alpha, gp->d_alpha, (size_t)n * sizeof(float),
-        cudaMemcpyDeviceToHost));
+    const float *d_ptrs[] = {gp->d_X, gp->d_y, gp->d_L, gp->d_alpha};
+    const size_t sizes[] = {(size_t)n * dim, (size_t)n, (size_t)n * n, (size_t)n};
+    for (int i = 0; i < 4; i++) {
+        float *h = (float *)malloc(sizes[i] * sizeof(float));
+        CUDA_CHECK(cudaMemcpy(h, d_ptrs[i], sizes[i] * sizeof(float), cudaMemcpyDeviceToHost));
+        fwrite(h, sizeof(float), sizes[i], f);
+        free(h);
+    }
 
-    fwrite(h_X, sizeof(float), (size_t)n * dim, f);
-    fwrite(h_y, sizeof(float), n, f);
-    fwrite(h_L, sizeof(float), (size_t)n * n, f);
-    fwrite(h_alpha, sizeof(float), n, f);
-
-    free(h_X);
-    free(h_y);
-    free(h_L);
-    free(h_alpha);
     fclose(f);
     return 0;
 }
 
-GaussianProcess* gp_load(const char* path, int extra_cap)
-{
-    GaussianProcess* gp = NULL;
-    float *h_X = NULL, *h_y = NULL;
-    float *h_L = NULL, *h_alpha = NULL;
-
-    FILE* f = fopen(path, "rb");
+GaussianProcess *gp_load(const char *path, int extra_cap) {
+    GaussianProcess *gp = NULL;
+    FILE *f = fopen(path, "rb");
     if (!f)
         return NULL;
 
-#define RD(ptr, sz, cnt)                         \
-    if (fread(ptr, sz, cnt, f) != (size_t)(cnt)) \
+#define RD(ptr, sz, cnt)                                                                                               \
+    if (fread(ptr, sz, cnt, f) != (size_t)(cnt))                                                                       \
     break
 
     do {
@@ -635,22 +485,20 @@ GaussianProcess* gp_load(const char* path, int extra_cap)
         RD(magic, 1, 4);
         if (memcmp(magic, "GC04", 4) != 0)
             break;
-
         RD(&dim, sizeof(int), 1);
         RD(&n, sizeof(int), 1);
         RD(&rn, sizeof(float), 1);
         RD(ktag, 1, 4);
         RD(&np, sizeof(int), 1);
 
-        float* rp = (float*)malloc((size_t)np * sizeof(float));
+        float *rp = (float *)malloc((size_t)np * sizeof(float));
         if (!rp)
             break;
         if (fread(rp, sizeof(float), np, f) != (size_t)np) {
             free(rp);
             break;
         }
-
-        GPKernel* k = kernel_from_tag(ktag, rp, np);
+        GPKernel *k = kernel_from_tag(ktag, rp, np);
         free(rp);
         if (!k)
             break;
@@ -660,38 +508,27 @@ GaussianProcess* gp_load(const char* path, int extra_cap)
         gp->raw_noise = rn;
         gp->n = n;
 
-        h_X = (float*)malloc((size_t)n * dim * sizeof(float));
-        h_y = (float*)malloc((size_t)n * sizeof(float));
-        h_L = (float*)malloc((size_t)n * n * sizeof(float));
-        h_alpha = (float*)malloc((size_t)n * sizeof(float));
+        float *d_ptrs[] = {gp->d_X, gp->d_y, gp->d_L, gp->d_alpha};
+        const size_t sizes[] = {(size_t)n * dim, (size_t)n, (size_t)n * n, (size_t)n};
+        int ok = 1;
+        for (int i = 0; i < 4 && ok; i++) {
+            float *h = (float *)malloc(sizes[i] * sizeof(float));
+            if (fread(h, sizeof(float), sizes[i], f) != sizes[i]) {
+                free(h);
+                ok = 0;
+            } else {
+                CUDA_CHECK(cudaMemcpy(d_ptrs[i], h, sizes[i] * sizeof(float), cudaMemcpyHostToDevice));
+                free(h);
+            }
+        }
+        if (!ok)
+            break;
 
-        RD(h_X, sizeof(float), (size_t)n * dim);
-        RD(h_y, sizeof(float), n);
-        RD(h_L, sizeof(float), (size_t)n * n);
-        RD(h_alpha, sizeof(float), n);
-
-        CUDA_CHECK(cudaMemcpy(gp->d_X, h_X, (size_t)n * dim * sizeof(float),
-            cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(gp->d_y, h_y, (size_t)n * sizeof(float),
-            cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(gp->d_L, h_L, (size_t)n * n * sizeof(float),
-            cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(gp->d_alpha, h_alpha, (size_t)n * sizeof(float),
-            cudaMemcpyHostToDevice));
-
-        free(h_X);
-        free(h_y);
-        free(h_L);
-        free(h_alpha);
         fclose(f);
         return gp;
     } while (0);
 
 #undef RD
-    free(h_X);
-    free(h_y);
-    free(h_L);
-    free(h_alpha);
     if (gp)
         gp_destroy(gp);
     fclose(f);

--- a/src/gp_cuda.cu
+++ b/src/gp_cuda.cu
@@ -65,21 +65,21 @@ GaussianProcess* gp_load(const char* path, int extra_cap);
 
 __global__ void gp_k_add_diag(float* A, int n, float val)
 {
-    int i = blockIdx.x * 256 + threadIdx.x;
+    int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         A[(size_t)i * (n + 1)] += val;
 }
 
 __global__ void gp_k_extract_diag(const float* A, float* d, int n)
 {
-    int i = blockIdx.x * 256 + threadIdx.x;
+    int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         d[i] = A[(size_t)i * (n + 1)];
 }
 
 __global__ void gp_k_col_sqnorms(const float* V, float* sqnorms, int n, int m)
 {
-    int j = blockIdx.x * 256 + threadIdx.x;
+    int j = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (j >= m)
         return;
     float sq = 0.0;
@@ -91,7 +91,7 @@ __global__ void gp_k_col_sqnorms(const float* V, float* sqnorms, int n, int m)
 
 __global__ void gp_k_var_subtract(float* vars, const float* sqnorms, int m)
 {
-    int j = blockIdx.x * 256 + threadIdx.x;
+    int j = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (j >= m)
         return;
     float v = vars[j] - sqnorms[j];
@@ -342,7 +342,7 @@ int gp_recompute(GaussianProcess* gp, cudaStream_t stream)
     if (info != 0) {
         gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp),
             gp->d_L, stream);
-        gp_k_add_diag<<<(n + 255) / 256, 256, 0, stream>>>(gp->d_L, n, 1e-8);
+        gp_k_add_diag<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(gp->d_L, n, 1e-8);
         CUDA_CHECK(cudaGetLastError());
         info = run_potrf(gp, gp->d_L, n, stream);
         if (info != 0)
@@ -414,10 +414,10 @@ static void predict_dev(const GaussianProcess* gp, const float* d_Xte,
             CUBLAS_DIAG_NON_UNIT, n, m, &one, gp->d_L, n, d_Ks, n));
         float* d_sqnorms;
         CUDA_CHECK(cudaMallocAsync(&d_sqnorms, (size_t)m * sizeof(float), stream));
-        gp_k_col_sqnorms<<<(m + 255) / 256, 256, 0, stream>>>(d_Ks, d_sqnorms, n,
+        gp_k_col_sqnorms<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_Ks, d_sqnorms, n,
             m);
         CUDA_CHECK(cudaGetLastError());
-        gp_k_var_subtract<<<(m + 255) / 256, 256, 0, stream>>>(d_vars, d_sqnorms,
+        gp_k_var_subtract<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_vars, d_sqnorms,
             m);
         CUDA_CHECK(cudaGetLastError());
         CUDA_CHECK(cudaFreeAsync(d_sqnorms, stream));
@@ -479,7 +479,7 @@ float gp_marginal_log_likelihood(const GaussianProcess* gp)
 
     float* d_diag;
     CUDA_CHECK(cudaMalloc(&d_diag, (size_t)n * sizeof(float)));
-    gp_k_extract_diag<<<(n + 255) / 256, 256>>>(gp->d_L, d_diag, n);
+    gp_k_extract_diag<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(gp->d_L, d_diag, n);
     CUDA_CHECK(cudaGetLastError());
 
     float* h_diag = (float*)malloc(n * sizeof(float));
@@ -514,7 +514,7 @@ void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
     float* d_Kinv;
     CUDA_CHECK(cudaMallocAsync(&d_Kinv, (size_t)n * n * sizeof(float), stream));
     CUDA_CHECK(cudaMemsetAsync(d_Kinv, 0, (size_t)n * n * sizeof(float), stream));
-    gp_k_add_diag<<<(n + 255) / 256, 256, 0, stream>>>(d_Kinv, n, 1.0);
+    gp_k_add_diag<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_Kinv, n, 1.0);
     CUDA_CHECK(cudaGetLastError());
 
     CUSOLVER_CHECK(cusolverDnSpotrs(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, n,

--- a/src/gp_cuda.cu
+++ b/src/gp_cuda.cu
@@ -8,83 +8,92 @@
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
 #include <cusolverDn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "gp_cuda_kernel.cu"
 
-#define CUSOLVER_CHECK(call) do { \
-    cusolverStatus_t _s = (call); \
-    if (_s != CUSOLVER_STATUS_SUCCESS) { \
-        fprintf(stderr, "cuSOLVER error %s:%d: %d\n", __FILE__, __LINE__, (int)_s); \
-        abort(); \
-    } \
-} while (0)
+#define CUSOLVER_CHECK(call)                                                  \
+    do {                                                                      \
+        cusolverStatus_t _s = (call);                                         \
+        if (_s != CUSOLVER_STATUS_SUCCESS) {                                  \
+            fprintf(stderr, "cuSOLVER error %s:%d: %d\n", __FILE__, __LINE__, \
+                (int)_s);                                                     \
+            abort();                                                          \
+        }                                                                     \
+    } while (0)
 
-// -- GaussianProcess struct -------------------------------------------------------------
+// -- GaussianProcess struct
+// -------------------------------------------------------------
 
 typedef struct {
     int dim, n, cap;
-    float *d_X;
-    float *d_y;
-    float *d_L;
-    float *d_alpha;
-    float *d_work;
+    float* d_X;
+    float* d_y;
+    float* d_L;
+    float* d_alpha;
+    float* d_work;
     int lwork;
-    int *d_info;
+    int* d_info;
     float raw_noise;
     float dedup_threshold;
     cublasHandle_t cublas;
     cusolverDnHandle_t cusolver;
-    GPKernel *kernel;
+    GPKernel* kernel;
 } GaussianProcess;
 
-GaussianProcess *gp_create  (int dim, int cap, GPKernel *kernel, float noise);
-void  gp_destroy (GaussianProcess *gp);
-float gp_get_noise(const GaussianProcess *gp);
-void   gp_set_noise(GaussianProcess *gp, float v);
-int  gp_fit      (GaussianProcess *gp, const float *X, const float *y, int n, cudaStream_t stream);
-int  gp_recompute(GaussianProcess *gp, cudaStream_t stream);
-void gp_predict(const GaussianProcess *gp, const float *Xs,
-                  float *means, float *vars, int m, cudaStream_t stream);
-float gp_marginal_log_likelihood(const GaussianProcess *gp);
-void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_grads,
-                   cudaStream_t stream);
-int   gp_save(const GaussianProcess *gp, const char *path);
-GaussianProcess *gp_load(const char *path, int extra_cap);
+GaussianProcess* gp_create(int dim, int cap, GPKernel* kernel, float noise);
+void gp_destroy(GaussianProcess* gp);
+float gp_get_noise(const GaussianProcess* gp);
+void gp_set_noise(GaussianProcess* gp, float v);
+int gp_fit(GaussianProcess* gp, const float* X, const float* y, int n,
+    cudaStream_t stream);
+int gp_recompute(GaussianProcess* gp, cudaStream_t stream);
+void gp_predict(const GaussianProcess* gp, const float* Xs, float* means,
+    float* vars, int m, cudaStream_t stream);
+float gp_marginal_log_likelihood(const GaussianProcess* gp);
+void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
+    float* kernel_grads, cudaStream_t stream);
+int gp_save(const GaussianProcess* gp, const char* path);
+GaussianProcess* gp_load(const char* path, int extra_cap);
 
 // -- utility device kernels --------------------------------------------------
 
-__global__ void gp_k_add_diag(float *A, int n, float val)
+__global__ void gp_k_add_diag(float* A, int n, float val)
 {
     int i = blockIdx.x * 256 + threadIdx.x;
-    if (i < n) A[(size_t)i * (n + 1)] += val;
+    if (i < n)
+        A[(size_t)i * (n + 1)] += val;
 }
 
-__global__ void gp_k_extract_diag(const float *A, float *d, int n)
+__global__ void gp_k_extract_diag(const float* A, float* d, int n)
 {
     int i = blockIdx.x * 256 + threadIdx.x;
-    if (i < n) d[i] = A[(size_t)i * (n + 1)];
+    if (i < n)
+        d[i] = A[(size_t)i * (n + 1)];
 }
 
-__global__ void gp_k_col_sqnorms(const float *V, float *sqnorms, int n, int m)
+__global__ void gp_k_col_sqnorms(const float* V, float* sqnorms, int n, int m)
 {
     int j = blockIdx.x * 256 + threadIdx.x;
-    if (j >= m) return;
+    if (j >= m)
+        return;
     float sq = 0.0;
-    const float *col = V + (size_t)j * n;
-    for (int i = 0; i < n; i++) sq += col[i] * col[i];
+    const float* col = V + (size_t)j * n;
+    for (int i = 0; i < n; i++)
+        sq += col[i] * col[i];
     sqnorms[j] = sq;
 }
 
-__global__ void gp_k_var_subtract(float *vars, const float *sqnorms, int m)
+__global__ void gp_k_var_subtract(float* vars, const float* sqnorms, int m)
 {
     int j = blockIdx.x * 256 + threadIdx.x;
-    if (j >= m) return;
+    if (j >= m)
+        return;
     float v = vars[j] - sqnorms[j];
     vars[j] = v > 0.0 ? v : 0.0;
 }
@@ -93,145 +102,201 @@ __global__ void gp_k_var_subtract(float *vars, const float *sqnorms, int m)
 
 #define KD_LEAF 16
 
-typedef struct { int lo, hi, left, right, split_dim; float split_val; } KDNode;
-typedef struct { const float *X; int n, dim, n_nodes; int *idx; KDNode *nodes; } KDTree;
+typedef struct {
+    int lo, hi, left, right, split_dim;
+    float split_val;
+} KDNode;
+typedef struct {
+    const float* X;
+    int n, dim, n_nodes;
+    int* idx;
+    KDNode* nodes;
+} KDTree;
 
-static int          g_kd_split_dim, g_kd_d;
-static const float *g_kd_X;
+static int g_kd_split_dim, g_kd_d;
+static const float* g_kd_X;
 
-static int kd_cmp_fn(const void *a, const void *b)
+static int kd_cmp_fn(const void* a, const void* b)
 {
-    float va = g_kd_X[*(const int *)a * g_kd_d + g_kd_split_dim];
-    float vb = g_kd_X[*(const int *)b * g_kd_d + g_kd_split_dim];
+    float va = g_kd_X[*(const int*)a * g_kd_d + g_kd_split_dim];
+    float vb = g_kd_X[*(const int*)b * g_kd_d + g_kd_split_dim];
     return (va > vb) - (va < vb);
 }
 
-static void kd_build(KDTree *t, int node, int lo, int hi)
+static void kd_build(KDTree* t, int node, int lo, int hi)
 {
-    KDNode *nd = &t->nodes[node];
-    nd->lo = lo; nd->hi = hi; nd->left = nd->right = -1; nd->split_dim = -1;
-    if (hi - lo <= KD_LEAF) return;
+    KDNode* nd = &t->nodes[node];
+    nd->lo = lo;
+    nd->hi = hi;
+    nd->left = nd->right = -1;
+    nd->split_dim = -1;
+    if (hi - lo <= KD_LEAF)
+        return;
 
-    int best = 0; float spread = -1.0;
+    int best = 0;
+    float spread = -1.0;
     for (int k = 0; k < t->dim; k++) {
         float mn = t->X[t->idx[lo] * t->dim + k], mx = mn;
         for (int i = lo + 1; i < hi; i++) {
             float v = t->X[t->idx[i] * t->dim + k];
-            if (v < mn) mn = v;
-            if (v > mx) mx = v;
+            if (v < mn)
+                mn = v;
+            if (v > mx)
+                mx = v;
         }
-        if (mx - mn > spread) { spread = mx - mn; best = k; }
+        if (mx - mn > spread) {
+            spread = mx - mn;
+            best = k;
+        }
     }
     int mid = (lo + hi) / 2;
-    g_kd_split_dim = best; g_kd_d = t->dim; g_kd_X = t->X;
+    g_kd_split_dim = best;
+    g_kd_d = t->dim;
+    g_kd_X = t->X;
     qsort(t->idx + lo, hi - lo, sizeof(int), kd_cmp_fn);
     nd->split_dim = best;
     nd->split_val = t->X[t->idx[mid] * t->dim + best];
     int ln = t->n_nodes++, rn = t->n_nodes++;
-    nd->left = ln; nd->right = rn;
+    nd->left = ln;
+    nd->right = rn;
     kd_build(t, ln, lo, mid);
     kd_build(t, rn, mid, hi);
 }
 
-static KDTree kd_create(const float *X, int n, int dim)
+static KDTree kd_create(const float* X, int n, int dim)
 {
     KDTree t;
-    t.X = X; t.n = n; t.dim = dim; t.n_nodes = 1;
-    t.idx   = (int    *)malloc(n * sizeof(int));
-    t.nodes = (KDNode *)malloc(2 * n * sizeof(KDNode));
-    for (int i = 0; i < n; i++) t.idx[i] = i;
+    t.X = X;
+    t.n = n;
+    t.dim = dim;
+    t.n_nodes = 1;
+    t.idx = (int*)malloc(n * sizeof(int));
+    t.nodes = (KDNode*)malloc(2 * n * sizeof(KDNode));
+    for (int i = 0; i < n; i++)
+        t.idx[i] = i;
     kd_build(&t, 0, 0, n);
     return t;
 }
 
-static void kd_destroy(KDTree *t) { free(t->idx); free(t->nodes); }
-
-static void kd_query_ball(const KDTree *t, int node, const float *q,
-                           float r, float r2, int *out, int *cnt)
+static void kd_destroy(KDTree* t)
 {
-    const KDNode *nd = &t->nodes[node];
+    free(t->idx);
+    free(t->nodes);
+}
+
+static void kd_query_ball(const KDTree* t, int node, const float* q, float r,
+    float r2, int* out, int* cnt)
+{
+    const KDNode* nd = &t->nodes[node];
     if (nd->split_dim < 0) {
         for (int i = nd->lo; i < nd->hi; i++) {
-            int p = t->idx[i]; float sq = 0.0;
+            int p = t->idx[i];
+            float sq = 0.0;
             for (int k = 0; k < t->dim; k++) {
-                float df = q[k] - t->X[p * t->dim + k]; sq += df * df;
+                float df = q[k] - t->X[p * t->dim + k];
+                sq += df * df;
             }
-            if (sq <= r2) out[(*cnt)++] = p;
+            if (sq <= r2)
+                out[(*cnt)++] = p;
         }
         return;
     }
     float dv = q[nd->split_dim] - nd->split_val;
-    if (nd->left  >= 0 && dv <=  r) kd_query_ball(t, nd->left,  q, r, r2, out, cnt);
-    if (nd->right >= 0 && dv >= -r) kd_query_ball(t, nd->right, q, r, r2, out, cnt);
+    if (nd->left >= 0 && dv <= r)
+        kd_query_ball(t, nd->left, q, r, r2, out, cnt);
+    if (nd->right >= 0 && dv >= -r)
+        kd_query_ball(t, nd->right, q, r, r2, out, cnt);
 }
 
-static int gp_filter_near_duplicates(const float *X, int n, int dim,
-                                        float threshold, int *kept_indices)
+static int gp_filter_near_duplicates(const float* X, int n, int dim,
+    float threshold, int* kept_indices)
 {
-    if (n <= 0) return 0;
-    if (n == 1) { kept_indices[0] = 0; return 1; }
+    if (n <= 0)
+        return 0;
+    if (n == 1) {
+        kept_indices[0] = 0;
+        return 1;
+    }
 
-    KDTree tree   = kd_create(X, n, dim);
-    int   *keep   = (int *)malloc(n * sizeof(int));
-    int   *nearby = (int *)malloc(n * sizeof(int));
-    float r2     = threshold * threshold;
-    for (int i = 0; i < n; i++) keep[i] = 1;
+    KDTree tree = kd_create(X, n, dim);
+    int* keep = (int*)malloc(n * sizeof(int));
+    int* nearby = (int*)malloc(n * sizeof(int));
+    float r2 = threshold * threshold;
+    for (int i = 0; i < n; i++)
+        keep[i] = 1;
 
     for (int i = n - 1; i >= 0; i--) {
-        if (!keep[i]) continue;
+        if (!keep[i])
+            continue;
         int cnt = 0;
         kd_query_ball(&tree, 0, &X[(size_t)i * dim], threshold, r2, nearby, &cnt);
         for (int j = 0; j < cnt; j++)
-            if (nearby[j] != i) keep[nearby[j]] = 0;
+            if (nearby[j] != i)
+                keep[nearby[j]] = 0;
     }
 
     int count = 0;
     for (int i = 0; i < n; i++)
-        if (keep[i]) kept_indices[count++] = i;
+        if (keep[i])
+            kept_indices[count++] = i;
 
-    free(nearby); free(keep); kd_destroy(&tree);
+    free(nearby);
+    free(keep);
+    kd_destroy(&tree);
     return count;
 }
 
 // -- hyperparameter access ---------------------------------------------------
 
-float gp_get_noise(const GaussianProcess *gp) { return softplus(gp->raw_noise);   }
-void   gp_set_noise(GaussianProcess *gp, float v) { gp->raw_noise = inv_softplus(v); }
+float gp_get_noise(const GaussianProcess* gp)
+{
+    return softplus(gp->raw_noise);
+}
+void gp_set_noise(GaussianProcess* gp, float v)
+{
+    gp->raw_noise = inv_softplus(v);
+}
 
 // -- lifecycle ---------------------------------------------------------------
 
-GaussianProcess *gp_create(int dim, int cap, GPKernel *kernel, float noise)
+GaussianProcess* gp_create(int dim, int cap, GPKernel* kernel, float noise)
 {
-    GaussianProcess *gp  = (GaussianProcess *)calloc(1, sizeof(GaussianProcess));
-    gp->dim   = dim;
-    gp->cap   = cap;
+    GaussianProcess* gp = (GaussianProcess*)calloc(1, sizeof(GaussianProcess));
+    gp->dim = dim;
+    gp->cap = cap;
     gp->kernel = kernel;
     gp_set_noise(gp, noise);
-    CUDA_CHECK(cudaMalloc(&gp->d_X,     (size_t)cap * dim * sizeof(float)));
-    CUDA_CHECK(cudaMalloc(&gp->d_y,     (size_t)cap       * sizeof(float)));
-    CUDA_CHECK(cudaMalloc(&gp->d_L,     (size_t)cap * cap * sizeof(float)));
-    CUDA_CHECK(cudaMalloc(&gp->d_alpha, (size_t)cap       * sizeof(float)));
-    CUDA_CHECK(cudaMalloc(&gp->d_info,  sizeof(int)));
-    CUBLAS_CHECK  (cublasCreate    (&gp->cublas));
+    CUDA_CHECK(cudaMalloc(&gp->d_X, (size_t)cap * dim * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_y, (size_t)cap * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_L, (size_t)cap * cap * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_alpha, (size_t)cap * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_info, sizeof(int)));
+    CUBLAS_CHECK(cublasCreate(&gp->cublas));
     CUSOLVER_CHECK(cusolverDnCreate(&gp->cusolver));
     return gp;
 }
 
-void gp_destroy(GaussianProcess *gp)
+void gp_destroy(GaussianProcess* gp)
 {
-    if (!gp) return;
-    cudaFree(gp->d_X); cudaFree(gp->d_y);
-    cudaFree(gp->d_L); cudaFree(gp->d_alpha);
-    cudaFree(gp->d_work); cudaFree(gp->d_info);
-    cublasDestroy    (gp->cublas);
+    if (!gp)
+        return;
+    cudaFree(gp->d_X);
+    cudaFree(gp->d_y);
+    cudaFree(gp->d_L);
+    cudaFree(gp->d_alpha);
+    cudaFree(gp->d_work);
+    cudaFree(gp->d_info);
+    cublasDestroy(gp->cublas);
     cusolverDnDestroy(gp->cusolver);
-    if (gp->kernel && gp->kernel->destroy) gp->kernel->destroy(gp->kernel);
+    if (gp->kernel && gp->kernel->destroy)
+        gp->kernel->destroy(gp->kernel);
     free(gp);
 }
 
 // -- internal helpers --------------------------------------------------------
 
-static int run_potrf(GaussianProcess *gp, float *d_K, int n, cudaStream_t stream)
+static int run_potrf(GaussianProcess* gp, float* d_K, int n,
+    cudaStream_t stream)
 {
     CUSOLVER_CHECK(cusolverDnSetStream(gp->cusolver, stream));
     int lwork = 0;
@@ -242,84 +307,83 @@ static int run_potrf(GaussianProcess *gp, float *d_K, int n, cudaStream_t stream
         CUDA_CHECK(cudaMalloc(&gp->d_work, (size_t)lwork * sizeof(float)));
         gp->lwork = lwork;
     }
-    CUSOLVER_CHECK(cusolverDnSpotrf(
-        gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K, n,
-        gp->d_work, gp->lwork, gp->d_info));
+    CUSOLVER_CHECK(cusolverDnSpotrf(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K,
+        n, gp->d_work, gp->lwork, gp->d_info));
 
     int h_info;
     CUDA_CHECK(cudaMemcpyAsync(&h_info, gp->d_info, sizeof(int),
-                               cudaMemcpyDeviceToHost, stream));
+        cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaStreamSynchronize(stream));
     return h_info;
 }
 
-static void solve_alpha(GaussianProcess *gp, const float *d_L, int n, float *d_alpha,
-                        cudaStream_t stream)
+static void solve_alpha(GaussianProcess* gp, const float* d_L, int n,
+    float* d_alpha, cudaStream_t stream)
 {
     CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
-    CUBLAS_CHECK(cublasStrsv(gp->cublas,
-        CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N, CUBLAS_DIAG_NON_UNIT,
-        n, d_L, n, d_alpha, 1));
-    CUBLAS_CHECK(cublasStrsv(gp->cublas,
-        CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_T, CUBLAS_DIAG_NON_UNIT,
-        n, d_L, n, d_alpha, 1));
+    CUBLAS_CHECK(cublasStrsv(gp->cublas, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
+        CUBLAS_DIAG_NON_UNIT, n, d_L, n, d_alpha, 1));
+    CUBLAS_CHECK(cublasStrsv(gp->cublas, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_T,
+        CUBLAS_DIAG_NON_UNIT, n, d_L, n, d_alpha, 1));
 }
 
 // -- training ----------------------------------------------------------------
 
-int gp_recompute(GaussianProcess *gp, cudaStream_t stream)
+int gp_recompute(GaussianProcess* gp, cudaStream_t stream)
 {
     int n = gp->n;
-    if (n == 0) return 0;
+    if (n == 0)
+        return 0;
 
-    gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp), gp->d_L, stream);
+    gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp),
+        gp->d_L, stream);
 
     int info = run_potrf(gp, gp->d_L, n, stream);
     if (info != 0) {
-        gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp), gp->d_L, stream);
+        gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp),
+            gp->d_L, stream);
         gp_k_add_diag<<<(n + 255) / 256, 256, 0, stream>>>(gp->d_L, n, 1e-8);
         CUDA_CHECK(cudaGetLastError());
         info = run_potrf(gp, gp->d_L, n, stream);
-        if (info != 0) return -2;
+        if (info != 0)
+            return -2;
     }
 
-    CUDA_CHECK(cudaMemcpyAsync(gp->d_alpha, gp->d_y,
-                               (size_t)n * sizeof(float), cudaMemcpyDeviceToDevice, stream));
+    CUDA_CHECK(cudaMemcpyAsync(gp->d_alpha, gp->d_y, (size_t)n * sizeof(float),
+        cudaMemcpyDeviceToDevice, stream));
     solve_alpha(gp, gp->d_L, n, gp->d_alpha, stream);
     return 0;
 }
 
-int gp_fit(GaussianProcess *gp, const float *X, const float *y, int n, cudaStream_t stream)
+int gp_fit(GaussianProcess* gp, const float* X, const float* y, int n,
+    cudaStream_t stream)
 {
-    if (n > gp->cap) return -1;
+    if (n > gp->cap)
+        return -1;
 
     if (gp->dedup_threshold > 0.0 && n > 1) {
-        int    *idx    = (int *)malloc(n * sizeof(int));
-        int     n_kept = gp_filter_near_duplicates(X, n, gp->dim,
-                                                   gp->dedup_threshold, idx);
-        float *X_c    = (float *)malloc((size_t)n_kept * gp->dim * sizeof(float));
-        float *y_c    = (float *)malloc((size_t)n_kept * sizeof(float));
+        int* idx = (int*)malloc(n * sizeof(int));
+        int n_kept = gp_filter_near_duplicates(X, n, gp->dim, gp->dedup_threshold, idx);
+        float* X_c = (float*)malloc((size_t)n_kept * gp->dim * sizeof(float));
+        float* y_c = (float*)malloc((size_t)n_kept * sizeof(float));
         for (int i = 0; i < n_kept; i++) {
-            memcpy(&X_c[i * gp->dim], &X[idx[i] * gp->dim],
-                   gp->dim * sizeof(float));
+            memcpy(&X_c[i * gp->dim], &X[idx[i] * gp->dim], gp->dim * sizeof(float));
             y_c[i] = y[idx[i]];
         }
         free(idx);
         CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X_c,
-                                   (size_t)n_kept * gp->dim * sizeof(float),
-                                   cudaMemcpyHostToDevice, stream));
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y_c,
-                                   (size_t)n_kept * sizeof(float),
-                                   cudaMemcpyHostToDevice, stream));
-        free(X_c); free(y_c);
+            (size_t)n_kept * gp->dim * sizeof(float),
+            cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y_c, (size_t)n_kept * sizeof(float),
+            cudaMemcpyHostToDevice, stream));
+        free(X_c);
+        free(y_c);
         gp->n = n_kept;
     } else {
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X,
-                                   (size_t)n * gp->dim * sizeof(float),
-                                   cudaMemcpyHostToDevice, stream));
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y,
-                                   (size_t)n * sizeof(float),
-                                   cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X, (size_t)n * gp->dim * sizeof(float),
+            cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y, (size_t)n * sizeof(float),
+            cudaMemcpyHostToDevice, stream));
         gp->n = n;
     }
     return gp_recompute(gp, stream);
@@ -327,31 +391,34 @@ int gp_fit(GaussianProcess *gp, const float *X, const float *y, int n, cudaStrea
 
 // -- prediction --------------------------------------------------------------
 
-static void predict_dev(const GaussianProcess *gp, const float *d_Xte,
-                        float *d_means, float *d_vars, int m, cudaStream_t stream)
+static void predict_dev(const GaussianProcess* gp, const float* d_Xte,
+    float* d_means, float* d_vars, int m,
+    cudaStream_t stream)
 {
     int n = gp->n, d = gp->dim;
     const float one = 1.0, zero = 0.0;
     CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
 
-    float *d_Ks;
+    float* d_Ks;
     CUDA_CHECK(cudaMallocAsync(&d_Ks, (size_t)n * m * sizeof(float), stream));
     gp->kernel->build_Ks(gp->kernel, gp->d_X, d_Xte, n, m, d, d_Ks, stream);
 
-    CUBLAS_CHECK(cublasSgemv(gp->cublas, CUBLAS_OP_T, n, m,
-                             &one, d_Ks, n, gp->d_alpha, 1, &zero, d_means, 1));
+    CUBLAS_CHECK(cublasSgemv(gp->cublas, CUBLAS_OP_T, n, m, &one, d_Ks, n,
+        gp->d_alpha, 1, &zero, d_means, 1));
 
     if (d_vars) {
         gp->kernel->build_kself_batch(gp->kernel, d_Xte, m, d, d_vars, stream);
 
-        CUBLAS_CHECK(cublasStrsm(gp->cublas,
-            CUBLAS_SIDE_LEFT, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
+        CUBLAS_CHECK(cublasStrsm(
+            gp->cublas, CUBLAS_SIDE_LEFT, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
             CUBLAS_DIAG_NON_UNIT, n, m, &one, gp->d_L, n, d_Ks, n));
-        float *d_sqnorms;
+        float* d_sqnorms;
         CUDA_CHECK(cudaMallocAsync(&d_sqnorms, (size_t)m * sizeof(float), stream));
-        gp_k_col_sqnorms<<<(m + 255) / 256, 256, 0, stream>>>(d_Ks, d_sqnorms, n, m);
+        gp_k_col_sqnorms<<<(m + 255) / 256, 256, 0, stream>>>(d_Ks, d_sqnorms, n,
+            m);
         CUDA_CHECK(cudaGetLastError());
-        gp_k_var_subtract<<<(m + 255) / 256, 256, 0, stream>>>(d_vars, d_sqnorms, m);
+        gp_k_var_subtract<<<(m + 255) / 256, 256, 0, stream>>>(d_vars, d_sqnorms,
+            m);
         CUDA_CHECK(cudaGetLastError());
         CUDA_CHECK(cudaFreeAsync(d_sqnorms, stream));
     }
@@ -359,36 +426,39 @@ static void predict_dev(const GaussianProcess *gp, const float *d_Xte,
     CUDA_CHECK(cudaFreeAsync(d_Ks, stream));
 }
 
-void gp_predict(const GaussianProcess *gp, const float *Xs, float *means, float *vars,
-                  int m, cudaStream_t stream)
+void gp_predict(const GaussianProcess* gp, const float* Xs, float* means,
+    float* vars, int m, cudaStream_t stream)
 {
     int n = gp->n;
     if (n == 0) {
         for (int j = 0; j < m; j++) {
             means[j] = 0.0;
-            if (vars) vars[j] = gp->kernel->k_self(gp->kernel, &Xs[j * gp->dim], gp->dim);
+            if (vars)
+                vars[j] = gp->kernel->k_self(gp->kernel, &Xs[j * gp->dim], gp->dim);
         }
         return;
     }
 
-    float *d_Xte;
-    CUDA_CHECK(cudaMallocAsync(&d_Xte, (size_t)m * gp->dim * sizeof(float), stream));
+    float* d_Xte;
+    CUDA_CHECK(
+        cudaMallocAsync(&d_Xte, (size_t)m * gp->dim * sizeof(float), stream));
     CUDA_CHECK(cudaMemcpyAsync(d_Xte, Xs, (size_t)m * gp->dim * sizeof(float),
-                               cudaMemcpyHostToDevice, stream));
+        cudaMemcpyHostToDevice, stream));
 
     float *d_means, *d_vars = NULL;
     CUDA_CHECK(cudaMallocAsync(&d_means, (size_t)m * sizeof(float), stream));
-    if (vars) CUDA_CHECK(cudaMallocAsync(&d_vars, (size_t)m * sizeof(float), stream));
+    if (vars)
+        CUDA_CHECK(cudaMallocAsync(&d_vars, (size_t)m * sizeof(float), stream));
 
     predict_dev(gp, d_Xte, d_means, d_vars, m, stream);
     CUDA_CHECK(cudaFreeAsync(d_Xte, stream));
 
     CUDA_CHECK(cudaMemcpyAsync(means, d_means, (size_t)m * sizeof(float),
-                               cudaMemcpyDeviceToHost, stream));
+        cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaFreeAsync(d_means, stream));
     if (vars) {
         CUDA_CHECK(cudaMemcpyAsync(vars, d_vars, (size_t)m * sizeof(float),
-                                   cudaMemcpyDeviceToHost, stream));
+            cudaMemcpyDeviceToHost, stream));
         CUDA_CHECK(cudaFreeAsync(d_vars, stream));
     }
     CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -396,67 +466,75 @@ void gp_predict(const GaussianProcess *gp, const float *Xs, float *means, float 
 
 // -- likelihood and gradients ------------------------------------------------
 
-float gp_marginal_log_likelihood(const GaussianProcess *gp)
+float gp_marginal_log_likelihood(const GaussianProcess* gp)
 {
     int n = gp->n;
-    if (n == 0) return 0.0;
+    if (n == 0)
+        return 0.0;
 
     CUBLAS_CHECK(cublasSetStream(gp->cublas, 0));
     float data_fit;
-    CUBLAS_CHECK(cublasSdot(gp->cublas, n, gp->d_y, 1, gp->d_alpha, 1, &data_fit));
+    CUBLAS_CHECK(
+        cublasSdot(gp->cublas, n, gp->d_y, 1, gp->d_alpha, 1, &data_fit));
 
-    float *d_diag;
+    float* d_diag;
     CUDA_CHECK(cudaMalloc(&d_diag, (size_t)n * sizeof(float)));
     gp_k_extract_diag<<<(n + 255) / 256, 256>>>(gp->d_L, d_diag, n);
     CUDA_CHECK(cudaGetLastError());
 
-    float *h_diag = (float *)malloc(n * sizeof(float));
+    float* h_diag = (float*)malloc(n * sizeof(float));
     CUDA_CHECK(cudaMemcpy(h_diag, d_diag, (size_t)n * sizeof(float),
-                          cudaMemcpyDeviceToHost));
+        cudaMemcpyDeviceToHost));
     CUDA_CHECK(cudaFree(d_diag));
 
     float log_det = 0.0;
-    for (int i = 0; i < n; i++) log_det += log(h_diag[i]);
+    for (int i = 0; i < n; i++)
+        log_det += log(h_diag[i]);
     free(h_diag);
 
     return (-0.5 * data_fit - log_det - 0.5 * n * log(2.0 * M_PI)) / n;
 }
 
-void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_grads,
-                   cudaStream_t stream)
+void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
+    float* kernel_grads, cudaStream_t stream)
 {
     int n = gp->n;
     if (n == 0) {
-        if (d_raw_noise) *d_raw_noise = 0.0;
+        if (d_raw_noise)
+            *d_raw_noise = 0.0;
         if (kernel_grads)
-            for (int i = 0; i < gp->kernel->n_params; i++) kernel_grads[i] = 0.0;
+            for (int i = 0; i < gp->kernel->n_params; i++)
+                kernel_grads[i] = 0.0;
         return;
     }
 
     CUSOLVER_CHECK(cusolverDnSetStream(gp->cusolver, stream));
     CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
 
-    float *d_Kinv;
+    float* d_Kinv;
     CUDA_CHECK(cudaMallocAsync(&d_Kinv, (size_t)n * n * sizeof(float), stream));
     CUDA_CHECK(cudaMemsetAsync(d_Kinv, 0, (size_t)n * n * sizeof(float), stream));
     gp_k_add_diag<<<(n + 255) / 256, 256, 0, stream>>>(d_Kinv, n, 1.0);
     CUDA_CHECK(cudaGetLastError());
 
-    CUSOLVER_CHECK(cusolverDnSpotrs(gp->cusolver, CUBLAS_FILL_MODE_LOWER,
-                                    n, n, gp->d_L, n, d_Kinv, n, gp->d_info));
+    CUSOLVER_CHECK(cusolverDnSpotrs(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, n,
+        gp->d_L, n, d_Kinv, n, gp->d_info));
 
     if (d_raw_noise) {
         float term1, term2;
-        CUBLAS_CHECK(cublasSdot (gp->cublas, n, gp->d_alpha, 1, gp->d_alpha, 1, &term1));
+        CUBLAS_CHECK(
+            cublasSdot(gp->cublas, n, gp->d_alpha, 1, gp->d_alpha, 1, &term1));
         CUBLAS_CHECK(cublasSasum(gp->cublas, n, d_Kinv, n + 1, &term2));
         *d_raw_noise = 0.5 * (term1 - term2) * softplus_grad(gp->raw_noise) / n;
     }
 
     if (kernel_grads) {
-        for (int i = 0; i < gp->kernel->n_params; i++) kernel_grads[i] = 0.0;
-        gp->kernel->mll_grad(gp->kernel, gp->d_X, n, gp->dim,
-                             gp->cublas, stream, gp->d_alpha, d_Kinv, kernel_grads);
-        for (int i = 0; i < gp->kernel->n_params; i++) kernel_grads[i] /= n;
+        for (int i = 0; i < gp->kernel->n_params; i++)
+            kernel_grads[i] = 0.0;
+        gp->kernel->mll_grad(gp->kernel, gp->d_X, n, gp->dim, gp->cublas, stream,
+            gp->d_alpha, d_Kinv, kernel_grads);
+        for (int i = 0; i < gp->kernel->n_params; i++)
+            kernel_grads[i] /= n;
     }
 
     CUDA_CHECK(cudaFreeAsync(d_Kinv, stream));
@@ -464,22 +542,24 @@ void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_gr
 
 // -- kernel registry for gp_load ---------------------------------------------
 
-typedef struct { const char *tag; GPKernel *(*make)(float *, int); } KernelFactory;
+typedef struct {
+    const char* tag;
+    GPKernel* (*make)(float*, int);
+} KernelFactory;
 
-static GPKernel *kf_matern32lin(float *rp, int np)
+static GPKernel* kf_matern32lin(float* rp, int np)
 {
     int dim = np - 2;
-    GPKernel *k = gp_kernel_matern32_linear(dim, 1.0, 1.0, 1.0);
+    GPKernel* k = gp_kernel_matern32_linear(dim, 1.0, 1.0, 1.0);
     memcpy(k->raw_params, rp, (size_t)np * sizeof(float));
     return k;
 }
 
 static const KernelFactory kernel_registry[] = {
-    { GP_KERNEL_TAG_MATERN32_LINEAR, kf_matern32lin },
-    { NULL, NULL }
+    { GP_KERNEL_TAG_MATERN32_LINEAR, kf_matern32lin }, { NULL, NULL }
 };
 
-static GPKernel *kernel_from_tag(const char *tag, float *rp, int np)
+static GPKernel* kernel_from_tag(const char* tag, float* rp, int np)
 {
     for (int i = 0; kernel_registry[i].tag; i++)
         if (memcmp(tag, kernel_registry[i].tag, 4) == 0)
@@ -489,103 +569,131 @@ static GPKernel *kernel_from_tag(const char *tag, float *rp, int np)
 
 // -- save / load -------------------------------------------------------------
 
-int gp_save(const GaussianProcess *gp, const char *path)
+int gp_save(const GaussianProcess* gp, const char* path)
 {
-    if (gp->n == 0) return -1;
+    if (gp->n == 0)
+        return -1;
     CUDA_CHECK(cudaDeviceSynchronize());
-    FILE *f = fopen(path, "wb");
-    if (!f) return -1;
+    FILE* f = fopen(path, "wb");
+    if (!f)
+        return -1;
 
     int n = gp->n, dim = gp->dim, np = gp->kernel->n_params;
-    fwrite("GC04",                  1,              4,  f);
-    fwrite(&dim,                    sizeof(int),    1,  f);
-    fwrite(&n,                      sizeof(int),    1,  f);
-    fwrite(&gp->raw_noise,          sizeof(float), 1,  f);
-    fwrite(gp->kernel->tag,         1,              4,  f);
-    fwrite(&np,                     sizeof(int),    1,  f);
-    fwrite(gp->kernel->raw_params,  sizeof(float), np, f);
+    fwrite("GC04", 1, 4, f);
+    fwrite(&dim, sizeof(int), 1, f);
+    fwrite(&n, sizeof(int), 1, f);
+    fwrite(&gp->raw_noise, sizeof(float), 1, f);
+    fwrite(gp->kernel->tag, 1, 4, f);
+    fwrite(&np, sizeof(int), 1, f);
+    fwrite(gp->kernel->raw_params, sizeof(float), np, f);
 
-    float *h_X     = (float *)malloc((size_t)n * dim * sizeof(float));
-    float *h_y     = (float *)malloc((size_t)n       * sizeof(float));
-    float *h_L     = (float *)malloc((size_t)n * n   * sizeof(float));
-    float *h_alpha = (float *)malloc((size_t)n       * sizeof(float));
-    CUDA_CHECK(cudaMemcpy(h_X,     gp->d_X,     (size_t)n * dim * sizeof(float), cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(h_y,     gp->d_y,     (size_t)n       * sizeof(float), cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(h_L,     gp->d_L,     (size_t)n * n   * sizeof(float), cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(h_alpha, gp->d_alpha, (size_t)n       * sizeof(float), cudaMemcpyDeviceToHost));
+    float* h_X = (float*)malloc((size_t)n * dim * sizeof(float));
+    float* h_y = (float*)malloc((size_t)n * sizeof(float));
+    float* h_L = (float*)malloc((size_t)n * n * sizeof(float));
+    float* h_alpha = (float*)malloc((size_t)n * sizeof(float));
+    CUDA_CHECK(cudaMemcpy(h_X, gp->d_X, (size_t)n * dim * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_y, gp->d_y, (size_t)n * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_L, gp->d_L, (size_t)n * n * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_alpha, gp->d_alpha, (size_t)n * sizeof(float),
+        cudaMemcpyDeviceToHost));
 
-    fwrite(h_X,     sizeof(float), (size_t)n * dim, f);
-    fwrite(h_y,     sizeof(float), n,               f);
-    fwrite(h_L,     sizeof(float), (size_t)n * n,   f);
-    fwrite(h_alpha, sizeof(float), n,               f);
+    fwrite(h_X, sizeof(float), (size_t)n * dim, f);
+    fwrite(h_y, sizeof(float), n, f);
+    fwrite(h_L, sizeof(float), (size_t)n * n, f);
+    fwrite(h_alpha, sizeof(float), n, f);
 
-    free(h_X); free(h_y); free(h_L); free(h_alpha);
+    free(h_X);
+    free(h_y);
+    free(h_L);
+    free(h_alpha);
     fclose(f);
     return 0;
 }
 
-GaussianProcess *gp_load(const char *path, int extra_cap)
+GaussianProcess* gp_load(const char* path, int extra_cap)
 {
-    GaussianProcess   *gp      = NULL;
-    float *h_X     = NULL, *h_y     = NULL;
-    float *h_L     = NULL, *h_alpha = NULL;
+    GaussianProcess* gp = NULL;
+    float *h_X = NULL, *h_y = NULL;
+    float *h_L = NULL, *h_alpha = NULL;
 
-    FILE *f = fopen(path, "rb");
-    if (!f) return NULL;
+    FILE* f = fopen(path, "rb");
+    if (!f)
+        return NULL;
 
-#define RD(ptr, sz, cnt) \
-    if (fread(ptr, sz, cnt, f) != (size_t)(cnt)) break
+#define RD(ptr, sz, cnt)                         \
+    if (fread(ptr, sz, cnt, f) != (size_t)(cnt)) \
+    break
 
     do {
-        char   magic[4], ktag[4];
-        int    dim, n, np;
+        char magic[4], ktag[4];
+        int dim, n, np;
         float rn;
 
         RD(magic, 1, 4);
-        if (memcmp(magic, "GC04", 4) != 0) break;
+        if (memcmp(magic, "GC04", 4) != 0)
+            break;
 
-        RD(&dim,  sizeof(int),    1);
-        RD(&n,    sizeof(int),    1);
-        RD(&rn,   sizeof(float), 1);
-        RD(ktag,  1, 4);
-        RD(&np,   sizeof(int),    1);
+        RD(&dim, sizeof(int), 1);
+        RD(&n, sizeof(int), 1);
+        RD(&rn, sizeof(float), 1);
+        RD(ktag, 1, 4);
+        RD(&np, sizeof(int), 1);
 
-        float *rp = (float *)malloc((size_t)np * sizeof(float));
-        if (!rp) break;
-        if (fread(rp, sizeof(float), np, f) != (size_t)np) { free(rp); break; }
+        float* rp = (float*)malloc((size_t)np * sizeof(float));
+        if (!rp)
+            break;
+        if (fread(rp, sizeof(float), np, f) != (size_t)np) {
+            free(rp);
+            break;
+        }
 
-        GPKernel *k = kernel_from_tag(ktag, rp, np);
+        GPKernel* k = kernel_from_tag(ktag, rp, np);
         free(rp);
-        if (!k) break;
+        if (!k)
+            break;
 
         int cap = n + (extra_cap > 0 ? extra_cap : 0);
         gp = gp_create(dim, cap, k, 1.0);
         gp->raw_noise = rn;
         gp->n = n;
 
-        h_X     = (float *)malloc((size_t)n * dim * sizeof(float));
-        h_y     = (float *)malloc((size_t)n       * sizeof(float));
-        h_L     = (float *)malloc((size_t)n * n   * sizeof(float));
-        h_alpha = (float *)malloc((size_t)n       * sizeof(float));
+        h_X = (float*)malloc((size_t)n * dim * sizeof(float));
+        h_y = (float*)malloc((size_t)n * sizeof(float));
+        h_L = (float*)malloc((size_t)n * n * sizeof(float));
+        h_alpha = (float*)malloc((size_t)n * sizeof(float));
 
-        RD(h_X,     sizeof(float), (size_t)n * dim);
-        RD(h_y,     sizeof(float), n);
-        RD(h_L,     sizeof(float), (size_t)n * n);
+        RD(h_X, sizeof(float), (size_t)n * dim);
+        RD(h_y, sizeof(float), n);
+        RD(h_L, sizeof(float), (size_t)n * n);
         RD(h_alpha, sizeof(float), n);
 
-        CUDA_CHECK(cudaMemcpy(gp->d_X,     h_X,     (size_t)n * dim * sizeof(float), cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(gp->d_y,     h_y,     (size_t)n       * sizeof(float), cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(gp->d_L,     h_L,     (size_t)n * n   * sizeof(float), cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(gp->d_alpha, h_alpha, (size_t)n       * sizeof(float), cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_X, h_X, (size_t)n * dim * sizeof(float),
+            cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_y, h_y, (size_t)n * sizeof(float),
+            cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_L, h_L, (size_t)n * n * sizeof(float),
+            cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_alpha, h_alpha, (size_t)n * sizeof(float),
+            cudaMemcpyHostToDevice));
 
-        free(h_X); free(h_y); free(h_L); free(h_alpha);
+        free(h_X);
+        free(h_y);
+        free(h_L);
+        free(h_alpha);
         fclose(f);
         return gp;
     } while (0);
 
 #undef RD
-    free(h_X); free(h_y); free(h_L); free(h_alpha);
-    if (gp) gp_destroy(gp);
+    free(h_X);
+    free(h_y);
+    free(h_L);
+    free(h_alpha);
+    if (gp)
+        gp_destroy(gp);
     fclose(f);
     return NULL;
 }

--- a/src/gp_cuda.cu
+++ b/src/gp_cuda.cu
@@ -1,0 +1,593 @@
+// Exact GP regression, CUDA (cuBLAS/cuSOLVER).
+
+#ifndef GP_CUDA_CU
+#define GP_CUDA_CU
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <cusolverDn.h>
+
+#include "gp_cuda_kernel.cu"
+
+#define CUSOLVER_CHECK(call) do { \
+    cusolverStatus_t _s = (call); \
+    if (_s != CUSOLVER_STATUS_SUCCESS) { \
+        fprintf(stderr, "cuSOLVER error %s:%d: %d\n", __FILE__, __LINE__, (int)_s); \
+        abort(); \
+    } \
+} while (0)
+
+// -- GaussianProcess struct -------------------------------------------------------------
+
+typedef struct {
+    int dim, n, cap;
+    float *d_X;
+    float *d_y;
+    float *d_L;
+    float *d_alpha;
+    float *d_work;
+    int lwork;
+    int *d_info;
+    float raw_noise;
+    float dedup_threshold;
+    cublasHandle_t cublas;
+    cusolverDnHandle_t cusolver;
+    GPKernel *kernel;
+} GaussianProcess;
+
+GaussianProcess *gp_create  (int dim, int cap, GPKernel *kernel, float noise);
+void  gp_destroy (GaussianProcess *gp);
+float gp_get_noise(const GaussianProcess *gp);
+void   gp_set_noise(GaussianProcess *gp, float v);
+int  gp_fit      (GaussianProcess *gp, const float *X, const float *y, int n, cudaStream_t stream);
+int  gp_recompute(GaussianProcess *gp, cudaStream_t stream);
+void gp_predict(const GaussianProcess *gp, const float *Xs,
+                  float *means, float *vars, int m, cudaStream_t stream);
+float gp_marginal_log_likelihood(const GaussianProcess *gp);
+void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_grads,
+                   cudaStream_t stream);
+int   gp_save(const GaussianProcess *gp, const char *path);
+GaussianProcess *gp_load(const char *path, int extra_cap);
+
+// -- utility device kernels --------------------------------------------------
+
+__global__ void gp_k_add_diag(float *A, int n, float val)
+{
+    int i = blockIdx.x * 256 + threadIdx.x;
+    if (i < n) A[(size_t)i * (n + 1)] += val;
+}
+
+__global__ void gp_k_extract_diag(const float *A, float *d, int n)
+{
+    int i = blockIdx.x * 256 + threadIdx.x;
+    if (i < n) d[i] = A[(size_t)i * (n + 1)];
+}
+
+__global__ void gp_k_col_sqnorms(const float *V, float *sqnorms, int n, int m)
+{
+    int j = blockIdx.x * 256 + threadIdx.x;
+    if (j >= m) return;
+    float sq = 0.0;
+    const float *col = V + (size_t)j * n;
+    for (int i = 0; i < n; i++) sq += col[i] * col[i];
+    sqnorms[j] = sq;
+}
+
+__global__ void gp_k_var_subtract(float *vars, const float *sqnorms, int m)
+{
+    int j = blockIdx.x * 256 + threadIdx.x;
+    if (j >= m) return;
+    float v = vars[j] - sqnorms[j];
+    vars[j] = v > 0.0 ? v : 0.0;
+}
+
+// -- host-side near-duplicate filter -----------------------------------------
+
+#define KD_LEAF 16
+
+typedef struct { int lo, hi, left, right, split_dim; float split_val; } KDNode;
+typedef struct { const float *X; int n, dim, n_nodes; int *idx; KDNode *nodes; } KDTree;
+
+static int          g_kd_split_dim, g_kd_d;
+static const float *g_kd_X;
+
+static int kd_cmp_fn(const void *a, const void *b)
+{
+    float va = g_kd_X[*(const int *)a * g_kd_d + g_kd_split_dim];
+    float vb = g_kd_X[*(const int *)b * g_kd_d + g_kd_split_dim];
+    return (va > vb) - (va < vb);
+}
+
+static void kd_build(KDTree *t, int node, int lo, int hi)
+{
+    KDNode *nd = &t->nodes[node];
+    nd->lo = lo; nd->hi = hi; nd->left = nd->right = -1; nd->split_dim = -1;
+    if (hi - lo <= KD_LEAF) return;
+
+    int best = 0; float spread = -1.0;
+    for (int k = 0; k < t->dim; k++) {
+        float mn = t->X[t->idx[lo] * t->dim + k], mx = mn;
+        for (int i = lo + 1; i < hi; i++) {
+            float v = t->X[t->idx[i] * t->dim + k];
+            if (v < mn) mn = v;
+            if (v > mx) mx = v;
+        }
+        if (mx - mn > spread) { spread = mx - mn; best = k; }
+    }
+    int mid = (lo + hi) / 2;
+    g_kd_split_dim = best; g_kd_d = t->dim; g_kd_X = t->X;
+    qsort(t->idx + lo, hi - lo, sizeof(int), kd_cmp_fn);
+    nd->split_dim = best;
+    nd->split_val = t->X[t->idx[mid] * t->dim + best];
+    int ln = t->n_nodes++, rn = t->n_nodes++;
+    nd->left = ln; nd->right = rn;
+    kd_build(t, ln, lo, mid);
+    kd_build(t, rn, mid, hi);
+}
+
+static KDTree kd_create(const float *X, int n, int dim)
+{
+    KDTree t;
+    t.X = X; t.n = n; t.dim = dim; t.n_nodes = 1;
+    t.idx   = (int    *)malloc(n * sizeof(int));
+    t.nodes = (KDNode *)malloc(2 * n * sizeof(KDNode));
+    for (int i = 0; i < n; i++) t.idx[i] = i;
+    kd_build(&t, 0, 0, n);
+    return t;
+}
+
+static void kd_destroy(KDTree *t) { free(t->idx); free(t->nodes); }
+
+static void kd_query_ball(const KDTree *t, int node, const float *q,
+                           float r, float r2, int *out, int *cnt)
+{
+    const KDNode *nd = &t->nodes[node];
+    if (nd->split_dim < 0) {
+        for (int i = nd->lo; i < nd->hi; i++) {
+            int p = t->idx[i]; float sq = 0.0;
+            for (int k = 0; k < t->dim; k++) {
+                float df = q[k] - t->X[p * t->dim + k]; sq += df * df;
+            }
+            if (sq <= r2) out[(*cnt)++] = p;
+        }
+        return;
+    }
+    float dv = q[nd->split_dim] - nd->split_val;
+    if (nd->left  >= 0 && dv <=  r) kd_query_ball(t, nd->left,  q, r, r2, out, cnt);
+    if (nd->right >= 0 && dv >= -r) kd_query_ball(t, nd->right, q, r, r2, out, cnt);
+}
+
+static int gp_filter_near_duplicates(const float *X, int n, int dim,
+                                        float threshold, int *kept_indices)
+{
+    if (n <= 0) return 0;
+    if (n == 1) { kept_indices[0] = 0; return 1; }
+
+    KDTree tree   = kd_create(X, n, dim);
+    int   *keep   = (int *)malloc(n * sizeof(int));
+    int   *nearby = (int *)malloc(n * sizeof(int));
+    float r2     = threshold * threshold;
+    for (int i = 0; i < n; i++) keep[i] = 1;
+
+    for (int i = n - 1; i >= 0; i--) {
+        if (!keep[i]) continue;
+        int cnt = 0;
+        kd_query_ball(&tree, 0, &X[(size_t)i * dim], threshold, r2, nearby, &cnt);
+        for (int j = 0; j < cnt; j++)
+            if (nearby[j] != i) keep[nearby[j]] = 0;
+    }
+
+    int count = 0;
+    for (int i = 0; i < n; i++)
+        if (keep[i]) kept_indices[count++] = i;
+
+    free(nearby); free(keep); kd_destroy(&tree);
+    return count;
+}
+
+// -- hyperparameter access ---------------------------------------------------
+
+float gp_get_noise(const GaussianProcess *gp) { return softplus(gp->raw_noise);   }
+void   gp_set_noise(GaussianProcess *gp, float v) { gp->raw_noise = inv_softplus(v); }
+
+// -- lifecycle ---------------------------------------------------------------
+
+GaussianProcess *gp_create(int dim, int cap, GPKernel *kernel, float noise)
+{
+    GaussianProcess *gp  = (GaussianProcess *)calloc(1, sizeof(GaussianProcess));
+    gp->dim   = dim;
+    gp->cap   = cap;
+    gp->kernel = kernel;
+    gp_set_noise(gp, noise);
+    CUDA_CHECK(cudaMalloc(&gp->d_X,     (size_t)cap * dim * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_y,     (size_t)cap       * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_L,     (size_t)cap * cap * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_alpha, (size_t)cap       * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_info,  sizeof(int)));
+    CUBLAS_CHECK  (cublasCreate    (&gp->cublas));
+    CUSOLVER_CHECK(cusolverDnCreate(&gp->cusolver));
+    return gp;
+}
+
+void gp_destroy(GaussianProcess *gp)
+{
+    if (!gp) return;
+    cudaFree(gp->d_X); cudaFree(gp->d_y);
+    cudaFree(gp->d_L); cudaFree(gp->d_alpha);
+    cudaFree(gp->d_work); cudaFree(gp->d_info);
+    cublasDestroy    (gp->cublas);
+    cusolverDnDestroy(gp->cusolver);
+    if (gp->kernel && gp->kernel->destroy) gp->kernel->destroy(gp->kernel);
+    free(gp);
+}
+
+// -- internal helpers --------------------------------------------------------
+
+static int run_potrf(GaussianProcess *gp, float *d_K, int n, cudaStream_t stream)
+{
+    CUSOLVER_CHECK(cusolverDnSetStream(gp->cusolver, stream));
+    int lwork = 0;
+    CUSOLVER_CHECK(cusolverDnSpotrf_bufferSize(
+        gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K, n, &lwork));
+    if (lwork > gp->lwork) {
+        cudaFree(gp->d_work);
+        CUDA_CHECK(cudaMalloc(&gp->d_work, (size_t)lwork * sizeof(float)));
+        gp->lwork = lwork;
+    }
+    CUSOLVER_CHECK(cusolverDnSpotrf(
+        gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K, n,
+        gp->d_work, gp->lwork, gp->d_info));
+
+    int h_info;
+    CUDA_CHECK(cudaMemcpyAsync(&h_info, gp->d_info, sizeof(int),
+                               cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+    return h_info;
+}
+
+static void solve_alpha(GaussianProcess *gp, const float *d_L, int n, float *d_alpha,
+                        cudaStream_t stream)
+{
+    CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
+    CUBLAS_CHECK(cublasStrsv(gp->cublas,
+        CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N, CUBLAS_DIAG_NON_UNIT,
+        n, d_L, n, d_alpha, 1));
+    CUBLAS_CHECK(cublasStrsv(gp->cublas,
+        CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_T, CUBLAS_DIAG_NON_UNIT,
+        n, d_L, n, d_alpha, 1));
+}
+
+// -- training ----------------------------------------------------------------
+
+int gp_recompute(GaussianProcess *gp, cudaStream_t stream)
+{
+    int n = gp->n;
+    if (n == 0) return 0;
+
+    gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp), gp->d_L, stream);
+
+    int info = run_potrf(gp, gp->d_L, n, stream);
+    if (info != 0) {
+        gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp), gp->d_L, stream);
+        gp_k_add_diag<<<(n + 255) / 256, 256, 0, stream>>>(gp->d_L, n, 1e-8);
+        CUDA_CHECK(cudaGetLastError());
+        info = run_potrf(gp, gp->d_L, n, stream);
+        if (info != 0) return -2;
+    }
+
+    CUDA_CHECK(cudaMemcpyAsync(gp->d_alpha, gp->d_y,
+                               (size_t)n * sizeof(float), cudaMemcpyDeviceToDevice, stream));
+    solve_alpha(gp, gp->d_L, n, gp->d_alpha, stream);
+    return 0;
+}
+
+int gp_fit(GaussianProcess *gp, const float *X, const float *y, int n, cudaStream_t stream)
+{
+    if (n > gp->cap) return -1;
+
+    if (gp->dedup_threshold > 0.0 && n > 1) {
+        int    *idx    = (int *)malloc(n * sizeof(int));
+        int     n_kept = gp_filter_near_duplicates(X, n, gp->dim,
+                                                   gp->dedup_threshold, idx);
+        float *X_c    = (float *)malloc((size_t)n_kept * gp->dim * sizeof(float));
+        float *y_c    = (float *)malloc((size_t)n_kept * sizeof(float));
+        for (int i = 0; i < n_kept; i++) {
+            memcpy(&X_c[i * gp->dim], &X[idx[i] * gp->dim],
+                   gp->dim * sizeof(float));
+            y_c[i] = y[idx[i]];
+        }
+        free(idx);
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X_c,
+                                   (size_t)n_kept * gp->dim * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y_c,
+                                   (size_t)n_kept * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream));
+        free(X_c); free(y_c);
+        gp->n = n_kept;
+    } else {
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X,
+                                   (size_t)n * gp->dim * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y,
+                                   (size_t)n * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream));
+        gp->n = n;
+    }
+    return gp_recompute(gp, stream);
+}
+
+// -- prediction --------------------------------------------------------------
+
+static void predict_dev(const GaussianProcess *gp, const float *d_Xte,
+                        float *d_means, float *d_vars, int m, cudaStream_t stream)
+{
+    int n = gp->n, d = gp->dim;
+    const float one = 1.0, zero = 0.0;
+    CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
+
+    float *d_Ks;
+    CUDA_CHECK(cudaMallocAsync(&d_Ks, (size_t)n * m * sizeof(float), stream));
+    gp->kernel->build_Ks(gp->kernel, gp->d_X, d_Xte, n, m, d, d_Ks, stream);
+
+    CUBLAS_CHECK(cublasSgemv(gp->cublas, CUBLAS_OP_T, n, m,
+                             &one, d_Ks, n, gp->d_alpha, 1, &zero, d_means, 1));
+
+    if (d_vars) {
+        gp->kernel->build_kself_batch(gp->kernel, d_Xte, m, d, d_vars, stream);
+
+        CUBLAS_CHECK(cublasStrsm(gp->cublas,
+            CUBLAS_SIDE_LEFT, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
+            CUBLAS_DIAG_NON_UNIT, n, m, &one, gp->d_L, n, d_Ks, n));
+        float *d_sqnorms;
+        CUDA_CHECK(cudaMallocAsync(&d_sqnorms, (size_t)m * sizeof(float), stream));
+        gp_k_col_sqnorms<<<(m + 255) / 256, 256, 0, stream>>>(d_Ks, d_sqnorms, n, m);
+        CUDA_CHECK(cudaGetLastError());
+        gp_k_var_subtract<<<(m + 255) / 256, 256, 0, stream>>>(d_vars, d_sqnorms, m);
+        CUDA_CHECK(cudaGetLastError());
+        CUDA_CHECK(cudaFreeAsync(d_sqnorms, stream));
+    }
+
+    CUDA_CHECK(cudaFreeAsync(d_Ks, stream));
+}
+
+void gp_predict(const GaussianProcess *gp, const float *Xs, float *means, float *vars,
+                  int m, cudaStream_t stream)
+{
+    int n = gp->n;
+    if (n == 0) {
+        for (int j = 0; j < m; j++) {
+            means[j] = 0.0;
+            if (vars) vars[j] = gp->kernel->k_self(gp->kernel, &Xs[j * gp->dim], gp->dim);
+        }
+        return;
+    }
+
+    float *d_Xte;
+    CUDA_CHECK(cudaMallocAsync(&d_Xte, (size_t)m * gp->dim * sizeof(float), stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_Xte, Xs, (size_t)m * gp->dim * sizeof(float),
+                               cudaMemcpyHostToDevice, stream));
+
+    float *d_means, *d_vars = NULL;
+    CUDA_CHECK(cudaMallocAsync(&d_means, (size_t)m * sizeof(float), stream));
+    if (vars) CUDA_CHECK(cudaMallocAsync(&d_vars, (size_t)m * sizeof(float), stream));
+
+    predict_dev(gp, d_Xte, d_means, d_vars, m, stream);
+    CUDA_CHECK(cudaFreeAsync(d_Xte, stream));
+
+    CUDA_CHECK(cudaMemcpyAsync(means, d_means, (size_t)m * sizeof(float),
+                               cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaFreeAsync(d_means, stream));
+    if (vars) {
+        CUDA_CHECK(cudaMemcpyAsync(vars, d_vars, (size_t)m * sizeof(float),
+                                   cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK(cudaFreeAsync(d_vars, stream));
+    }
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+}
+
+// -- likelihood and gradients ------------------------------------------------
+
+float gp_marginal_log_likelihood(const GaussianProcess *gp)
+{
+    int n = gp->n;
+    if (n == 0) return 0.0;
+
+    CUBLAS_CHECK(cublasSetStream(gp->cublas, 0));
+    float data_fit;
+    CUBLAS_CHECK(cublasSdot(gp->cublas, n, gp->d_y, 1, gp->d_alpha, 1, &data_fit));
+
+    float *d_diag;
+    CUDA_CHECK(cudaMalloc(&d_diag, (size_t)n * sizeof(float)));
+    gp_k_extract_diag<<<(n + 255) / 256, 256>>>(gp->d_L, d_diag, n);
+    CUDA_CHECK(cudaGetLastError());
+
+    float *h_diag = (float *)malloc(n * sizeof(float));
+    CUDA_CHECK(cudaMemcpy(h_diag, d_diag, (size_t)n * sizeof(float),
+                          cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaFree(d_diag));
+
+    float log_det = 0.0;
+    for (int i = 0; i < n; i++) log_det += log(h_diag[i]);
+    free(h_diag);
+
+    return (-0.5 * data_fit - log_det - 0.5 * n * log(2.0 * M_PI)) / n;
+}
+
+void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_grads,
+                   cudaStream_t stream)
+{
+    int n = gp->n;
+    if (n == 0) {
+        if (d_raw_noise) *d_raw_noise = 0.0;
+        if (kernel_grads)
+            for (int i = 0; i < gp->kernel->n_params; i++) kernel_grads[i] = 0.0;
+        return;
+    }
+
+    CUSOLVER_CHECK(cusolverDnSetStream(gp->cusolver, stream));
+    CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
+
+    float *d_Kinv;
+    CUDA_CHECK(cudaMallocAsync(&d_Kinv, (size_t)n * n * sizeof(float), stream));
+    CUDA_CHECK(cudaMemsetAsync(d_Kinv, 0, (size_t)n * n * sizeof(float), stream));
+    gp_k_add_diag<<<(n + 255) / 256, 256, 0, stream>>>(d_Kinv, n, 1.0);
+    CUDA_CHECK(cudaGetLastError());
+
+    CUSOLVER_CHECK(cusolverDnSpotrs(gp->cusolver, CUBLAS_FILL_MODE_LOWER,
+                                    n, n, gp->d_L, n, d_Kinv, n, gp->d_info));
+
+    if (d_raw_noise) {
+        float term1, term2;
+        CUBLAS_CHECK(cublasSdot (gp->cublas, n, gp->d_alpha, 1, gp->d_alpha, 1, &term1));
+        CUBLAS_CHECK(cublasSasum(gp->cublas, n, d_Kinv, n + 1, &term2));
+        *d_raw_noise = 0.5 * (term1 - term2) * softplus_grad(gp->raw_noise) / n;
+    }
+
+    if (kernel_grads) {
+        for (int i = 0; i < gp->kernel->n_params; i++) kernel_grads[i] = 0.0;
+        gp->kernel->mll_grad(gp->kernel, gp->d_X, n, gp->dim,
+                             gp->cublas, stream, gp->d_alpha, d_Kinv, kernel_grads);
+        for (int i = 0; i < gp->kernel->n_params; i++) kernel_grads[i] /= n;
+    }
+
+    CUDA_CHECK(cudaFreeAsync(d_Kinv, stream));
+}
+
+// -- kernel registry for gp_load ---------------------------------------------
+
+typedef struct { const char *tag; GPKernel *(*make)(float *, int); } KernelFactory;
+
+static GPKernel *kf_matern32lin(float *rp, int np)
+{
+    int dim = np - 2;
+    GPKernel *k = gp_kernel_matern32_linear(dim, 1.0, 1.0, 1.0);
+    memcpy(k->raw_params, rp, (size_t)np * sizeof(float));
+    return k;
+}
+
+static const KernelFactory kernel_registry[] = {
+    { GP_KERNEL_TAG_MATERN32_LINEAR, kf_matern32lin },
+    { NULL, NULL }
+};
+
+static GPKernel *kernel_from_tag(const char *tag, float *rp, int np)
+{
+    for (int i = 0; kernel_registry[i].tag; i++)
+        if (memcmp(tag, kernel_registry[i].tag, 4) == 0)
+            return kernel_registry[i].make(rp, np);
+    return NULL;
+}
+
+// -- save / load -------------------------------------------------------------
+
+int gp_save(const GaussianProcess *gp, const char *path)
+{
+    if (gp->n == 0) return -1;
+    CUDA_CHECK(cudaDeviceSynchronize());
+    FILE *f = fopen(path, "wb");
+    if (!f) return -1;
+
+    int n = gp->n, dim = gp->dim, np = gp->kernel->n_params;
+    fwrite("GC04",                  1,              4,  f);
+    fwrite(&dim,                    sizeof(int),    1,  f);
+    fwrite(&n,                      sizeof(int),    1,  f);
+    fwrite(&gp->raw_noise,          sizeof(float), 1,  f);
+    fwrite(gp->kernel->tag,         1,              4,  f);
+    fwrite(&np,                     sizeof(int),    1,  f);
+    fwrite(gp->kernel->raw_params,  sizeof(float), np, f);
+
+    float *h_X     = (float *)malloc((size_t)n * dim * sizeof(float));
+    float *h_y     = (float *)malloc((size_t)n       * sizeof(float));
+    float *h_L     = (float *)malloc((size_t)n * n   * sizeof(float));
+    float *h_alpha = (float *)malloc((size_t)n       * sizeof(float));
+    CUDA_CHECK(cudaMemcpy(h_X,     gp->d_X,     (size_t)n * dim * sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_y,     gp->d_y,     (size_t)n       * sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_L,     gp->d_L,     (size_t)n * n   * sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_alpha, gp->d_alpha, (size_t)n       * sizeof(float), cudaMemcpyDeviceToHost));
+
+    fwrite(h_X,     sizeof(float), (size_t)n * dim, f);
+    fwrite(h_y,     sizeof(float), n,               f);
+    fwrite(h_L,     sizeof(float), (size_t)n * n,   f);
+    fwrite(h_alpha, sizeof(float), n,               f);
+
+    free(h_X); free(h_y); free(h_L); free(h_alpha);
+    fclose(f);
+    return 0;
+}
+
+GaussianProcess *gp_load(const char *path, int extra_cap)
+{
+    GaussianProcess   *gp      = NULL;
+    float *h_X     = NULL, *h_y     = NULL;
+    float *h_L     = NULL, *h_alpha = NULL;
+
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+
+#define RD(ptr, sz, cnt) \
+    if (fread(ptr, sz, cnt, f) != (size_t)(cnt)) break
+
+    do {
+        char   magic[4], ktag[4];
+        int    dim, n, np;
+        float rn;
+
+        RD(magic, 1, 4);
+        if (memcmp(magic, "GC04", 4) != 0) break;
+
+        RD(&dim,  sizeof(int),    1);
+        RD(&n,    sizeof(int),    1);
+        RD(&rn,   sizeof(float), 1);
+        RD(ktag,  1, 4);
+        RD(&np,   sizeof(int),    1);
+
+        float *rp = (float *)malloc((size_t)np * sizeof(float));
+        if (!rp) break;
+        if (fread(rp, sizeof(float), np, f) != (size_t)np) { free(rp); break; }
+
+        GPKernel *k = kernel_from_tag(ktag, rp, np);
+        free(rp);
+        if (!k) break;
+
+        int cap = n + (extra_cap > 0 ? extra_cap : 0);
+        gp = gp_create(dim, cap, k, 1.0);
+        gp->raw_noise = rn;
+        gp->n = n;
+
+        h_X     = (float *)malloc((size_t)n * dim * sizeof(float));
+        h_y     = (float *)malloc((size_t)n       * sizeof(float));
+        h_L     = (float *)malloc((size_t)n * n   * sizeof(float));
+        h_alpha = (float *)malloc((size_t)n       * sizeof(float));
+
+        RD(h_X,     sizeof(float), (size_t)n * dim);
+        RD(h_y,     sizeof(float), n);
+        RD(h_L,     sizeof(float), (size_t)n * n);
+        RD(h_alpha, sizeof(float), n);
+
+        CUDA_CHECK(cudaMemcpy(gp->d_X,     h_X,     (size_t)n * dim * sizeof(float), cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_y,     h_y,     (size_t)n       * sizeof(float), cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_L,     h_L,     (size_t)n * n   * sizeof(float), cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_alpha, h_alpha, (size_t)n       * sizeof(float), cudaMemcpyHostToDevice));
+
+        free(h_X); free(h_y); free(h_L); free(h_alpha);
+        fclose(f);
+        return gp;
+    } while (0);
+
+#undef RD
+    free(h_X); free(h_y); free(h_L); free(h_alpha);
+    if (gp) gp_destroy(gp);
+    fclose(f);
+    return NULL;
+}
+
+#endif // GP_CUDA_CU

--- a/src/gp_cuda_kernel.cu
+++ b/src/gp_cuda_kernel.cu
@@ -1,5 +1,4 @@
 // gp_cuda_kernel.cu -- Matern32+Linear GP covariance kernel (CUDA), ARD.
-//
 
 #ifndef GP_CUDA_KERNEL_CU
 #define GP_CUDA_KERNEL_CU
@@ -11,97 +10,69 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define CUDA_CHECK(call)                                                  \
-    do {                                                                  \
-        cudaError_t _e = (call);                                          \
-        if (_e != cudaSuccess) {                                          \
-            fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, \
-                cudaGetErrorString(_e));                                  \
-            abort();                                                      \
-        }                                                                 \
-    } while (0)
-
-#define CUBLAS_CHECK(call)                                                            \
-    do {                                                                              \
-        cublasStatus_t _s = (call);                                                   \
-        if (_s != CUBLAS_STATUS_SUCCESS) {                                            \
-            fprintf(stderr, "cuBLAS error %s:%d: %d\n", __FILE__, __LINE__, (int)_s); \
-            abort();                                                                  \
-        }                                                                             \
-    } while (0)
+// clang-format off
+static inline void _cuda_check(cudaError_t e, const char* f, int l) {
+    if (e != cudaSuccess) { fprintf(stderr, "CUDA error %s:%d: %s\n", f, l, cudaGetErrorString(e)); abort(); }
+}
+static inline void _cublas_check(cublasStatus_t s, const char* f, int l) {
+    if (s != CUBLAS_STATUS_SUCCESS) { fprintf(stderr, "cuBLAS error %s:%d: %d\n", f, l, (int)s); abort(); }
+}
+#define CUDA_CHECK(call) _cuda_check((call), __FILE__, __LINE__)
+#define CUBLAS_CHECK(call) _cublas_check((call), __FILE__, __LINE__)
+// clang-format on
 
 #define SP_LB 1e-4
 __host__ __device__ __forceinline__ float softplus(float x) { return (x > 20.0 ? x : log1p(exp(x))) + SP_LB; }
-__host__ __device__ __forceinline__ float inv_softplus(float x)
-{
+__host__ __device__ __forceinline__ float inv_softplus(float x) {
     float v = x - SP_LB;
     return v > 20.0 ? v : log(expm1(v));
 }
 __host__ __device__ __forceinline__ float softplus_grad(float x) { return 1.0 / (1.0 + exp(-x)); }
 
-// -- kernel struct -----------------------------------------------------------
-
 typedef struct GPKernel GPKernel;
 struct GPKernel {
     int n_params;
-    float* raw_params;
+    float *raw_params;
     char tag[4];
-
-    void (*build_K)(const GPKernel* k, const float* d_X, int n, int d,
-        float sigma_n, float* d_K, cudaStream_t stream);
-    void (*build_Ks)(const GPKernel* k, const float* d_Xtr, const float* d_Xte,
-        int n, int m, int d, float* d_Ks, cudaStream_t stream);
-    void (*build_kself_batch)(const GPKernel* k, const float* d_X, int m, int d,
-        float* d_out, cudaStream_t stream);
-    float (*k_self)(const GPKernel* k, const float* x, int d);
-    void (*mll_grad)(const GPKernel* k, const float* d_X, int n, int d,
-        cublasHandle_t cublas, cudaStream_t stream,
-        const float* d_alpha, const float* d_Kinv,
-        float* kernel_grads);
-    void (*destroy)(GPKernel* k);
+    void (*build_K)(const GPKernel *k, const float *d_X, int n, int d, float sigma_n, float *d_K, cudaStream_t stream);
+    void (*build_Ks)(const GPKernel *k, const float *d_Xtr, const float *d_Xte, int n, int m, int d, float *d_Ks,
+                     cudaStream_t stream);
+    void (*build_kself_batch)(const GPKernel *k, const float *d_X, int m, int d, float *d_out, cudaStream_t stream);
+    float (*k_self)(const GPKernel *k, const float *x, int d);
+    void (*mll_grad)(const GPKernel *k, const float *d_X, int n, int d, cublasHandle_t cublas, cudaStream_t stream,
+                     const float *d_alpha, const float *d_Kinv, float *kernel_grads);
+    void (*destroy)(GPKernel *k);
 };
 
 #define GP_KERNEL_TAG_MATERN32_LINEAR "M32L"
-
-GPKernel* gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
-    float offset);
-
-float gp_kernel_get_lengthscale(const GPKernel* k, int d);
-float gp_kernel_get_outputscale(const GPKernel* k);
-float gp_kernel_get_offset(const GPKernel* k);
-void gp_kernel_set_lengthscale(GPKernel* k, int d, float v);
-void gp_kernel_set_outputscale(GPKernel* k, float v);
-void gp_kernel_set_offset(GPKernel* k, float v);
-
-// -- kernel implementations --------------------------------------------------
-
 #define SF_IDX(np) ((np)-2)
 #define OFF_IDX(np) ((np)-1)
-
 #define GP_BLOCK 16
-
 #ifndef BLOCK_SIZE
 #define BLOCK_SIZE 256
 #endif
 
-inline int gp_grid(int n)
-{
-    return (n + GP_BLOCK - 1) / GP_BLOCK;
+inline int gp_grid(int n) { return (n + GP_BLOCK - 1) / GP_BLOCK; }
+
+typedef struct {
+    float sigma_f, offset;
+} KParams;
+
+static inline KParams kernel_params(const GPKernel *k) {
+    int np = k->n_params;
+    return (KParams){softplus(k->raw_params[SF_IDX(np)]), softplus(k->raw_params[OFF_IDX(np)])};
 }
 
-__global__ void matern32lin_k_build_K(
-    const float* __restrict__ X,
-    float* __restrict__ K,
-    const float* __restrict__ inv_ells,
-    int n, int d, float sigma_f, float sigma_n, float offset)
-{
+__global__ void matern32lin_k_kernel(const float *__restrict__ X1, const float *__restrict__ X2, float *__restrict__ K,
+                                     const float *__restrict__ inv_ells, int n, int m, int d, float sigma_f,
+                                     float diag_noise, float offset) {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= n)
+    if (row >= n || col >= m)
         return;
     float dot = 0.0, r2 = 0.0;
     for (int k = 0; k < d; k++) {
-        float xr = X[row * d + k], xc = X[col * d + k];
+        float xr = X1[row * d + k], xc = X2[col * d + k];
         dot += xr * xc;
         float diff = (xr - xc) * inv_ells[k];
         r2 += diff * diff;
@@ -110,41 +81,13 @@ __global__ void matern32lin_k_build_K(
         r2 = 0.0;
     float u = sqrt(3.0) * sqrt(r2);
     float val = sigma_f * (dot + offset + (1.0 + u) * exp(-u));
-    if (row == col)
-        val += sigma_n;
+    if (diag_noise != 0.0 && row == col)
+        val += diag_noise;
     K[col * n + row] = val;
 }
 
-__global__ void matern32lin_k_build_Ks(
-    const float* __restrict__ Xtr,
-    const float* __restrict__ Xte,
-    float* __restrict__ Ks,
-    const float* __restrict__ inv_ells,
-    int n, int m, int d, float sigma_f, float offset)
-{
-    int col = blockIdx.x * GP_BLOCK + threadIdx.x;
-    int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= m)
-        return;
-    float dot = 0.0, r2 = 0.0;
-    for (int k = 0; k < d; k++) {
-        float xr = Xtr[row * d + k], xc = Xte[col * d + k];
-        dot += xr * xc;
-        float diff = (xr - xc) * inv_ells[k];
-        r2 += diff * diff;
-    }
-    if (r2 < 0.0)
-        r2 = 0.0;
-    float u = sqrt(3.0) * sqrt(r2);
-    Ks[col * n + row] = sigma_f * (dot + offset + (1.0 + u) * exp(-u));
-}
-
-__global__ void matern32lin_k_build_D_ard(
-    const float* __restrict__ X,
-    float* __restrict__ D,
-    const float* __restrict__ inv_ells,
-    int n, int d)
-{
+__global__ void matern32lin_k_build_D_ard(const float *__restrict__ X, float *__restrict__ D,
+                                          const float *__restrict__ inv_ells, int n, int d) {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
     if (row >= n || col >= n)
@@ -157,12 +100,8 @@ __global__ void matern32lin_k_build_D_ard(
     D[col * n + row] = sq < 0.0 ? 0.0 : sq;
 }
 
-__global__ void matern32lin_k_compute_W(
-    const float* __restrict__ alpha,
-    const float* __restrict__ Kinv,
-    float* __restrict__ W,
-    int n)
-{
+__global__ void matern32lin_k_compute_W(const float *__restrict__ alpha, const float *__restrict__ Kinv,
+                                        float *__restrict__ W, int n) {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
     if (row >= n || col >= n)
@@ -170,33 +109,26 @@ __global__ void matern32lin_k_compute_W(
     W[col * n + row] = alpha[row] * alpha[col] - Kinv[col * n + row];
 }
 
-__global__ void matern32lin_k_dk_dell_d(
-    const float* __restrict__ X,
-    const float* __restrict__ D_ard,
-    float* __restrict__ out,
-    int n, int d, int dd, float sigma_f, float inv_ell_d3)
-{
+__global__ void matern32lin_k_dk_dell_d(const float *__restrict__ X, const float *__restrict__ D_ard,
+                                        float *__restrict__ out, int n, int d, int dd, float sigma_f,
+                                        float inv_ell_d3) {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
     if (row >= n || col >= n)
         return;
     float r2 = D_ard[col * n + row];
     float diff = X[row * d + dd] - X[col * d + dd];
-    out[col * n + row] = sigma_f * 3.0 * diff * diff * inv_ell_d3
-        * exp(-sqrt(3.0) * sqrt(r2));
+    out[col * n + row] = sigma_f * 3.0 * diff * diff * inv_ell_d3 * exp(-sqrt(3.0) * sqrt(r2));
 }
 
-__global__ void matern32lin_k_fill(float* v, int n, float val)
-{
+__global__ void matern32lin_k_fill(float *v, int n, float val) {
     int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         v[i] = val;
 }
 
-__global__ void matern32lin_k_kself_batch(
-    const float* __restrict__ X, float* __restrict__ out,
-    int m, int d, float sigma_f, float offset)
-{
+__global__ void matern32lin_k_kself_batch(const float *__restrict__ X, float *__restrict__ out, int m, int d,
+                                          float sigma_f, float offset) {
     int row = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (row >= m)
         return;
@@ -208,94 +140,70 @@ __global__ void matern32lin_k_kself_batch(
     out[row] = sigma_f * (norm2 + offset + 1.0);
 }
 
-// -- helpers -----------------------------------------------------------------
-
-static float* h2d(const float* h, int n, cudaStream_t stream)
-{
-    float* d;
+static float *h2d(const float *h, int n, cudaStream_t stream) {
+    float *d;
     CUDA_CHECK(cudaMallocAsync(&d, (size_t)n * sizeof(float), stream));
-    CUDA_CHECK(cudaMemcpyAsync(d, h, (size_t)n * sizeof(float),
-        cudaMemcpyHostToDevice, stream));
+    CUDA_CHECK(cudaMemcpyAsync(d, h, (size_t)n * sizeof(float), cudaMemcpyHostToDevice, stream));
     return d;
 }
 
-static float* device_inv_ells(const GPKernel* k, int d, cudaStream_t stream)
-{
-    float* h = (float*)malloc(d * sizeof(float));
+static float *device_inv_ells(const GPKernel *k, int d, cudaStream_t stream) {
+    float *h = (float *)malloc(d * sizeof(float));
     for (int i = 0; i < d; i++)
         h[i] = 1.0 / softplus(k->raw_params[i]);
-    float* dev = h2d(h, d, stream);
+    float *dev = h2d(h, d, stream);
     free(h);
     return dev;
 }
 
-// -- launcher functions ------------------------------------------------------
-
-static void matern32lin_build_K(const GPKernel* k, const float* d_X, int n, int d,
-    float sigma_n, float* d_K, cudaStream_t stream)
-{
-    int np = k->n_params;
-    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset = softplus(k->raw_params[OFF_IDX(np)]);
-    float* d_inv = device_inv_ells(k, d, stream);
+static void matern32lin_build_K(const GPKernel *k, const float *d_X, int n, int d, float sigma_n, float *d_K,
+                                cudaStream_t stream) {
+    KParams p = kernel_params(k);
+    float *d_inv = device_inv_ells(k, d, stream);
     dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(n), gp_grid(n));
-    matern32lin_k_build_K<<<grid, block, 0, stream>>>(d_X, d_K, d_inv, n, d, sigma_f, sigma_n, offset);
+    matern32lin_k_kernel<<<grid, block, 0, stream>>>(d_X, d_X, d_K, d_inv, n, n, d, p.sigma_f, sigma_n, p.offset);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaFreeAsync(d_inv, stream));
 }
 
-static void matern32lin_build_Ks(const GPKernel* k, const float* d_Xtr, const float* d_Xte,
-    int n, int m, int d, float* d_Ks, cudaStream_t stream)
-{
-    int np = k->n_params;
-    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset = softplus(k->raw_params[OFF_IDX(np)]);
-    float* d_inv = device_inv_ells(k, d, stream);
+static void matern32lin_build_Ks(const GPKernel *k, const float *d_Xtr, const float *d_Xte, int n, int m, int d,
+                                 float *d_Ks, cudaStream_t stream) {
+    KParams p = kernel_params(k);
+    float *d_inv = device_inv_ells(k, d, stream);
     dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(m), gp_grid(n));
-    matern32lin_k_build_Ks<<<grid, block, 0, stream>>>(d_Xtr, d_Xte, d_Ks, d_inv, n, m, d, sigma_f, offset);
+    matern32lin_k_kernel<<<grid, block, 0, stream>>>(d_Xtr, d_Xte, d_Ks, d_inv, n, m, d, p.sigma_f, 0.0, p.offset);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaFreeAsync(d_inv, stream));
 }
 
-static float matern32lin_k_self(const GPKernel* k, const float* x, int d)
-{
-    int np = k->n_params;
-    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset = softplus(k->raw_params[OFF_IDX(np)]);
+static float matern32lin_k_self(const GPKernel *k, const float *x, int d) {
+    KParams p = kernel_params(k);
     float norm2 = 0.0;
     for (int i = 0; i < d; i++)
         norm2 += x[i] * x[i];
-    return sigma_f * (norm2 + offset + 1.0);
+    return p.sigma_f * (norm2 + p.offset + 1.0);
 }
 
-static void matern32lin_build_kself_batch(const GPKernel* k, const float* d_X,
-    int m, int d, float* d_out, cudaStream_t stream)
-{
-    int np = k->n_params;
-    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset = softplus(k->raw_params[OFF_IDX(np)]);
-    matern32lin_k_kself_batch<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_X, d_out, m, d, sigma_f, offset);
+static void matern32lin_build_kself_batch(const GPKernel *k, const float *d_X, int m, int d, float *d_out,
+                                          cudaStream_t stream) {
+    KParams p = kernel_params(k);
+    matern32lin_k_kself_batch<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_X, d_out, m, d, p.sigma_f,
+                                                                                            p.offset);
     CUDA_CHECK(cudaGetLastError());
 }
 
-static void matern32lin_mll_grad(const GPKernel* k, const float* d_X, int n, int d,
-    cublasHandle_t cublas, cudaStream_t stream,
-    const float* d_alpha, const float* d_Kinv,
-    float* kernel_grads)
-{
+static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int d, cublasHandle_t cublas,
+                                 cudaStream_t stream, const float *d_alpha, const float *d_Kinv, float *kernel_grads) {
     int np = k->n_params;
-    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset = softplus(k->raw_params[OFF_IDX(np)]);
+    KParams p = kernel_params(k);
     const float one = 1.0, zero = 0.0;
-
     CUBLAS_CHECK(cublasSetStream(cublas, stream));
 
-    float* d_inv = device_inv_ells(k, d, stream);
+    float *d_inv = device_inv_ells(k, d, stream);
     float *d_D, *d_W, *d_temp;
     CUDA_CHECK(cudaMallocAsync(&d_D, (size_t)n * n * sizeof(float), stream));
     CUDA_CHECK(cudaMallocAsync(&d_W, (size_t)n * n * sizeof(float), stream));
     CUDA_CHECK(cudaMallocAsync(&d_temp, (size_t)n * n * sizeof(float), stream));
-
     dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(n), gp_grid(n));
 
     matern32lin_k_build_D_ard<<<grid, block, 0, stream>>>(d_X, d_D, d_inv, n, d);
@@ -306,37 +214,30 @@ static void matern32lin_mll_grad(const GPKernel* k, const float* d_X, int n, int
     for (int dd = 0; dd < d; dd++) {
         float ell_d = softplus(k->raw_params[dd]);
         float inv_ell3 = 1.0 / (ell_d * ell_d * ell_d);
-        matern32lin_k_dk_dell_d<<<grid, block, 0, stream>>>(d_X, d_D, d_temp, n, d, dd, sigma_f, inv_ell3);
+        matern32lin_k_dk_dell_d<<<grid, block, 0, stream>>>(d_X, d_D, d_temp, n, d, dd, p.sigma_f, inv_ell3);
         CUDA_CHECK(cudaGetLastError());
         float dot_val;
         CUBLAS_CHECK(cublasSdot(cublas, n * n, d_W, 1, d_temp, 1, &dot_val));
         kernel_grads[dd] = 0.5 * dot_val * softplus_grad(k->raw_params[dd]);
     }
 
-    matern32lin_k_build_K<<<grid, block, 0, stream>>>(d_X, d_temp, d_inv, n, d, sigma_f, 0.0, offset);
+    matern32lin_k_kernel<<<grid, block, 0, stream>>>(d_X, d_X, d_temp, d_inv, n, n, d, p.sigma_f, 0.0, p.offset);
     CUDA_CHECK(cudaGetLastError());
-    {
-        float dot_val;
-        CUBLAS_CHECK(cublasSdot(cublas, n * n, d_W, 1, d_temp, 1, &dot_val));
-        kernel_grads[SF_IDX(np)] = 0.5 * dot_val / sigma_f
-            * softplus_grad(k->raw_params[SF_IDX(np)]);
-    }
+    float dot_val;
+    CUBLAS_CHECK(cublasSdot(cublas, n * n, d_W, 1, d_temp, 1, &dot_val));
+    kernel_grads[SF_IDX(np)] = 0.5 * dot_val / p.sigma_f * softplus_grad(k->raw_params[SF_IDX(np)]);
 
-    {
-        float *d_ones, *d_wrow;
-        CUDA_CHECK(cudaMallocAsync(&d_ones, (size_t)n * sizeof(float), stream));
-        CUDA_CHECK(cudaMallocAsync(&d_wrow, (size_t)n * sizeof(float), stream));
-        matern32lin_k_fill<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_ones, n, 1.0);
-        CUDA_CHECK(cudaGetLastError());
-        float w_sum;
-        CUBLAS_CHECK(cublasSgemv(cublas, CUBLAS_OP_N, n, n,
-            &one, d_W, n, d_ones, 1, &zero, d_wrow, 1));
-        CUBLAS_CHECK(cublasSdot(cublas, n, d_wrow, 1, d_ones, 1, &w_sum));
-        kernel_grads[OFF_IDX(np)] = 0.5 * sigma_f * w_sum
-            * softplus_grad(k->raw_params[OFF_IDX(np)]);
-        CUDA_CHECK(cudaFreeAsync(d_ones, stream));
-        CUDA_CHECK(cudaFreeAsync(d_wrow, stream));
-    }
+    float *d_ones, *d_wrow;
+    CUDA_CHECK(cudaMallocAsync(&d_ones, (size_t)n * sizeof(float), stream));
+    CUDA_CHECK(cudaMallocAsync(&d_wrow, (size_t)n * sizeof(float), stream));
+    matern32lin_k_fill<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_ones, n, 1.0);
+    CUDA_CHECK(cudaGetLastError());
+    float w_sum;
+    CUBLAS_CHECK(cublasSgemv(cublas, CUBLAS_OP_N, n, n, &one, d_W, n, d_ones, 1, &zero, d_wrow, 1));
+    CUBLAS_CHECK(cublasSdot(cublas, n, d_wrow, 1, d_ones, 1, &w_sum));
+    kernel_grads[OFF_IDX(np)] = 0.5 * p.sigma_f * w_sum * softplus_grad(k->raw_params[OFF_IDX(np)]);
+    CUDA_CHECK(cudaFreeAsync(d_ones, stream));
+    CUDA_CHECK(cudaFreeAsync(d_wrow, stream));
 
     CUDA_CHECK(cudaFreeAsync(d_inv, stream));
     CUDA_CHECK(cudaFreeAsync(d_D, stream));
@@ -344,15 +245,13 @@ static void matern32lin_mll_grad(const GPKernel* k, const float* d_X, int n, int
     CUDA_CHECK(cudaFreeAsync(d_temp, stream));
 }
 
-static void matern32lin_destroy(GPKernel* k) { free(k); }
+static void matern32lin_destroy(GPKernel *k) { free(k); }
 
-GPKernel* gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
-    float offset)
-{
+GPKernel *gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale, float offset) {
     int n_params = dim + 2;
-    GPKernel* k = (GPKernel*)malloc(sizeof(GPKernel) + (size_t)n_params * sizeof(float));
+    GPKernel *k = (GPKernel *)malloc(sizeof(GPKernel) + (size_t)n_params * sizeof(float));
     k->n_params = n_params;
-    k->raw_params = (float*)(k + 1);
+    k->raw_params = (float *)(k + 1);
     memcpy(k->tag, GP_KERNEL_TAG_MATERN32_LINEAR, 4);
     for (int i = 0; i < dim; i++)
         k->raw_params[i] = inv_softplus(lengthscale);
@@ -367,11 +266,11 @@ GPKernel* gp_kernel_matern32_linear(int dim, float lengthscale, float outputscal
     return k;
 }
 
-float gp_kernel_get_lengthscale(const GPKernel* k, int d) { return softplus(k->raw_params[d]); }
-float gp_kernel_get_outputscale(const GPKernel* k) { return softplus(k->raw_params[SF_IDX(k->n_params)]); }
-float gp_kernel_get_offset(const GPKernel* k) { return softplus(k->raw_params[OFF_IDX(k->n_params)]); }
-void gp_kernel_set_lengthscale(GPKernel* k, int d, float v) { k->raw_params[d] = inv_softplus(v); }
-void gp_kernel_set_outputscale(GPKernel* k, float v) { k->raw_params[SF_IDX(k->n_params)] = inv_softplus(v); }
-void gp_kernel_set_offset(GPKernel* k, float v) { k->raw_params[OFF_IDX(k->n_params)] = inv_softplus(v); }
+float gp_kernel_get_lengthscale(const GPKernel *k, int d) { return softplus(k->raw_params[d]); }
+float gp_kernel_get_outputscale(const GPKernel *k) { return softplus(k->raw_params[SF_IDX(k->n_params)]); }
+float gp_kernel_get_offset(const GPKernel *k) { return softplus(k->raw_params[OFF_IDX(k->n_params)]); }
+void gp_kernel_set_lengthscale(GPKernel *k, int d, float v) { k->raw_params[d] = inv_softplus(v); }
+void gp_kernel_set_outputscale(GPKernel *k, float v) { k->raw_params[SF_IDX(k->n_params)] = inv_softplus(v); }
+void gp_kernel_set_offset(GPKernel *k, float v) { k->raw_params[OFF_IDX(k->n_params)] = inv_softplus(v); }
 
 #endif // GP_CUDA_KERNEL_CU

--- a/src/gp_cuda_kernel.cu
+++ b/src/gp_cuda_kernel.cu
@@ -1,0 +1,348 @@
+// gp_cuda_kernel.cu -- Matern32+Linear GP covariance kernel (CUDA), ARD.
+//
+
+#ifndef GP_CUDA_KERNEL_CU
+#define GP_CUDA_KERNEL_CU
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+
+#define CUDA_CHECK(call) do { \
+    cudaError_t _e = (call); \
+    if (_e != cudaSuccess) { \
+        fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, \
+                cudaGetErrorString(_e)); \
+        abort(); \
+    } \
+} while (0)
+
+#define CUBLAS_CHECK(call) do { \
+    cublasStatus_t _s = (call); \
+    if (_s != CUBLAS_STATUS_SUCCESS) { \
+        fprintf(stderr, "cuBLAS error %s:%d: %d\n", __FILE__, __LINE__, (int)_s); \
+        abort(); \
+    } \
+} while (0)
+
+#define SP_LB 1e-4
+__host__ __device__ __forceinline__ float softplus(float x)      { return (x > 20.0 ? x : log1p(exp(x))) + SP_LB; }
+__host__ __device__ __forceinline__ float inv_softplus(float x)  { float v = x - SP_LB; return v > 20.0 ? v : log(expm1(v)); }
+__host__ __device__ __forceinline__ float softplus_grad(float x) { return 1.0 / (1.0 + exp(-x)); }
+
+// -- kernel struct -----------------------------------------------------------
+
+typedef struct GPKernel GPKernel;
+struct GPKernel {
+    int     n_params;
+    float *raw_params;
+    char    tag[4];
+
+    void (*build_K)(const GPKernel *k, const float *d_X, int n, int d,
+                    float sigma_n, float *d_K, cudaStream_t stream);
+    void (*build_Ks)(const GPKernel *k, const float *d_Xtr, const float *d_Xte,
+                     int n, int m, int d, float *d_Ks, cudaStream_t stream);
+    void (*build_kself_batch)(const GPKernel *k, const float *d_X, int m, int d,
+                               float *d_out, cudaStream_t stream);
+    float (*k_self)(const GPKernel *k, const float *x, int d);
+    void (*mll_grad)(const GPKernel *k, const float *d_X, int n, int d,
+                     cublasHandle_t cublas, cudaStream_t stream,
+                     const float *d_alpha, const float *d_Kinv,
+                     float *kernel_grads);
+    void (*destroy)(GPKernel *k);
+};
+
+#define GP_KERNEL_TAG_MATERN32_LINEAR "M32L"
+
+GPKernel *gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
+                                        float offset);
+
+float gp_kernel_get_lengthscale(const GPKernel *k, int d);
+float gp_kernel_get_outputscale(const GPKernel *k);
+float gp_kernel_get_offset     (const GPKernel *k);
+void   gp_kernel_set_lengthscale(GPKernel *k, int d, float v);
+void   gp_kernel_set_outputscale(GPKernel *k, float v);
+void   gp_kernel_set_offset     (GPKernel *k, float v);
+
+// -- kernel implementations --------------------------------------------------
+
+#define SF_IDX(np)  ((np) - 2)
+#define OFF_IDX(np) ((np) - 1)
+
+#define GP_BLOCK 16
+inline int gp_grid(int n) { return (n + GP_BLOCK - 1) / GP_BLOCK; }
+
+__global__ void matern32lin_k_build_K(
+    const float * __restrict__ X,
+    float       * __restrict__ K,
+    const float * __restrict__ inv_ells,
+    int n, int d, float sigma_f, float sigma_n, float offset)
+{
+    int col = blockIdx.x * GP_BLOCK + threadIdx.x;
+    int row = blockIdx.y * GP_BLOCK + threadIdx.y;
+    if (row >= n || col >= n) return;
+    float dot = 0.0, r2 = 0.0;
+    for (int k = 0; k < d; k++) {
+        float xr = X[row * d + k], xc = X[col * d + k];
+        dot += xr * xc;
+        float diff = (xr - xc) * inv_ells[k];
+        r2 += diff * diff;
+    }
+    if (r2 < 0.0) r2 = 0.0;
+    float u   = sqrt(3.0) * sqrt(r2);
+    float val = sigma_f * (dot + offset + (1.0 + u) * exp(-u));
+    if (row == col) val += sigma_n;
+    K[col * n + row] = val;
+}
+
+__global__ void matern32lin_k_build_Ks(
+    const float * __restrict__ Xtr,
+    const float * __restrict__ Xte,
+    float       * __restrict__ Ks,
+    const float * __restrict__ inv_ells,
+    int n, int m, int d, float sigma_f, float offset)
+{
+    int col = blockIdx.x * GP_BLOCK + threadIdx.x;
+    int row = blockIdx.y * GP_BLOCK + threadIdx.y;
+    if (row >= n || col >= m) return;
+    float dot = 0.0, r2 = 0.0;
+    for (int k = 0; k < d; k++) {
+        float xr = Xtr[row * d + k], xc = Xte[col * d + k];
+        dot += xr * xc;
+        float diff = (xr - xc) * inv_ells[k];
+        r2 += diff * diff;
+    }
+    if (r2 < 0.0) r2 = 0.0;
+    float u = sqrt(3.0) * sqrt(r2);
+    Ks[col * n + row] = sigma_f * (dot + offset + (1.0 + u) * exp(-u));
+}
+
+__global__ void matern32lin_k_build_D_ard(
+    const float * __restrict__ X,
+    float       * __restrict__ D,
+    const float * __restrict__ inv_ells,
+    int n, int d)
+{
+    int col = blockIdx.x * GP_BLOCK + threadIdx.x;
+    int row = blockIdx.y * GP_BLOCK + threadIdx.y;
+    if (row >= n || col >= n) return;
+    float sq = 0.0;
+    for (int k = 0; k < d; k++) {
+        float diff = (X[row * d + k] - X[col * d + k]) * inv_ells[k];
+        sq += diff * diff;
+    }
+    D[col * n + row] = sq < 0.0 ? 0.0 : sq;
+}
+
+__global__ void matern32lin_k_compute_W(
+    const float * __restrict__ alpha,
+    const float * __restrict__ Kinv,
+    float       * __restrict__ W,
+    int n)
+{
+    int col = blockIdx.x * GP_BLOCK + threadIdx.x;
+    int row = blockIdx.y * GP_BLOCK + threadIdx.y;
+    if (row >= n || col >= n) return;
+    W[col * n + row] = alpha[row] * alpha[col] - Kinv[col * n + row];
+}
+
+__global__ void matern32lin_k_dk_dell_d(
+    const float * __restrict__ X,
+    const float * __restrict__ D_ard,
+    float       * __restrict__ out,
+    int n, int d, int dd, float sigma_f, float inv_ell_d3)
+{
+    int col = blockIdx.x * GP_BLOCK + threadIdx.x;
+    int row = blockIdx.y * GP_BLOCK + threadIdx.y;
+    if (row >= n || col >= n) return;
+    float r2   = D_ard[col * n + row];
+    float diff = X[row * d + dd] - X[col * d + dd];
+    out[col * n + row] = sigma_f * 3.0 * diff * diff * inv_ell_d3
+                       * exp(-sqrt(3.0) * sqrt(r2));
+}
+
+__global__ void matern32lin_k_fill(float *v, int n, float val)
+{
+    int i = blockIdx.x * 256 + threadIdx.x;
+    if (i < n) v[i] = val;
+}
+
+__global__ void matern32lin_k_kself_batch(
+    const float * __restrict__ X, float * __restrict__ out,
+    int m, int d, float sigma_f, float offset)
+{
+    int row = blockIdx.x * 256 + threadIdx.x;
+    if (row >= m) return;
+    float norm2 = 0.0;
+    for (int k = 0; k < d; k++) { float v = X[row * d + k]; norm2 += v * v; }
+    out[row] = sigma_f * (norm2 + offset + 1.0);
+}
+
+// -- helpers -----------------------------------------------------------------
+
+static float *h2d(const float *h, int n, cudaStream_t stream)
+{
+    float *d;
+    CUDA_CHECK(cudaMallocAsync(&d, (size_t)n * sizeof(float), stream));
+    CUDA_CHECK(cudaMemcpyAsync(d, h, (size_t)n * sizeof(float),
+                               cudaMemcpyHostToDevice, stream));
+    return d;
+}
+
+static float *device_inv_ells(const GPKernel *k, int d, cudaStream_t stream)
+{
+    float *h = (float *)malloc(d * sizeof(float));
+    for (int i = 0; i < d; i++) h[i] = 1.0 / softplus(k->raw_params[i]);
+    float *dev = h2d(h, d, stream);
+    free(h);
+    return dev;
+}
+
+// -- launcher functions ------------------------------------------------------
+
+static void matern32lin_build_K(const GPKernel *k, const float *d_X, int n, int d,
+                            float sigma_n, float *d_K, cudaStream_t stream)
+{
+    int    np      = k->n_params;
+    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
+    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    float *d_inv  = device_inv_ells(k, d, stream);
+    dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(n), gp_grid(n));
+    matern32lin_k_build_K<<<grid, block, 0, stream>>>(d_X, d_K, d_inv, n, d, sigma_f, sigma_n, offset);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaFreeAsync(d_inv, stream));
+}
+
+static void matern32lin_build_Ks(const GPKernel *k, const float *d_Xtr, const float *d_Xte,
+                             int n, int m, int d, float *d_Ks, cudaStream_t stream)
+{
+    int    np      = k->n_params;
+    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
+    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    float *d_inv  = device_inv_ells(k, d, stream);
+    dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(m), gp_grid(n));
+    matern32lin_k_build_Ks<<<grid, block, 0, stream>>>(d_Xtr, d_Xte, d_Ks, d_inv, n, m, d, sigma_f, offset);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaFreeAsync(d_inv, stream));
+}
+
+static float matern32lin_k_self(const GPKernel *k, const float *x, int d)
+{
+    int    np      = k->n_params;
+    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
+    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    float norm2   = 0.0;
+    for (int i = 0; i < d; i++) norm2 += x[i] * x[i];
+    return sigma_f * (norm2 + offset + 1.0);
+}
+
+static void matern32lin_build_kself_batch(const GPKernel *k, const float *d_X,
+                                      int m, int d, float *d_out, cudaStream_t stream)
+{
+    int    np      = k->n_params;
+    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
+    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    matern32lin_k_kself_batch<<<(m + 255) / 256, 256, 0, stream>>>(d_X, d_out, m, d, sigma_f, offset);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int d,
+                             cublasHandle_t cublas, cudaStream_t stream,
+                             const float *d_alpha, const float *d_Kinv,
+                             float *kernel_grads)
+{
+    int    np      = k->n_params;
+    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
+    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    const float one = 1.0, zero = 0.0;
+
+    CUBLAS_CHECK(cublasSetStream(cublas, stream));
+
+    float *d_inv  = device_inv_ells(k, d, stream);
+    float *d_D, *d_W, *d_temp;
+    CUDA_CHECK(cudaMallocAsync(&d_D,    (size_t)n * n * sizeof(float), stream));
+    CUDA_CHECK(cudaMallocAsync(&d_W,    (size_t)n * n * sizeof(float), stream));
+    CUDA_CHECK(cudaMallocAsync(&d_temp, (size_t)n * n * sizeof(float), stream));
+
+    dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(n), gp_grid(n));
+
+    matern32lin_k_build_D_ard<<<grid, block, 0, stream>>>(d_X, d_D, d_inv, n, d);
+    CUDA_CHECK(cudaGetLastError());
+    matern32lin_k_compute_W<<<grid, block, 0, stream>>>(d_alpha, d_Kinv, d_W, n);
+    CUDA_CHECK(cudaGetLastError());
+
+    for (int dd = 0; dd < d; dd++) {
+        float ell_d    = softplus(k->raw_params[dd]);
+        float inv_ell3 = 1.0 / (ell_d * ell_d * ell_d);
+        matern32lin_k_dk_dell_d<<<grid, block, 0, stream>>>(d_X, d_D, d_temp, n, d, dd, sigma_f, inv_ell3);
+        CUDA_CHECK(cudaGetLastError());
+        float dot_val;
+        CUBLAS_CHECK(cublasSdot(cublas, n * n, d_W, 1, d_temp, 1, &dot_val));
+        kernel_grads[dd] = 0.5 * dot_val * softplus_grad(k->raw_params[dd]);
+    }
+
+    matern32lin_k_build_K<<<grid, block, 0, stream>>>(d_X, d_temp, d_inv, n, d, sigma_f, 0.0, offset);
+    CUDA_CHECK(cudaGetLastError());
+    {
+        float dot_val;
+        CUBLAS_CHECK(cublasSdot(cublas, n * n, d_W, 1, d_temp, 1, &dot_val));
+        kernel_grads[SF_IDX(np)] = 0.5 * dot_val / sigma_f
+                                 * softplus_grad(k->raw_params[SF_IDX(np)]);
+    }
+
+    {
+        float *d_ones, *d_wrow;
+        CUDA_CHECK(cudaMallocAsync(&d_ones, (size_t)n * sizeof(float), stream));
+        CUDA_CHECK(cudaMallocAsync(&d_wrow, (size_t)n * sizeof(float), stream));
+        matern32lin_k_fill<<<(n + 255) / 256, 256, 0, stream>>>(d_ones, n, 1.0);
+        CUDA_CHECK(cudaGetLastError());
+        float w_sum;
+        CUBLAS_CHECK(cublasSgemv(cublas, CUBLAS_OP_N, n, n,
+                                 &one, d_W, n, d_ones, 1, &zero, d_wrow, 1));
+        CUBLAS_CHECK(cublasSdot(cublas, n, d_wrow, 1, d_ones, 1, &w_sum));
+        kernel_grads[OFF_IDX(np)] = 0.5 * sigma_f * w_sum
+                                  * softplus_grad(k->raw_params[OFF_IDX(np)]);
+        CUDA_CHECK(cudaFreeAsync(d_ones, stream));
+        CUDA_CHECK(cudaFreeAsync(d_wrow, stream));
+    }
+
+    CUDA_CHECK(cudaFreeAsync(d_inv, stream));
+    CUDA_CHECK(cudaFreeAsync(d_D, stream));
+    CUDA_CHECK(cudaFreeAsync(d_W, stream));
+    CUDA_CHECK(cudaFreeAsync(d_temp, stream));
+}
+
+static void matern32lin_destroy(GPKernel *k) { free(k); }
+
+GPKernel *gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
+                                        float offset)
+{
+    int n_params = dim + 2;
+    GPKernel *k = (GPKernel *)malloc(sizeof(GPKernel) + (size_t)n_params * sizeof(float));
+    k->n_params   = n_params;
+    k->raw_params = (float *)(k + 1);
+    memcpy(k->tag, GP_KERNEL_TAG_MATERN32_LINEAR, 4);
+    for (int i = 0; i < dim; i++)
+        k->raw_params[i] = inv_softplus(lengthscale);
+    k->raw_params[SF_IDX(n_params)]  = inv_softplus(outputscale);
+    k->raw_params[OFF_IDX(n_params)] = inv_softplus(offset);
+    k->build_K          = matern32lin_build_K;
+    k->build_Ks         = matern32lin_build_Ks;
+    k->build_kself_batch = matern32lin_build_kself_batch;
+    k->k_self           = matern32lin_k_self;
+    k->mll_grad         = matern32lin_mll_grad;
+    k->destroy          = matern32lin_destroy;
+    return k;
+}
+
+float gp_kernel_get_lengthscale(const GPKernel *k, int d) { return softplus(k->raw_params[d]); }
+float gp_kernel_get_outputscale(const GPKernel *k) { return softplus(k->raw_params[SF_IDX(k->n_params)]);  }
+float gp_kernel_get_offset     (const GPKernel *k) { return softplus(k->raw_params[OFF_IDX(k->n_params)]); }
+void gp_kernel_set_lengthscale(GPKernel *k, int d, float v) { k->raw_params[d] = inv_softplus(v); }
+void gp_kernel_set_outputscale(GPKernel *k, float v) { k->raw_params[SF_IDX(k->n_params)]  = inv_softplus(v); }
+void gp_kernel_set_offset     (GPKernel *k, float v) { k->raw_params[OFF_IDX(k->n_params)] = inv_softplus(v); }
+
+#endif // GP_CUDA_KERNEL_CU

--- a/src/gp_cuda_kernel.cu
+++ b/src/gp_cuda_kernel.cu
@@ -4,86 +4,96 @@
 #ifndef GP_CUDA_KERNEL_CU
 #define GP_CUDA_KERNEL_CU
 
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <cublas_v2.h>
-#include <cuda_runtime.h>
 
-#define CUDA_CHECK(call) do { \
-    cudaError_t _e = (call); \
-    if (_e != cudaSuccess) { \
-        fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, \
-                cudaGetErrorString(_e)); \
-        abort(); \
-    } \
-} while (0)
+#define CUDA_CHECK(call)                                                  \
+    do {                                                                  \
+        cudaError_t _e = (call);                                          \
+        if (_e != cudaSuccess) {                                          \
+            fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, \
+                cudaGetErrorString(_e));                                  \
+            abort();                                                      \
+        }                                                                 \
+    } while (0)
 
-#define CUBLAS_CHECK(call) do { \
-    cublasStatus_t _s = (call); \
-    if (_s != CUBLAS_STATUS_SUCCESS) { \
-        fprintf(stderr, "cuBLAS error %s:%d: %d\n", __FILE__, __LINE__, (int)_s); \
-        abort(); \
-    } \
-} while (0)
+#define CUBLAS_CHECK(call)                                                            \
+    do {                                                                              \
+        cublasStatus_t _s = (call);                                                   \
+        if (_s != CUBLAS_STATUS_SUCCESS) {                                            \
+            fprintf(stderr, "cuBLAS error %s:%d: %d\n", __FILE__, __LINE__, (int)_s); \
+            abort();                                                                  \
+        }                                                                             \
+    } while (0)
 
 #define SP_LB 1e-4
-__host__ __device__ __forceinline__ float softplus(float x)      { return (x > 20.0 ? x : log1p(exp(x))) + SP_LB; }
-__host__ __device__ __forceinline__ float inv_softplus(float x)  { float v = x - SP_LB; return v > 20.0 ? v : log(expm1(v)); }
+__host__ __device__ __forceinline__ float softplus(float x) { return (x > 20.0 ? x : log1p(exp(x))) + SP_LB; }
+__host__ __device__ __forceinline__ float inv_softplus(float x)
+{
+    float v = x - SP_LB;
+    return v > 20.0 ? v : log(expm1(v));
+}
 __host__ __device__ __forceinline__ float softplus_grad(float x) { return 1.0 / (1.0 + exp(-x)); }
 
 // -- kernel struct -----------------------------------------------------------
 
 typedef struct GPKernel GPKernel;
 struct GPKernel {
-    int     n_params;
-    float *raw_params;
-    char    tag[4];
+    int n_params;
+    float* raw_params;
+    char tag[4];
 
-    void (*build_K)(const GPKernel *k, const float *d_X, int n, int d,
-                    float sigma_n, float *d_K, cudaStream_t stream);
-    void (*build_Ks)(const GPKernel *k, const float *d_Xtr, const float *d_Xte,
-                     int n, int m, int d, float *d_Ks, cudaStream_t stream);
-    void (*build_kself_batch)(const GPKernel *k, const float *d_X, int m, int d,
-                               float *d_out, cudaStream_t stream);
-    float (*k_self)(const GPKernel *k, const float *x, int d);
-    void (*mll_grad)(const GPKernel *k, const float *d_X, int n, int d,
-                     cublasHandle_t cublas, cudaStream_t stream,
-                     const float *d_alpha, const float *d_Kinv,
-                     float *kernel_grads);
-    void (*destroy)(GPKernel *k);
+    void (*build_K)(const GPKernel* k, const float* d_X, int n, int d,
+        float sigma_n, float* d_K, cudaStream_t stream);
+    void (*build_Ks)(const GPKernel* k, const float* d_Xtr, const float* d_Xte,
+        int n, int m, int d, float* d_Ks, cudaStream_t stream);
+    void (*build_kself_batch)(const GPKernel* k, const float* d_X, int m, int d,
+        float* d_out, cudaStream_t stream);
+    float (*k_self)(const GPKernel* k, const float* x, int d);
+    void (*mll_grad)(const GPKernel* k, const float* d_X, int n, int d,
+        cublasHandle_t cublas, cudaStream_t stream,
+        const float* d_alpha, const float* d_Kinv,
+        float* kernel_grads);
+    void (*destroy)(GPKernel* k);
 };
 
 #define GP_KERNEL_TAG_MATERN32_LINEAR "M32L"
 
-GPKernel *gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
-                                        float offset);
+GPKernel* gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
+    float offset);
 
-float gp_kernel_get_lengthscale(const GPKernel *k, int d);
-float gp_kernel_get_outputscale(const GPKernel *k);
-float gp_kernel_get_offset     (const GPKernel *k);
-void   gp_kernel_set_lengthscale(GPKernel *k, int d, float v);
-void   gp_kernel_set_outputscale(GPKernel *k, float v);
-void   gp_kernel_set_offset     (GPKernel *k, float v);
+float gp_kernel_get_lengthscale(const GPKernel* k, int d);
+float gp_kernel_get_outputscale(const GPKernel* k);
+float gp_kernel_get_offset(const GPKernel* k);
+void gp_kernel_set_lengthscale(GPKernel* k, int d, float v);
+void gp_kernel_set_outputscale(GPKernel* k, float v);
+void gp_kernel_set_offset(GPKernel* k, float v);
 
 // -- kernel implementations --------------------------------------------------
 
-#define SF_IDX(np)  ((np) - 2)
-#define OFF_IDX(np) ((np) - 1)
+#define SF_IDX(np) ((np)-2)
+#define OFF_IDX(np) ((np)-1)
 
 #define GP_BLOCK 16
-inline int gp_grid(int n) { return (n + GP_BLOCK - 1) / GP_BLOCK; }
+inline int gp_grid(int n)
+{
+    return (n + GP_BLOCK - 1) / GP_BLOCK;
+}
 
 __global__ void matern32lin_k_build_K(
-    const float * __restrict__ X,
-    float       * __restrict__ K,
-    const float * __restrict__ inv_ells,
+    const float* __restrict__ X,
+    float* __restrict__ K,
+    const float* __restrict__ inv_ells,
     int n, int d, float sigma_f, float sigma_n, float offset)
 {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= n) return;
+    if (row >= n || col >= n)
+        return;
     float dot = 0.0, r2 = 0.0;
     for (int k = 0; k < d; k++) {
         float xr = X[row * d + k], xc = X[col * d + k];
@@ -91,23 +101,26 @@ __global__ void matern32lin_k_build_K(
         float diff = (xr - xc) * inv_ells[k];
         r2 += diff * diff;
     }
-    if (r2 < 0.0) r2 = 0.0;
-    float u   = sqrt(3.0) * sqrt(r2);
+    if (r2 < 0.0)
+        r2 = 0.0;
+    float u = sqrt(3.0) * sqrt(r2);
     float val = sigma_f * (dot + offset + (1.0 + u) * exp(-u));
-    if (row == col) val += sigma_n;
+    if (row == col)
+        val += sigma_n;
     K[col * n + row] = val;
 }
 
 __global__ void matern32lin_k_build_Ks(
-    const float * __restrict__ Xtr,
-    const float * __restrict__ Xte,
-    float       * __restrict__ Ks,
-    const float * __restrict__ inv_ells,
+    const float* __restrict__ Xtr,
+    const float* __restrict__ Xte,
+    float* __restrict__ Ks,
+    const float* __restrict__ inv_ells,
     int n, int m, int d, float sigma_f, float offset)
 {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= m) return;
+    if (row >= n || col >= m)
+        return;
     float dot = 0.0, r2 = 0.0;
     for (int k = 0; k < d; k++) {
         float xr = Xtr[row * d + k], xc = Xte[col * d + k];
@@ -115,20 +128,22 @@ __global__ void matern32lin_k_build_Ks(
         float diff = (xr - xc) * inv_ells[k];
         r2 += diff * diff;
     }
-    if (r2 < 0.0) r2 = 0.0;
+    if (r2 < 0.0)
+        r2 = 0.0;
     float u = sqrt(3.0) * sqrt(r2);
     Ks[col * n + row] = sigma_f * (dot + offset + (1.0 + u) * exp(-u));
 }
 
 __global__ void matern32lin_k_build_D_ard(
-    const float * __restrict__ X,
-    float       * __restrict__ D,
-    const float * __restrict__ inv_ells,
+    const float* __restrict__ X,
+    float* __restrict__ D,
+    const float* __restrict__ inv_ells,
     int n, int d)
 {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= n) return;
+    if (row >= n || col >= n)
+        return;
     float sq = 0.0;
     for (int k = 0; k < d; k++) {
         float diff = (X[row * d + k] - X[col * d + k]) * inv_ells[k];
@@ -138,133 +153,142 @@ __global__ void matern32lin_k_build_D_ard(
 }
 
 __global__ void matern32lin_k_compute_W(
-    const float * __restrict__ alpha,
-    const float * __restrict__ Kinv,
-    float       * __restrict__ W,
+    const float* __restrict__ alpha,
+    const float* __restrict__ Kinv,
+    float* __restrict__ W,
     int n)
 {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= n) return;
+    if (row >= n || col >= n)
+        return;
     W[col * n + row] = alpha[row] * alpha[col] - Kinv[col * n + row];
 }
 
 __global__ void matern32lin_k_dk_dell_d(
-    const float * __restrict__ X,
-    const float * __restrict__ D_ard,
-    float       * __restrict__ out,
+    const float* __restrict__ X,
+    const float* __restrict__ D_ard,
+    float* __restrict__ out,
     int n, int d, int dd, float sigma_f, float inv_ell_d3)
 {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= n) return;
-    float r2   = D_ard[col * n + row];
+    if (row >= n || col >= n)
+        return;
+    float r2 = D_ard[col * n + row];
     float diff = X[row * d + dd] - X[col * d + dd];
     out[col * n + row] = sigma_f * 3.0 * diff * diff * inv_ell_d3
-                       * exp(-sqrt(3.0) * sqrt(r2));
+        * exp(-sqrt(3.0) * sqrt(r2));
 }
 
-__global__ void matern32lin_k_fill(float *v, int n, float val)
+__global__ void matern32lin_k_fill(float* v, int n, float val)
 {
     int i = blockIdx.x * 256 + threadIdx.x;
-    if (i < n) v[i] = val;
+    if (i < n)
+        v[i] = val;
 }
 
 __global__ void matern32lin_k_kself_batch(
-    const float * __restrict__ X, float * __restrict__ out,
+    const float* __restrict__ X, float* __restrict__ out,
     int m, int d, float sigma_f, float offset)
 {
     int row = blockIdx.x * 256 + threadIdx.x;
-    if (row >= m) return;
+    if (row >= m)
+        return;
     float norm2 = 0.0;
-    for (int k = 0; k < d; k++) { float v = X[row * d + k]; norm2 += v * v; }
+    for (int k = 0; k < d; k++) {
+        float v = X[row * d + k];
+        norm2 += v * v;
+    }
     out[row] = sigma_f * (norm2 + offset + 1.0);
 }
 
 // -- helpers -----------------------------------------------------------------
 
-static float *h2d(const float *h, int n, cudaStream_t stream)
+static float* h2d(const float* h, int n, cudaStream_t stream)
 {
-    float *d;
+    float* d;
     CUDA_CHECK(cudaMallocAsync(&d, (size_t)n * sizeof(float), stream));
     CUDA_CHECK(cudaMemcpyAsync(d, h, (size_t)n * sizeof(float),
-                               cudaMemcpyHostToDevice, stream));
+        cudaMemcpyHostToDevice, stream));
     return d;
 }
 
-static float *device_inv_ells(const GPKernel *k, int d, cudaStream_t stream)
+static float* device_inv_ells(const GPKernel* k, int d, cudaStream_t stream)
 {
-    float *h = (float *)malloc(d * sizeof(float));
-    for (int i = 0; i < d; i++) h[i] = 1.0 / softplus(k->raw_params[i]);
-    float *dev = h2d(h, d, stream);
+    float* h = (float*)malloc(d * sizeof(float));
+    for (int i = 0; i < d; i++)
+        h[i] = 1.0 / softplus(k->raw_params[i]);
+    float* dev = h2d(h, d, stream);
     free(h);
     return dev;
 }
 
 // -- launcher functions ------------------------------------------------------
 
-static void matern32lin_build_K(const GPKernel *k, const float *d_X, int n, int d,
-                            float sigma_n, float *d_K, cudaStream_t stream)
+static void matern32lin_build_K(const GPKernel* k, const float* d_X, int n, int d,
+    float sigma_n, float* d_K, cudaStream_t stream)
 {
-    int    np      = k->n_params;
+    int np = k->n_params;
     float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
-    float *d_inv  = device_inv_ells(k, d, stream);
+    float offset = softplus(k->raw_params[OFF_IDX(np)]);
+    float* d_inv = device_inv_ells(k, d, stream);
     dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(n), gp_grid(n));
     matern32lin_k_build_K<<<grid, block, 0, stream>>>(d_X, d_K, d_inv, n, d, sigma_f, sigma_n, offset);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaFreeAsync(d_inv, stream));
 }
 
-static void matern32lin_build_Ks(const GPKernel *k, const float *d_Xtr, const float *d_Xte,
-                             int n, int m, int d, float *d_Ks, cudaStream_t stream)
+static void matern32lin_build_Ks(const GPKernel* k, const float* d_Xtr, const float* d_Xte,
+    int n, int m, int d, float* d_Ks, cudaStream_t stream)
 {
-    int    np      = k->n_params;
+    int np = k->n_params;
     float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
-    float *d_inv  = device_inv_ells(k, d, stream);
+    float offset = softplus(k->raw_params[OFF_IDX(np)]);
+    float* d_inv = device_inv_ells(k, d, stream);
     dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(m), gp_grid(n));
     matern32lin_k_build_Ks<<<grid, block, 0, stream>>>(d_Xtr, d_Xte, d_Ks, d_inv, n, m, d, sigma_f, offset);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaFreeAsync(d_inv, stream));
 }
 
-static float matern32lin_k_self(const GPKernel *k, const float *x, int d)
+static float matern32lin_k_self(const GPKernel* k, const float* x, int d)
 {
-    int    np      = k->n_params;
+    int np = k->n_params;
     float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
-    float norm2   = 0.0;
-    for (int i = 0; i < d; i++) norm2 += x[i] * x[i];
+    float offset = softplus(k->raw_params[OFF_IDX(np)]);
+    float norm2 = 0.0;
+    for (int i = 0; i < d; i++)
+        norm2 += x[i] * x[i];
     return sigma_f * (norm2 + offset + 1.0);
 }
 
-static void matern32lin_build_kself_batch(const GPKernel *k, const float *d_X,
-                                      int m, int d, float *d_out, cudaStream_t stream)
+static void matern32lin_build_kself_batch(const GPKernel* k, const float* d_X,
+    int m, int d, float* d_out, cudaStream_t stream)
 {
-    int    np      = k->n_params;
+    int np = k->n_params;
     float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    float offset = softplus(k->raw_params[OFF_IDX(np)]);
     matern32lin_k_kself_batch<<<(m + 255) / 256, 256, 0, stream>>>(d_X, d_out, m, d, sigma_f, offset);
     CUDA_CHECK(cudaGetLastError());
 }
 
-static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int d,
-                             cublasHandle_t cublas, cudaStream_t stream,
-                             const float *d_alpha, const float *d_Kinv,
-                             float *kernel_grads)
+static void matern32lin_mll_grad(const GPKernel* k, const float* d_X, int n, int d,
+    cublasHandle_t cublas, cudaStream_t stream,
+    const float* d_alpha, const float* d_Kinv,
+    float* kernel_grads)
 {
-    int    np      = k->n_params;
+    int np = k->n_params;
     float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    float offset = softplus(k->raw_params[OFF_IDX(np)]);
     const float one = 1.0, zero = 0.0;
 
     CUBLAS_CHECK(cublasSetStream(cublas, stream));
 
-    float *d_inv  = device_inv_ells(k, d, stream);
+    float* d_inv = device_inv_ells(k, d, stream);
     float *d_D, *d_W, *d_temp;
-    CUDA_CHECK(cudaMallocAsync(&d_D,    (size_t)n * n * sizeof(float), stream));
-    CUDA_CHECK(cudaMallocAsync(&d_W,    (size_t)n * n * sizeof(float), stream));
+    CUDA_CHECK(cudaMallocAsync(&d_D, (size_t)n * n * sizeof(float), stream));
+    CUDA_CHECK(cudaMallocAsync(&d_W, (size_t)n * n * sizeof(float), stream));
     CUDA_CHECK(cudaMallocAsync(&d_temp, (size_t)n * n * sizeof(float), stream));
 
     dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(n), gp_grid(n));
@@ -275,7 +299,7 @@ static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int
     CUDA_CHECK(cudaGetLastError());
 
     for (int dd = 0; dd < d; dd++) {
-        float ell_d    = softplus(k->raw_params[dd]);
+        float ell_d = softplus(k->raw_params[dd]);
         float inv_ell3 = 1.0 / (ell_d * ell_d * ell_d);
         matern32lin_k_dk_dell_d<<<grid, block, 0, stream>>>(d_X, d_D, d_temp, n, d, dd, sigma_f, inv_ell3);
         CUDA_CHECK(cudaGetLastError());
@@ -290,7 +314,7 @@ static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int
         float dot_val;
         CUBLAS_CHECK(cublasSdot(cublas, n * n, d_W, 1, d_temp, 1, &dot_val));
         kernel_grads[SF_IDX(np)] = 0.5 * dot_val / sigma_f
-                                 * softplus_grad(k->raw_params[SF_IDX(np)]);
+            * softplus_grad(k->raw_params[SF_IDX(np)]);
     }
 
     {
@@ -301,10 +325,10 @@ static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int
         CUDA_CHECK(cudaGetLastError());
         float w_sum;
         CUBLAS_CHECK(cublasSgemv(cublas, CUBLAS_OP_N, n, n,
-                                 &one, d_W, n, d_ones, 1, &zero, d_wrow, 1));
+            &one, d_W, n, d_ones, 1, &zero, d_wrow, 1));
         CUBLAS_CHECK(cublasSdot(cublas, n, d_wrow, 1, d_ones, 1, &w_sum));
         kernel_grads[OFF_IDX(np)] = 0.5 * sigma_f * w_sum
-                                  * softplus_grad(k->raw_params[OFF_IDX(np)]);
+            * softplus_grad(k->raw_params[OFF_IDX(np)]);
         CUDA_CHECK(cudaFreeAsync(d_ones, stream));
         CUDA_CHECK(cudaFreeAsync(d_wrow, stream));
     }
@@ -315,34 +339,34 @@ static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int
     CUDA_CHECK(cudaFreeAsync(d_temp, stream));
 }
 
-static void matern32lin_destroy(GPKernel *k) { free(k); }
+static void matern32lin_destroy(GPKernel* k) { free(k); }
 
-GPKernel *gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
-                                        float offset)
+GPKernel* gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
+    float offset)
 {
     int n_params = dim + 2;
-    GPKernel *k = (GPKernel *)malloc(sizeof(GPKernel) + (size_t)n_params * sizeof(float));
-    k->n_params   = n_params;
-    k->raw_params = (float *)(k + 1);
+    GPKernel* k = (GPKernel*)malloc(sizeof(GPKernel) + (size_t)n_params * sizeof(float));
+    k->n_params = n_params;
+    k->raw_params = (float*)(k + 1);
     memcpy(k->tag, GP_KERNEL_TAG_MATERN32_LINEAR, 4);
     for (int i = 0; i < dim; i++)
         k->raw_params[i] = inv_softplus(lengthscale);
-    k->raw_params[SF_IDX(n_params)]  = inv_softplus(outputscale);
+    k->raw_params[SF_IDX(n_params)] = inv_softplus(outputscale);
     k->raw_params[OFF_IDX(n_params)] = inv_softplus(offset);
-    k->build_K          = matern32lin_build_K;
-    k->build_Ks         = matern32lin_build_Ks;
+    k->build_K = matern32lin_build_K;
+    k->build_Ks = matern32lin_build_Ks;
     k->build_kself_batch = matern32lin_build_kself_batch;
-    k->k_self           = matern32lin_k_self;
-    k->mll_grad         = matern32lin_mll_grad;
-    k->destroy          = matern32lin_destroy;
+    k->k_self = matern32lin_k_self;
+    k->mll_grad = matern32lin_mll_grad;
+    k->destroy = matern32lin_destroy;
     return k;
 }
 
-float gp_kernel_get_lengthscale(const GPKernel *k, int d) { return softplus(k->raw_params[d]); }
-float gp_kernel_get_outputscale(const GPKernel *k) { return softplus(k->raw_params[SF_IDX(k->n_params)]);  }
-float gp_kernel_get_offset     (const GPKernel *k) { return softplus(k->raw_params[OFF_IDX(k->n_params)]); }
-void gp_kernel_set_lengthscale(GPKernel *k, int d, float v) { k->raw_params[d] = inv_softplus(v); }
-void gp_kernel_set_outputscale(GPKernel *k, float v) { k->raw_params[SF_IDX(k->n_params)]  = inv_softplus(v); }
-void gp_kernel_set_offset     (GPKernel *k, float v) { k->raw_params[OFF_IDX(k->n_params)] = inv_softplus(v); }
+float gp_kernel_get_lengthscale(const GPKernel* k, int d) { return softplus(k->raw_params[d]); }
+float gp_kernel_get_outputscale(const GPKernel* k) { return softplus(k->raw_params[SF_IDX(k->n_params)]); }
+float gp_kernel_get_offset(const GPKernel* k) { return softplus(k->raw_params[OFF_IDX(k->n_params)]); }
+void gp_kernel_set_lengthscale(GPKernel* k, int d, float v) { k->raw_params[d] = inv_softplus(v); }
+void gp_kernel_set_outputscale(GPKernel* k, float v) { k->raw_params[SF_IDX(k->n_params)] = inv_softplus(v); }
+void gp_kernel_set_offset(GPKernel* k, float v) { k->raw_params[OFF_IDX(k->n_params)] = inv_softplus(v); }
 
 #endif // GP_CUDA_KERNEL_CU

--- a/src/gp_cuda_kernel.cu
+++ b/src/gp_cuda_kernel.cu
@@ -79,6 +79,11 @@ void gp_kernel_set_offset(GPKernel* k, float v);
 #define OFF_IDX(np) ((np)-1)
 
 #define GP_BLOCK 16
+
+#ifndef BLOCK_SIZE
+#define BLOCK_SIZE 256
+#endif
+
 inline int gp_grid(int n)
 {
     return (n + GP_BLOCK - 1) / GP_BLOCK;
@@ -183,7 +188,7 @@ __global__ void matern32lin_k_dk_dell_d(
 
 __global__ void matern32lin_k_fill(float* v, int n, float val)
 {
-    int i = blockIdx.x * 256 + threadIdx.x;
+    int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         v[i] = val;
 }
@@ -192,7 +197,7 @@ __global__ void matern32lin_k_kself_batch(
     const float* __restrict__ X, float* __restrict__ out,
     int m, int d, float sigma_f, float offset)
 {
-    int row = blockIdx.x * 256 + threadIdx.x;
+    int row = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (row >= m)
         return;
     float norm2 = 0.0;
@@ -269,7 +274,7 @@ static void matern32lin_build_kself_batch(const GPKernel* k, const float* d_X,
     int np = k->n_params;
     float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
     float offset = softplus(k->raw_params[OFF_IDX(np)]);
-    matern32lin_k_kself_batch<<<(m + 255) / 256, 256, 0, stream>>>(d_X, d_out, m, d, sigma_f, offset);
+    matern32lin_k_kself_batch<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_X, d_out, m, d, sigma_f, offset);
     CUDA_CHECK(cudaGetLastError());
 }
 
@@ -321,7 +326,7 @@ static void matern32lin_mll_grad(const GPKernel* k, const float* d_X, int n, int
         float *d_ones, *d_wrow;
         CUDA_CHECK(cudaMallocAsync(&d_ones, (size_t)n * sizeof(float), stream));
         CUDA_CHECK(cudaMallocAsync(&d_wrow, (size_t)n * sizeof(float), stream));
-        matern32lin_k_fill<<<(n + 255) / 256, 256, 0, stream>>>(d_ones, n, 1.0);
+        matern32lin_k_fill<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_ones, n, 1.0);
         CUDA_CHECK(cudaGetLastError());
         float w_sum;
         CUBLAS_CHECK(cublasSgemv(cublas, CUBLAS_OP_N, n, n,

--- a/tests/test_custom_gp_numerics.py
+++ b/tests/test_custom_gp_numerics.py
@@ -1,0 +1,137 @@
+"""
+Custom CUDA GP vs GPyTorch
+
+Hyperparameters are fixed identically, just comparing the raw numerical results and timings for training and prediction.
+"""
+
+import time, sys, math
+import numpy as np
+
+def make_data(n, dim=1, seed=42):
+    rng = np.random.RandomState(seed)
+    X = rng.uniform(-5, 5, size=(n, dim))
+    y = np.sin(X[:, 0]) + 0.1 * rng.randn(n)
+    return X.astype(np.float64), y.astype(np.float64)
+
+def make_test(m=200, dim=1):
+    xs = np.linspace(-6, 6, m).reshape(-1, 1)
+    if dim > 1:
+        xs = np.hstack([xs, np.zeros((m, dim - 1))])
+    return xs.astype(np.float64)
+
+def bench_custom(X, y, Xs, hp):
+    from pufferlib.gp_torch import GaussianProcess
+    import torch  # ensure CUDA context is warm before timing
+
+    # Warm-up: a tiny fit so the first CUDA call overhead isn't charged
+    # to the benchmark (driver init, JIT, etc.)
+    _gp = GaussianProcess(dim=X.shape[1], capacity=1,
+                          lengthscale=hp["lengthscale"],
+                          outputscale=hp["outputscale"],
+                          noise=hp["noise"])
+
+    t0 = time.perf_counter()
+    gp = GaussianProcess(dim=X.shape[1], capacity=len(X),
+                          lengthscale=hp["lengthscale"],
+                          outputscale=hp["outputscale"],
+                          noise=hp["noise"])
+    
+    print(gp)
+    gp.fit(X, y)
+    t_train = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    means, vars_ = gp.predict(Xs)
+    t_pred = time.perf_counter() - t0
+
+    return means.numpy(), vars_.numpy(), gp.log_marginal_likelihood, t_train, t_pred
+
+def bench_gpytorch(X, y, Xs, hp):
+    import torch, gpytorch
+
+    class ExactGP(gpytorch.models.ExactGP):
+        def __init__(self, tx, ty, lik):
+            super().__init__(tx, ty, lik)
+            from gpytorch.kernels import (MaternKernel, PolynomialKernel,
+                                          AdditiveKernel, ScaleKernel)
+            self.mean_module  = gpytorch.means.ZeroMean()
+            matern = MaternKernel(nu=1.5, ard_num_dims=tx.shape[-1])
+            linear = PolynomialKernel(power=1)
+            self.covar_module = ScaleKernel(AdditiveKernel(linear, matern))
+        def forward(self, x):
+            return gpytorch.distributions.MultivariateNormal(
+                self.mean_module(x), self.covar_module(x))
+
+    Xt  = torch.from_numpy(X).double()
+    yt  = torch.from_numpy(y).double()
+    Xst = torch.from_numpy(Xs).double()
+
+    t0 = time.perf_counter()
+    lik   = gpytorch.likelihoods.GaussianLikelihood()
+    model = ExactGP(Xt, yt, lik)
+    model.double()
+    model.covar_module.base_kernel.kernels[1].lengthscale  = hp["lengthscale"]
+    model.covar_module.outputscale                         = hp["outputscale"]
+    lik.noise                                              = hp["noise"]
+    model.covar_module.base_kernel.kernels[0].raw_offset.data.fill_(
+        math.log(math.expm1(hp["offset"])))
+    t_train = time.perf_counter() - t0
+
+    # Force exact Cholesky (default CG cutoff is 800)
+    chol_size = max(len(yt) + 1, 801)
+    model.eval(); lik.eval()
+    t0 = time.perf_counter()
+    with torch.no_grad(), \
+         gpytorch.settings.fast_pred_var(), \
+         gpytorch.settings.max_cholesky_size(chol_size):
+        latent = model(Xst)
+        means  = latent.mean.numpy()
+        vars_  = latent.variance.numpy()
+    t_pred = time.perf_counter() - t0
+
+    model.train(); lik.train()
+    with torch.no_grad(), gpytorch.settings.max_cholesky_size(chol_size):
+        mll = gpytorch.mlls.ExactMarginalLogLikelihood(lik, model)
+        mll = mll(model(Xt), yt).item()
+
+    return means, vars_, mll, t_train, t_pred
+
+def run(n, dim=1):
+    hp   = dict(lengthscale=1.0, outputscale=1.0, noise=0.01, offset=math.log(2))
+    X, y = make_data(n, dim)
+    Xs   = make_test(200, dim)
+
+    rows = {}
+
+    try:
+        rows["CUDA"] = bench_custom(X, y, Xs, hp)
+    except ImportError:
+        pass
+
+    rows["GPyTorch"] = bench_gpytorch(X, y, Xs, hp)
+
+    ref_means = rows["GPyTorch"][0]
+    ref_vars  = rows["GPyTorch"][1]
+
+    print(f"\n{'='*84}")
+    print(f"  n={n}  dim={dim}")
+    print(f"{'='*84}")
+    print(f"  {'':22s} {'train':>8s} {'predict':>8s} {'total':>8s}"
+          f" {'MLL':>12s} {'|err_mean|':>10s} {'|err_var|':>10s}")
+
+    for label, (m_, v_, mll, tt, tp) in rows.items():
+        me = np.max(np.abs(m_ - ref_means))
+        ve = np.max(np.abs(v_ - ref_vars))
+        print(f"  {label:22s} {tt:7.4f}s {tp:7.4f}s {tt+tp:7.4f}s"
+              f" {mll:12.4f} {me:9.2e} {ve:9.2e}")
+
+    print(f"  {'':22s} (GPyTorch: exact Cholesky forced for n>800, errors vs GPyTorch)")
+
+if __name__ == "__main__":
+    sizes = [100, 200, 1000, 2000]
+    dims  = [1, 5]
+    if len(sys.argv) > 1:
+        sizes = [int(s) for s in sys.argv[1:]]
+    for n in sizes:
+        for d in dims:
+            run(n, dim=d)

--- a/tests/test_custom_gp_optim.py
+++ b/tests/test_custom_gp_optim.py
@@ -1,0 +1,171 @@
+"""
+mini-batch hyperparameter optimization: custom CUDA GP vs GPyTorch
+
+Runs Adam on the same batches from the same starting point
+"""
+
+import math, sys
+import numpy as np
+import torch
+import gpytorch
+from gpytorch.kernels import MaternKernel, PolynomialKernel, AdditiveKernel, ScaleKernel
+
+sys.path.insert(0, ".")
+from pufferlib.gp_torch import GaussianProcess
+
+N     = 300
+BATCH = 40
+STEPS = 60
+LR    = 0.05
+SEED  = 42
+
+
+def make_data(n, seed):
+    rng = np.random.RandomState(seed)
+    X   = rng.uniform(-5, 5, (n, 1)).astype(np.float64)
+    y   = (np.sin(X[:, 0]) + 0.1 * rng.randn(n)).astype(np.float64)
+    return X, y
+
+
+class ExactGP(gpytorch.models.ExactGP):
+    def __init__(self, tx, ty, lik):
+        super().__init__(tx, ty, lik)
+        self.mean_module  = gpytorch.means.ZeroMean()
+        matern = MaternKernel(nu=1.5, ard_num_dims=1)
+        linear = PolynomialKernel(power=1)
+        self.covar_module = ScaleKernel(AdditiveKernel(linear, matern))
+
+    def forward(self, x):
+        return gpytorch.distributions.MultivariateNormal(
+            self.mean_module(x), self.covar_module(x))
+
+
+def main():
+    X, y   = make_data(N, SEED)
+    Xt, yt = torch.from_numpy(X).double(), torch.from_numpy(y).double()
+
+    rng     = np.random.RandomState(SEED + 1)
+    batches = [rng.choice(N, BATCH, replace=False) for _ in range(STEPS)]
+
+    # shared initial constrained hyperparameters
+    ell0, sf0, noise0, off0 = 1.0, 1.0, 0.01, 1.0
+
+    # -- our model ---------------------------------------------------------
+    gp = GaussianProcess(dim=1, capacity=BATCH,
+            lengthscale=ell0, outputscale=sf0, noise=noise0, offset=off0,
+            use_cuda=False)
+    opt_ours = torch.optim.Adam(gp.parameters(), lr=LR)
+    gp.train()
+
+    # -- GPyTorch model ----------------------------------------------------
+    lik = gpytorch.likelihoods.GaussianLikelihood()
+    gpyt = ExactGP(Xt, yt, lik)
+    gpyt.double()
+    # Match initial constrained hyperparameters
+    gpyt.covar_module.base_kernel.kernels[1].lengthscale = ell0
+    gpyt.covar_module.outputscale                         = sf0
+    lik.noise                                            = noise0
+    gpyt.covar_module.base_kernel.kernels[0].raw_offset.data.fill_(
+        math.log(math.expm1(off0)))
+
+    mll_fn  = gpytorch.mlls.ExactMarginalLogLikelihood(lik, gpyt)
+    opt_gpyt = torch.optim.Adam(gpyt.parameters(), lr=LR)
+    gpyt.train(); lik.train()
+
+    # -- step-by-step comparison -------------------------------------------
+    print(f"\n{'step':>4}  {'MLL (ours)':>11}  {'MLL (gpyt)':>11}  {'|dMLL|':>8}"
+          f"  {'ell_ours':>9}  {'ell_gpyt':>9}  {'noise_ours':>11}  {'noise_gpyt':>11}")
+    print("-" * 102)
+
+    for step, idx in enumerate(batches):
+        X_b, y_b = Xt[idx], yt[idx]
+
+        # ours: fit loads batch + Cholesky; mll(recompute=False) skips a second one
+        gp.fit(X_b.numpy(), y_b.numpy())
+        opt_ours.zero_grad()
+        loss_ours = -gp.mll(recompute=False)
+        loss_ours.backward()
+        mll_ours = -loss_ours.item()
+        opt_ours.step()
+
+        # gpytorch: update stored training data to the batch, then compute MLL
+        gpyt.set_train_data(inputs=X_b, targets=y_b, strict=False)
+        opt_gpyt.zero_grad()
+        with gpytorch.settings.max_cholesky_size(BATCH + 1):
+            loss_gpyt = -mll_fn(gpyt(X_b), y_b)
+        loss_gpyt.backward()
+        mll_gpyt = -loss_gpyt.item()
+        opt_gpyt.step()
+
+        if step % 10 == 0 or step == STEPS - 1:
+            ell_ours = float(gp.lengthscale[0])
+            ell_g    = gpyt.covar_module.base_kernel.kernels[1].lengthscale.flatten()[0].item()
+            print(f"{step:>4}  {mll_ours:>11.5f}  {mll_gpyt:>11.5f}  "
+                  f"{abs(mll_ours - mll_gpyt):>8.2e}"
+                  f"  {ell_ours:>9.4f}  {ell_g:>9.4f}"
+                  f"  {gp.noise:>11.6f}  {lik.noise.item():>11.6f}")
+
+    # -- final hyperparameter comparison -----------------------------------
+    ell_ours = float(gp.lengthscale[0])
+    ell_gpyt  = gpyt.covar_module.base_kernel.kernels[1].lengthscale.flatten()[0].item()
+    ours_vals = [ell_ours, gp.outputscale, gp.noise, gp.offset]
+    gpyt_vals  = [
+        ell_gpyt,
+        gpyt.covar_module.outputscale.item(),
+        lik.noise.item(),
+        gpyt.covar_module.base_kernel.kernels[0].offset.item(),
+    ]
+    print()
+    print("Final hyperparameters:")
+    for label, ov, gv in zip(["lengthscale", "outputscale", "noise", "offset"],
+                              ours_vals, gpyt_vals):
+        print(f"  {label:12s}  ours={ov:.6f}  gpyt={gv:.6f}  |d|={abs(ov - gv):.2e}")
+
+    # -- gradient agreement at a fixed point (sanity check) ----------------
+    print()
+    print("Gradient agreement check (fresh models, same batch, same params):")
+    idx0 = batches[0]
+    X_b0, y_b0 = Xt[idx0], yt[idx0]
+
+    # fresh ours
+    gp2 = GaussianProcess(dim=1, capacity=BATCH,
+             lengthscale=ell0, outputscale=sf0, noise=noise0, offset=off0,
+             use_cuda=False)
+    gp2.train()
+    gp2.fit(X_b0.numpy(), y_b0.numpy())
+    (-gp2.mll(recompute=False)).backward()
+    # raw_lengthscale is (1,); flatten all param grads into a list
+    grads_ours = []
+    for p in gp2.parameters():
+        grads_ours.extend(p.grad.detach().flatten().tolist())
+
+    # fresh gpytorch
+    lik2 = gpytorch.likelihoods.GaussianLikelihood()
+    gpyt2 = ExactGP(Xt, yt, lik2)
+    gpyt2.double()
+    gpyt2.covar_module.base_kernel.kernels[1].lengthscale = ell0
+    gpyt2.covar_module.outputscale                         = sf0
+    lik2.noise                                            = noise0
+    gpyt2.covar_module.base_kernel.kernels[0].raw_offset.data.fill_(
+        math.log(math.expm1(off0)))
+    gpyt2.train(); lik2.train()
+    mll_fn2 = gpytorch.mlls.ExactMarginalLogLikelihood(lik2, gpyt2)
+    gpyt2.set_train_data(inputs=X_b0, targets=y_b0, strict=False)
+    with gpytorch.settings.max_cholesky_size(BATCH + 1):
+        (-mll_fn2(gpyt2(X_b0), y_b0)).backward()
+
+    # collect gpytorch gradients in the same param order as ours
+    gpyt_grads = [
+        gpyt2.covar_module.base_kernel.kernels[1].raw_lengthscale.grad.flatten()[0].item(),
+        gpyt2.covar_module.raw_outputscale.grad.item(),
+        lik2.noise_covar.raw_noise.grad.item(),
+        gpyt2.covar_module.base_kernel.kernels[0].raw_offset.grad.item(),
+    ]
+
+    labels = ["raw_ell_0", "raw_outputscale", "raw_noise", "raw_offset"]
+    for label, og, gg in zip(labels, grads_ours, gpyt_grads):
+        print(f"  {label:16s}  ours={og:+.6f}  gpyt={gg:+.6f}  |d|={abs(og - gg):.2e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -76,7 +76,7 @@ def test_sweep(args):
 
     target_metric = args['sweep']['metric']
     scores, costs = [], []
-    for i in range(args['max_runs']):
+    for i in range(args['sweep']['max_runs']):
         seed = time.time_ns() & 0xFFFFFFFF
         random.seed(seed)
         np.random.seed(seed)
@@ -164,19 +164,26 @@ def visualize(args):
 
 
 if __name__ == '__main__':
+    import argparse
+    import sys
     from pufferlib import pufferl
 
-    parser = pufferl.make_parser()
-    parser.add_argument('--task', type=str, default='linear', help='Task to optimize')
-    parser.add_argument('--vis-path', type=str, default='',
+    custom_parser = argparse.ArgumentParser(add_help=False)
+    custom_parser.add_argument('--task', type=str, default='linear', help='Task to optimize')
+    custom_parser.add_argument('--vis-path', type=str, default='',
         help='Set to visualize a saved sweep')
-    parser.add_argument('--data-path', type=str, default='sweep',
+    custom_parser.add_argument('--data-path', type=str, default='sweep',
         help='Used for testing hparam algorithms')
+    custom_args, remaining_argv = custom_parser.parse_known_args()
+    sys.argv = [sys.argv[0]] + remaining_argv
 
-    args = pufferl.load_config('default', parser=parser)
+    args = pufferl.load_config('default')
+    args['task'] = custom_args.task
+    args['vis_path'] = custom_args.vis_path
+    args['data_path'] = custom_args.data_path
+
+    test_sweep(args)
 
     if args['vis_path']:
         visualize(args)
         exit(0)
-
-    test_sweep(args)


### PR DESCRIPTION
# Summary

A custom CUDA C implementation of a Gaussian Process to begin porting Protein to CUDA C: 

- `src/gp_cuda.cu` implements the core logic for GP regression. Operations are implemented in single precision, still agrees to ~1e-3 precision with gpytorch. Can change to double precision if desired, but that's roughly 2x-4x the computational cost.
- `src/gp_cuda_kernel.cu` is for the GP covariance kernel. For the time being it only implements the current kernel used by Protein (Matern 3/2+linear), but keeping this separate could be useful if in the future we want to change the kernel.
- Modified `src/bindings.cu` and `pufferlib/sweep.py`  to adopt the custom GP, respectively. As it is right now, running sweeps on CPU would be broken since the GP is only implemented for CUDA, since I would think that sweeps make most sense with a GPU environment. 
    - If desired, I have a separate implementation in C [in this repo](https://github.com/vyeoms/puffing_gp), but it introduces more dependencies on either CBLAS or LAPACKE (can be chosen). Alternatively, could potentially just adjust the import calls and use gpytorch for CPU.
- Added tests: 
    - `tests/test_custom_gp_numerics.py` to verify numerical evaluation of this implementation vs gpytorch. Single precision agrees to ~1e-3, double precision agrees to ~1e-9
    - `tests/test_custom_gp_optimpy` to verify the GP implementations get updated more or less the same. Parameters agree to ~1e-3.
- Updated `tests/test_sweep.py` to use Puffer 3.0 format

# Numerical and qualitative results

## Output of `tests/test_custom_gp_numerics.py`

Running in my laptop with an A1000 GPU

```
python3 tests/test_custom_gp_numerics.py
<GaussianProcess dim=1 n=0 cap=100 ell=1 sf=1 noise=0.01>

====================================================================================
  n=100  dim=1
====================================================================================
                            train  predict    total          MLL |err_mean|  |err_var|
  CUDA                    0.0138s  0.0538s  0.0676s       0.4207  1.21e-03  4.35e-03
  GPyTorch                0.1798s  0.0086s  0.1884s       0.4222  0.00e+00  0.00e+00
                         (GPyTorch: exact Cholesky forced for n>800, errors vs GPyTorch)
<GaussianProcess dim=5 n=0 cap=100 ell=[1..1] sf=1 noise=0.01>

====================================================================================
  n=100  dim=5
====================================================================================
                            train  predict    total          MLL |err_mean|  |err_var|
  CUDA                    0.0007s  0.0012s  0.0019s      -1.3530  7.89e-05  7.27e-05
  GPyTorch                0.0014s  0.0044s  0.0058s      -1.3512  0.00e+00  0.00e+00
                         (GPyTorch: exact Cholesky forced for n>800, errors vs GPyTorch)
<GaussianProcess dim=1 n=0 cap=200 ell=1 sf=1 noise=0.01>

====================================================================================
  n=200  dim=1
====================================================================================
                            train  predict    total          MLL |err_mean|  |err_var|
  CUDA                    0.0008s  0.0035s  0.0042s       0.5845  1.22e-03  4.30e-03
  GPyTorch                0.0013s  0.0114s  0.0126s       0.5852  0.00e+00  0.00e+00
                         (GPyTorch: exact Cholesky forced for n>800, errors vs GPyTorch)
<GaussianProcess dim=5 n=0 cap=200 ell=[1..1] sf=1 noise=0.01>

====================================================================================
  n=200  dim=5
====================================================================================
                            train  predict    total          MLL |err_mean|  |err_var|
  CUDA                    0.0009s  0.0013s  0.0021s      -1.2414  7.64e-05  4.24e-05
  GPyTorch                0.0018s  0.0061s  0.0078s      -1.2405  0.00e+00  0.00e+00
                         (GPyTorch: exact Cholesky forced for n>800, errors vs GPyTorch)
<GaussianProcess dim=1 n=0 cap=1000 ell=1 sf=1 noise=0.01>

====================================================================================
  n=1000  dim=1
====================================================================================
                            train  predict    total          MLL |err_mean|  |err_var|
  CUDA                    0.0013s  0.0017s  0.0030s       0.7854  1.57e-03  3.56e-03
  GPyTorch                0.0012s  0.0501s  0.0513s       0.7856  0.00e+00  0.00e+00
                         (GPyTorch: exact Cholesky forced for n>800, errors vs GPyTorch)
<GaussianProcess dim=5 n=0 cap=1000 ell=[1..1] sf=1 noise=0.01>

====================================================================================
  n=1000  dim=5
====================================================================================
                            train  predict    total          MLL |err_mean|  |err_var|
  CUDA                    0.0014s  0.0017s  0.0031s      -1.1051  5.33e-05  1.69e-04
  GPyTorch                0.0014s  0.0444s  0.0458s      -1.1049  0.00e+00  0.00e+00
                         (GPyTorch: exact Cholesky forced for n>800, errors vs GPyTorch)
<GaussianProcess dim=1 n=0 cap=2000 ell=1 sf=1 noise=0.01>

====================================================================================
  n=2000  dim=1
====================================================================================
                            train  predict    total          MLL |err_mean|  |err_var|
  CUDA                    0.0035s  0.0025s  0.0060s       0.8255  2.78e-03  3.45e-03
  GPyTorch                0.0017s  0.2396s  0.2413s       0.8256  0.00e+00  0.00e+00
                         (GPyTorch: exact Cholesky forced for n>800, errors vs GPyTorch)
<GaussianProcess dim=5 n=0 cap=2000 ell=[1..1] sf=1 noise=0.01>

====================================================================================
  n=2000  dim=5
====================================================================================
                            train  predict    total          MLL |err_mean|  |err_var|
  CUDA                    0.0035s  0.0024s  0.0060s      -1.0348  5.27e-04  4.14e-04
  GPyTorch                0.0014s  0.1602s  0.1616s      -1.0347  0.00e+00  0.00e+00
                         (GPyTorch: exact Cholesky forced for n>800, errors vs GPyTorch)
```

## Output of `tests/test_custom_gp_optimpy`

Running in my laptop with an A1000 GPU

```
python3 tests/test_custom_gp_optim.py 

step   MLL (ours)   MLL (gpyt)    |dMLL|   ell_ours   ell_gpyt   noise_ours   noise_gpyt
------------------------------------------------------------------------------------------------------
   0     -0.01350     -0.01350  2.77e-06     1.0000     1.0319     0.010000     0.009519
  10      0.08714      0.08716  2.49e-05     1.3407     1.3766     0.008839     0.008702
  20      0.09407      0.09409  1.80e-05     1.6936     1.7266     0.007376     0.007327
  30      0.28398      0.28396  1.99e-05     1.9821     2.0041     0.007577     0.007637
  40      0.26798      0.26799  4.01e-06     2.1305     2.1381     0.007893     0.007919
  50      0.20838      0.20839  1.16e-05     2.1709     2.1711     0.007845     0.007886
  59      0.13616      0.13615  1.48e-05     2.1970     2.2010     0.007777     0.007847

Final hyperparameters:
  lengthscale   ours=2.196962  gpyt=2.201036  |d|=4.07e-03
  outputscale   ours=0.506837  gpyt=0.512420  |d|=5.58e-03
  noise         ours=0.007777  gpyt=0.007847  |d|=6.99e-05
  offset        ours=0.113545  gpyt=0.109945  |d|=3.60e-03

Gradient agreement check (fresh models, same batch, same params):
  raw_ell_0         ours=-0.225116  gpyt=-0.225130  |d|=1.36e-05
  raw_outputscale   ours=+0.119949  gpyt=+0.119963  |d|=1.38e-05
  raw_noise         ours=+0.091917  gpyt=+0.091916  |d|=1.13e-06
  raw_offset        ours=+0.006617  gpyt=+0.006617  |d|=1.82e-07
```

## Running `tests/test_sweep.py`

For more experiments see [this thread](https://discord.com/channels/1019421966429593712/1513437960509460551) on discord. Running 200 iters on my laptop with an A1000 GPU.

### gpytorch

<img width="1227" height="1192" alt="image" src="https://github.com/user-attachments/assets/1f64c239-6035-4f0d-a940-4375aef7fcec" />

Last 4 iterations:

```
Predicted --  Score: 1998.153 Cost: 1998.238 Rating: 0.441
196th sweep.suggest() took 6.0027s, score_loss: -2.6922, cost_loss: -3.0726
score_lengthscale: (0.29905853460017584, 10.167150127777367), cost_lengthscale: (7.47679755462468, 9.74540144925938)
Score: 399.5986720385235 Cost: 400.0
Score: 799.197344077047 Cost: 800.0
Score: 1198.7960161155704 Cost: 1200.0
Score: 1598.394688154094 Cost: 1600.0
Score: 1997.9933601926175 Cost: 2000.0
Predicted --  Score: 1996.813 Cost: 1998.563 Rating: 0.456
197th sweep.suggest() took 5.9045s, score_loss: -2.7016, cost_loss: -3.0819
score_lengthscale: (0.2995976852471699, 10.218646419804578), cost_lengthscale: (7.526265068733572, 9.796569932002358)
Score: 399.47347948362307 Cost: 400.0
Score: 798.9469589672461 Cost: 800.0
Score: 1198.4204384508691 Cost: 1200.0
Score: 1597.8939179344923 Cost: 1600.0
Score: 1997.3673974181152 Cost: 2000.0
Predicted --  Score: 1989.399 Cost: 1994.990 Rating: 0.666
198th sweep.suggest() took 6.1254s, score_loss: -2.7136, cost_loss: -3.0921
score_lengthscale: (0.29935269245337226, 10.270866115980953), cost_lengthscale: (7.574612105626908, 9.847318390411866)
Score: 399.90292790988974 Cost: 400.0
Score: 799.8058558197795 Cost: 800.0
Score: 1199.7087837296692 Cost: 1200.0
Score: 1599.611711639559 Cost: 1600.0
Score: 1999.5146395494487 Cost: 2000.0
Resetting GP optimizers at suggestion 200
Predicted --  Score: 1995.713 Cost: 1995.764 Rating: 0.755
199th sweep.suggest() took 5.8800s, score_loss: -2.7234, cost_loss: -3.1010
score_lengthscale: (0.2938725521362531, 10.323430282364289), cost_lengthscale: (7.623147214651303, 9.897310807614435)
Score: 399.04383487610795 Cost: 400.0
Score: 798.0876697522159 Cost: 800.0
Score: 1197.131504628324 Cost: 1200.0
Score: 1596.1753395044318 Cost: 1600.0
Score: 1995.21917438054 Cost: 2000.0
```

### This implementation

<img width="1155" height="1207" alt="image" src="https://github.com/user-attachments/assets/a81cb88f-a883-4d06-b05c-41a9203c5df9" />

Last 4 iterations:

```
Predicted --  Score: 1966.847 Cost: 1941.924 Rating: 0.512
196th sweep.suggest() took 1.3605s, score_loss: -1.9132, cost_loss: -2.0066
score_lengthscale: (0.260856956243515, 9.255864143371582), cost_lengthscale: (4.239974498748779, 8.621585845947266)
Score: 399.3732635476037 Cost: 400.0
Score: 798.7465270952074 Cost: 800.0
Score: 1198.1197906428113 Cost: 1200.0
Score: 1597.4930541904148 Cost: 1600.0
Score: 1996.8663177380186 Cost: 2000.0
Predicted --  Score: 1971.421 Cost: 1973.673 Rating: 0.446
197th sweep.suggest() took 1.3495s, score_loss: -1.9137, cost_loss: -2.0063
score_lengthscale: (0.2555449604988098, 9.292190551757812), cost_lengthscale: (4.275691986083984, 8.656906127929688)
Score: 399.9670546182794 Cost: 400.0
Score: 799.9341092365588 Cost: 800.0
Score: 1199.9011638548382 Cost: 1200.0
Score: 1599.8682184731176 Cost: 1600.0
Score: 1999.835273091397 Cost: 2000.0
Predicted --  Score: 1946.673 Cost: 1854.647 Rating: 0.413
198th sweep.suggest() took 1.3514s, score_loss: -1.9151, cost_loss: -2.0067
score_lengthscale: (0.25784075260162354, 9.327220916748047), cost_lengthscale: (4.261244773864746, 8.691877365112305)
Score: 399.9138531460248 Cost: 400.0
Score: 799.8277062920496 Cost: 800.0
Score: 1199.7415594380743 Cost: 1200.0
Score: 1599.6554125840992 Cost: 1600.0
Score: 1999.5692657301238 Cost: 2000.0
Resetting GP optimizers at suggestion 200
Predicted --  Score: -114.115 Cost: 0.565 Rating: 0.057
199th sweep.suggest() took 1.3616s, score_loss: -1.9141, cost_loss: -2.0066
score_lengthscale: (0.2558309733867645, 9.36167049407959), cost_lengthscale: (4.284342288970947, 8.727143287658691)
Score: 0.0031129867384367457 Cost: 0.11999999999999955
Score: 0.006225973476873491 Cost: 0.2399999999999991
Score: 0.009338960215310237 Cost: 0.35999999999999865
Score: 0.012451946953746983 Cost: 0.4799999999999982
Score: 0.015564933692183728 Cost: 0.5999999999999978
```

## Sweeping breakout

Constellation output with 60 iters:

<img width="1920" height="1134" alt="image" src="https://github.com/user-attachments/assets/49d2af3b-1392-46fe-933c-b687fe5e2033" />

Seems to play ok with the top score hyperparams:

<img width="582" height="407" alt="image" src="https://github.com/user-attachments/assets/626ede11-0744-4f7d-81c8-1a909cdf5804" />
