### PR TITLE
Drop unsupported eval GIF flags

### DIFF
--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -596,16 +596,11 @@ def load_config(env_name):
         help='num_layers of the enemy checkpoint (defaults to primary)')
     parser.add_argument('--load-id', type=str,
         default=None, help='Kickstart/eval from from a finished Wandbrun')
-    parser.add_argument('--render-mode', type=str, default='auto',
-        choices=['auto', 'human', 'ansi', 'rgb_array', 'raylib', 'None'])
     parser.add_argument('--wandb', action='store_true', help='Use wandb for logging')
     parser.add_argument('--wandb-project', type=str, default='puffer4')
     parser.add_argument('--wandb-group', type=str, default='debug')
     parser.add_argument('--tag', type=str, default=None, help='Tag for experiment')
     parser.add_argument('--slowly', action='store_true', help='Use PyTorch training backend')
-    parser.add_argument('--save-frames', type=int, default=0)
-    parser.add_argument('--gif-path', type=str, default='eval.gif')
-    parser.add_argument('--fps', type=float, default=15)
     parser.description = f':blowfish: PufferLib [bright_cyan]{pufferlib.__version__}[/]' \
         ' demo options. Shows valid args for your env and policy'
 

--- a/tests/test_pufferl_cli_flags.py
+++ b/tests/test_pufferl_cli_flags.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_eval_gif_flags_are_not_registered_without_capture_support():
+    source = Path('pufferlib/pufferl.py').read_text()
+
+    assert '--render-mode' not in source
+    assert '--save-frames' not in source
+    assert '--gif-path' not in source
+    assert '--fps' not in source


### PR DESCRIPTION
## Summary
- Remove eval rendering/GIF CLI flags that are not connected to v4 eval behavior.
- Add a regression that prevents re-registering those flags without frame-capture support.

## Root cause
The old GIF implementation depended on Python env drivers returning ANSI or RGB frames. The v4 eval path uses the native backend render loop and no longer exposes frames through these options, so the flags silently advertised unsupported behavior.

## Validation
- `python -m pytest tests/test_pufferl_cli_flags.py tests/test_import_performance.py -q`

Fixes #541
