### PR TITLE
Synchronize BF16 weight loads

### DIFF
--- a/src/bindings.cu
+++ b/src/bindings.cu
@@ -10,6 +10,12 @@
 
 namespace py = pybind11;
 
+static void throw_if_cuda_error(cudaError_t err, const char* context) {
+    if (err != cudaSuccess) {
+        throw std::runtime_error(std::string(context) + ": " + cudaGetErrorString(err));
+    }
+}
+
 // Wrapper functions for Python bindings
 pybind11::dict puf_log(pybind11::object pufferl_obj) {
     auto& pufferl = pufferl_obj.cast<PuffeRL&>();
@@ -209,11 +215,16 @@ void load_weights(pybind11::object pufferl_obj, const std::string& path) {
         throw std::runtime_error("Failed to read weight file");
     }
     fclose(f);
-    cudaMemcpy(pufferl.master_weights.data, buf.data(), nbytes, cudaMemcpyHostToDevice);
+    throw_if_cuda_error(
+        cudaMemcpy(pufferl.master_weights.data, buf.data(), nbytes, cudaMemcpyHostToDevice),
+        "Failed to copy weights to device");
     if (USE_BF16) {
         int n = numel(pufferl.param_puf.shape);
         cast<<<grid_size(n), BLOCK_SIZE, 0, pufferl.default_stream>>>(
             pufferl.param_puf.data, pufferl.master_weights.data, n);
+        throw_if_cuda_error(cudaGetLastError(), "Failed to launch BF16 weight cast");
+        throw_if_cuda_error(cudaStreamSynchronize(pufferl.default_stream),
+            "Failed to synchronize BF16 weight load");
     }
 }
 

--- a/tests/test_cuda_load_weights.py
+++ b/tests/test_cuda_load_weights.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_bf16_load_weights_syncs_cast_before_return():
+    source = Path('src/bindings.cu').read_text()
+    body = source.split('void load_weights', 1)[1].split('\n}\n\nint py_add_frozen_bank', 1)[0]
+
+    cast_idx = body.index('cast<<<grid_size(n), BLOCK_SIZE, 0, pufferl.default_stream>>>')
+    launch_check_idx = body.index('cudaGetLastError()')
+    sync_idx = body.index('cudaStreamSynchronize(pufferl.default_stream)')
+
+    assert cast_idx < launch_check_idx < sync_idx
+    assert 'throw_if_cuda_error' in body


### PR DESCRIPTION
## Summary
- Check CUDA errors while loading primary weights.
- Synchronize the BF16 cast on `pufferl.default_stream` before `load_weights` returns.
- Add a regression that guards cast launch checking and stream synchronization ordering.

## Root cause
BF16 `load_weights` copied fp32 master weights, launched the fp32-to-BF16 cast on `default_stream`, and then returned without ordering that stream against subsequent inference streams. A first rollout could consume stale `param_puf` data.

## Validation
- `python -m pytest tests/test_cuda_load_weights.py tests/test_import_performance.py -q`

GPU runtime validation still needs CUDA hardware; the local environment used for this patch does not include `nvcc`.

cc @Infatoshi for the original BF16 checkpoint repro.

Fixes #534
