### PR TITLE
Conditionally apply AVX2/FMA flags by architecture (fix Apple Silicon build)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -142,8 +142,14 @@ OUTPUT_NAME=${OUTPUT_NAME:-$ENV}
 
 # Standalone environment build
 # -mavx2 enables AVX2 intrinsics (__m256, _mm256_*) which drive.h and
-# src/bf16.h use directly. x86_64 only — strip if porting to ARM/Apple Silicon.
-SIMD_FLAGS=(-mavx2 -mfma)
+# src/bf16.h use directly. x86_64 only; skip on ARM (Apple Silicon).
+ARCH_NAME="$(uname -m)"
+if [ "$ARCH_NAME" = "x86_64" ]; then
+    SIMD_FLAGS=(-mavx2 -mfma)
+else
+    SIMD_FLAGS=()
+fi
+
 if [ -n "$DEBUG" ] || [ "$MODE" = "local" ]; then
     CLANG_OPT=(-g -O0 "${CLANG_WARN[@]}" "${SANITIZE_FLAGS[@]}" "${SIMD_FLAGS[@]}")
     NVCC_OPT="-O0 -g"


### PR DESCRIPTION
### Problem
The `--mavx2/-mfma` flags are hardcoded in `SIMD_FLAGS`, which fails on arm64 (`error: unsupported option '-mavx2' for target 'arm64-apple-darwin'`). 

### Solution
We condition the flags on the architecture so x86_64 keeps AVX2/FMA unchanged, and ARM builds skip them. 

### Verified
Tested using 

```bash
bash build.sh breakout --local
```
or `--cpu`

rendering via 
```
./breakout   
```
works.