### PR TITLE
Port Protein to CUDA C

### DIFF
--- a/pufferlib/gp_torch.py
+++ b/pufferlib/gp_torch.py
@@ -1,0 +1,140 @@
+"""
+Drop-in replacement for GPyTorch exact GP training, CUDA implementation only.
+"""
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from pufferlib import _C
+
+class _MLLFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, params, backend):
+        ctx.backend = backend
+        return params.new_tensor(backend.log_marginal_likelihood)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        grads = torch.tensor(ctx.backend.mll_grad(),
+                             dtype=grad_output.dtype, device=grad_output.device)
+        return grad_output * grads, None
+
+
+def _np32(x):
+    if isinstance(x, torch.Tensor):
+        x = x.detach().cpu().numpy()
+    return np.ascontiguousarray(x, dtype=np.float32)
+
+
+class GaussianProcess(nn.Module):
+    def __init__(self, dim, capacity,
+                 lengthscale=1.0, outputscale=1.0, noise=1e-2, offset=1.0,
+                 use_cuda=True):
+        super().__init__()
+        self._backend = _C.GaussianProcess(dim=dim, capacity=capacity,
+                                lengthscale=lengthscale, outputscale=outputscale,
+                                noise=noise, offset=offset)
+        self.raw_lengthscale = nn.Parameter(
+            torch.tensor(np.asarray(self._backend.raw_lengthscale), dtype=torch.float64))
+        self.raw_outputscale = nn.Parameter(
+            torch.tensor(self._backend.raw_outputscale, dtype=torch.float64))
+        self.raw_noise = nn.Parameter(
+            torch.tensor(self._backend.raw_noise, dtype=torch.float64))
+        self.raw_offset = nn.Parameter(
+            torch.tensor(self._backend.raw_offset, dtype=torch.float64))
+
+    @property
+    def lengthscale(self):
+        return np.asarray(self._backend.lengthscale)
+
+    @property
+    def outputscale(self): return self._backend.outputscale
+
+    @property
+    def noise(self): return self._backend.noise
+
+    @property
+    def offset(self): return self._backend.offset
+
+    @property
+    def log_marginal_likelihood(self): return self._backend.log_marginal_likelihood
+
+    @property
+    def lengthscale_range(self):
+        ells = self.lengthscale
+        return float(np.min(ells)), float(np.max(ells))
+
+    @property
+    def n(self):        return self._backend.n
+
+    @property
+    def dim(self):      return self._backend.dim
+
+    @property
+    def capacity(self): return self._backend.capacity
+
+    def fit(self, X, y):
+        self._sync()
+        self._backend.fit(_np32(X), _np32(y))
+
+    def recompute(self):
+        self._sync()
+        self._backend.recompute()
+
+    def mll(self, recompute=True):
+        self._sync()
+        if recompute:
+            self._backend.recompute()
+        params = torch.cat([self.raw_lengthscale,
+                            self.raw_outputscale.unsqueeze(0),
+                            self.raw_noise.unsqueeze(0),
+                            self.raw_offset.unsqueeze(0)])
+        return _MLLFunction.apply(params, self._backend)
+
+    def predict(self, Xs):
+        self._sync()
+        means, vars_ = self._backend.predict(_np32(Xs))
+        return torch.from_numpy(means), torch.from_numpy(vars_)
+
+    def eval(self):
+        result = super().eval()
+        if hasattr(self, '_backend'):
+            self._sync()
+            self._backend.recompute()
+        return result
+
+    def save(self, path):
+        self._sync()
+        self._backend.save(path)
+
+    @classmethod
+    def load(cls, path, extra_cap=0, use_cuda=True):
+        obj = cls.__new__(cls)
+        nn.Module.__init__(obj)
+        obj._backend = _C.GaussianProcess.load(path, extra_cap)
+        obj.raw_lengthscale = nn.Parameter(
+            torch.tensor(np.asarray(obj._backend.raw_lengthscale), dtype=torch.float64))
+        obj.raw_outputscale = nn.Parameter(
+            torch.tensor(obj._backend.raw_outputscale, dtype=torch.float64))
+        obj.raw_noise = nn.Parameter(
+            torch.tensor(obj._backend.raw_noise, dtype=torch.float64))
+        obj.raw_offset = nn.Parameter(
+            torch.tensor(obj._backend.raw_offset, dtype=torch.float64))
+        return obj
+
+    def __repr__(self):
+        ells = self.lengthscale
+        if len(ells) == 1:
+            ell_s = f"{ells[0]:.3g}"
+        else:
+            ell_s = f"[{np.min(ells):.3g}..{np.max(ells):.3g}]"
+        return (f"<GaussianProcess dim={self.dim} n={self.n} cap={self.capacity} "
+                f"ell={ell_s} sf={self.outputscale:.3g} "
+                f"noise={self.noise:.3g}>")
+
+    def _sync(self):
+        self._backend.raw_lengthscale = self.raw_lengthscale.detach().cpu().numpy().astype(np.float32)
+        self._backend.raw_outputscale = float(self.raw_outputscale.item())
+        self._backend.raw_noise       = float(self.raw_noise.item())
+        self._backend.raw_offset      = float(self.raw_offset.item())

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -413,13 +413,20 @@ def sweep(env_name, args=None, pareto=False):
 
     sweep_config = args['sweep']
     method = sweep_config.pop('method')
-    import pufferlib.sweep
-    try:
-        sweep_cls = getattr(pufferlib.sweep, method)
-    except:
-        raise ValueError(f'Invalid sweep method {method}. See pufferlib.sweep')
-
-    sweep_obj = sweep_cls(sweep_config)
+    sweep_obj = None
+    if method == 'Protein':
+        try:
+            from pufferlib._C import Protein as _CProtein
+            sweep_obj = _CProtein(sweep_config)
+        except Exception:
+            pass
+    if sweep_obj is None:
+        import pufferlib.sweep
+        try:
+            sweep_cls = getattr(pufferlib.sweep, method)
+        except:
+            raise ValueError(f'Invalid sweep method {method}. See pufferlib.sweep')
+        sweep_obj = sweep_cls(sweep_config)
     num_experiments = args['sweep']['max_runs']
     ts_default = args['train']['total_timesteps']
     ts_config = sweep_config.get('train', {}).get('total_timesteps', {'min': ts_default, 'max': ts_default})

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -146,7 +146,8 @@ def _params_from_puffer_sweep(sweep_config, only_include=None):
 
     for name, param in sweep_config.items():
         if name in ('method', 'metric', 'metric_distribution', 'goal', 'downsample', 'use_gpu', 'prune_pareto',
-                    'sweep_only', 'max_suggestion_cost', 'early_stop_quantile', 'gpus', 'max_runs'):
+                    'sweep_only', 'max_suggestion_cost', 'early_stop_quantile', 'gpus', 'max_runs',
+                    'match_enemy_model_path', 'match_num_games', 'match_enemy_hidden_size', 'match_enemy_num_layers'):
             continue
 
         assert isinstance(param, dict), f'Param {name} is not a dict'

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -9,17 +9,12 @@ import numpy as np
 import pufferlib
 
 import torch
-import gpytorch
-from gpytorch.models import ExactGP
-from gpytorch.likelihoods import GaussianLikelihood
-from gpytorch.kernels import MaternKernel, PolynomialKernel, ScaleKernel, AdditiveKernel
-from gpytorch.means import ConstantMean
-from gpytorch.mlls import ExactMarginalLogLikelihood
-from gpytorch.priors import LogNormalPrior
 from scipy.optimize import minimize
 from scipy.stats.qmc import Sobol
 from scipy.spatial import KDTree
 from sklearn.linear_model import LogisticRegression
+
+from pufferlib.gp_torch import GaussianProcess
 
 EPSILON = 1e-6
 
@@ -397,53 +392,41 @@ class ParetoGenetic:
         return False
 
 
-class ExactGPModel(ExactGP):
-    def __init__(self, train_x, train_y, likelihood, x_dim):
-        super(ExactGPModel, self).__init__(train_x, train_y, likelihood)
-        self.mean_module = ConstantMean()
-        # Matern 3/2 kernel (equivalent to Pyro's Matern32)
-        matern_kernel = MaternKernel(nu=1.5, ard_num_dims=x_dim)
+_NOISE_PRIOR_MU    = math.log(1e-2)  # LogNormal prior on noise, from HEBO
+_NOISE_PRIOR_SIGMA = 0.5
 
-        # NOTE: setting this constraint changes GP behavior, including the lengthscale
-        # even though the lengthscale is well within the range ... Commenting out for now.
-        # lengthscale_constraint = gpytorch.constraints.Interval(0.01, 10.0)
-        # matern_kernel = MaternKernel(nu=1.5, ard_num_dims=x_dim, lengthscale_constraint=lengthscale_constraint)
+def _noise_log_prior(raw_noise_param):
+    # LogNormal(mu, sigma) prior in constrained space, with softplus change-of-variables.
+    # log p(raw) = log p_lognormal(softplus(raw) + lb) + log softplus_grad(raw)
+    noise      = torch.nn.functional.softplus(raw_noise_param) + 1e-4
+    log_noise  = torch.log(noise)
+    log_p      = -0.5 * ((log_noise - _NOISE_PRIOR_MU) / _NOISE_PRIOR_SIGMA) ** 2 \
+                 - log_noise - math.log(_NOISE_PRIOR_SIGMA)
+    log_jac    = -torch.log1p(torch.exp(-raw_noise_param))  # log sigmoid = log softplus_grad
+    return log_p + log_jac
 
-        linear_kernel = PolynomialKernel(power=1)
-        self.covar_module = ScaleKernel(AdditiveKernel(linear_kernel, matern_kernel))
 
-    def forward(self, x):
-        mean_x = self.mean_module(x)
-        covar_x = self.covar_module(x)
-        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
+def _fit_gp(gp_model, optimizer, train_x, train_y, training_iter=50):
+    if isinstance(train_x, torch.Tensor):
+        train_x = train_x.cpu().numpy()
+    if isinstance(train_y, torch.Tensor):
+        train_y = train_y.cpu().numpy()
 
-    @property
-    def lengthscale_range(self):
-        # Get lengthscale from MaternKernel
-        lengthscale = self.covar_module.base_kernel.kernels[1].lengthscale.tolist()[0]
-        return min(lengthscale), max(lengthscale)
-
-def train_gp_model(model, likelihood, mll, optimizer, train_x, train_y, training_iter=50):
-    model.train()
-    likelihood.train()
-    model.set_train_data(inputs=train_x, targets=train_y, strict=False)
+    gp_model.train()
+    gp_model.fit(train_x, train_y)
 
     loss = None
     for _ in range(training_iter):
         try:
             optimizer.zero_grad()
-            output = model(train_x)
-            loss = -mll(output, train_y)
+            loss = -gp_model.mll() - _noise_log_prior(gp_model.raw_noise)
             loss.backward()
             optimizer.step()
             loss = loss.detach()
-
-        except gpytorch.utils.errors.NotPSDError:
-            # It's rare but it does happen. Hope it's a transient issue.
+        except Exception:
             break
 
-    model.eval()
-    likelihood.eval()
+    gp_model.eval()
     return loss.item() if loss is not None else 0
 
 
@@ -593,36 +576,24 @@ class Protein:
         self.stop_threshold_model = RobustLogCostModel(quantile=sweep_config['early_stop_quantile'])
         self.upper_cost_threshold = -np.inf
 
-        # Use 64 bit for GP regression
-        with default_tensor_dtype(torch.float64):
-            # Params taken from HEBO: https://arxiv.org/abs/2012.03826
-            noise_prior = LogNormalPrior(math.log(1e-2), 0.5)
+        # Score GP
+        self.gp_score = GaussianProcess(dim=self.hyperparameters.num, capacity=self.gp_max_obs, use_cuda=_use_gpu)
+        self.score_opt = torch.optim.Adam(self.gp_score.parameters(), lr=self.gp_learning_rate, amsgrad=True)
 
-            # Create dummy data for model initialization on the selected device
-            dummy_x = torch.ones((1, self.hyperparameters.num), device=self.device)
-            dummy_y = torch.zeros(1, device=self.device)
-            # Score GP
-            self.likelihood_score = GaussianLikelihood(noise_prior=deepcopy(noise_prior)).to(self.device)
-            self.gp_score = ExactGPModel(dummy_x, dummy_y, self.likelihood_score, self.hyperparameters.num).to(self.device)
-            self.mll_score = ExactMarginalLogLikelihood(self.likelihood_score, self.gp_score).to(self.device)
-            self.score_opt = torch.optim.Adam(self.gp_score.parameters(), lr=self.gp_learning_rate, amsgrad=True)
+        # Cost GP
+        self.gp_cost = GaussianProcess(dim=self.hyperparameters.num, capacity=self.gp_max_obs, use_cuda=_use_gpu)
+        self.cost_opt = torch.optim.Adam(self.gp_cost.parameters(), lr=self.gp_learning_rate, amsgrad=True)
 
-            # Cost GP
-            self.likelihood_cost = GaussianLikelihood(noise_prior=deepcopy(noise_prior)).to(self.device)
-            self.gp_cost = ExactGPModel(dummy_x, dummy_y, self.likelihood_cost, self.hyperparameters.num).to(self.device)
-            self.mll_cost = ExactMarginalLogLikelihood(self.likelihood_cost, self.gp_cost).to(self.device)
-            self.cost_opt = torch.optim.Adam(self.gp_cost.parameters(), lr=self.gp_learning_rate, amsgrad=True)
-
-            # Buffers for GP training and inference
-            self.gp_params_buffer = torch.empty(self.gp_max_obs, self.hyperparameters.num, device=self.device)
-            self.gp_score_buffer = torch.empty(self.gp_max_obs, device=self.device)
-            self.gp_cost_buffer = torch.empty(self.gp_max_obs, device=self.device)
-            self.infer_batch_buffer = torch.empty(self.infer_batch_size, self.hyperparameters.num, device=self.device)
+        # Buffers for GP training and inference
+        self.gp_params_buffer = torch.empty(self.gp_max_obs, self.hyperparameters.num, dtype=torch.float64, device=self.device)
+        self.gp_score_buffer = torch.empty(self.gp_max_obs, dtype=torch.float64, device=self.device)
+        self.gp_cost_buffer = torch.empty(self.gp_max_obs, dtype=torch.float64, device=self.device)
+        self.infer_batch_buffer = torch.empty(self.infer_batch_size, self.hyperparameters.num, dtype=torch.float64, device=self.device)
 
     def to(self, device):
         self.device = torch.device(device)
-        for attr in ('gp_score', 'gp_cost', 'likelihood_score', 'likelihood_cost',
-                     'mll_score', 'mll_cost', 'gp_params_buffer', 'gp_score_buffer',
+        for attr in ('gp_score', 'gp_cost',
+                     'gp_params_buffer', 'gp_score_buffer',
                      'gp_cost_buffer', 'infer_batch_buffer'):
             setattr(self, attr, getattr(self, attr).to(self.device))
         for opt in (self.score_opt, self.cost_opt):
@@ -714,10 +685,8 @@ class Protein:
         log_c_norm_tensor = self.gp_cost_buffer[:num_sampled]
         log_c_norm_tensor.copy_(torch.from_numpy(log_c_norm))
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", gpytorch.utils.warnings.NumericalWarning)
-            score_loss = train_gp_model(self.gp_score, self.likelihood_score, self.mll_score, self.score_opt, params_tensor, y_norm_tensor, training_iter=self.gp_training_iter)
-            cost_loss = train_gp_model(self.gp_cost, self.likelihood_cost, self.mll_cost, self.cost_opt, params_tensor, log_c_norm_tensor, training_iter=self.gp_training_iter)
+        score_loss = _fit_gp(self.gp_score, self.score_opt, params_tensor, y_norm_tensor, training_iter=self.gp_training_iter)
+        cost_loss  = _fit_gp(self.gp_cost, self.cost_opt, params_tensor, log_c_norm_tensor, training_iter=self.gp_training_iter)
 
         return score_loss, cost_loss
 
@@ -819,30 +788,25 @@ class Protein:
         # Batch predictions to avoid GPU OOM for large number of suggestions
         gp_y_norm_list, gp_log_c_norm_list = [], []
 
-        with torch.no_grad(), gpytorch.settings.fast_pred_var(), warnings.catch_warnings():
-            warnings.simplefilter("ignore", gpytorch.utils.warnings.NumericalWarning)
-
-            # Create a reusable buffer on the device to avoid allocating a huge tensor
+        with torch.no_grad():
             for i in range(0, len(suggestions), self.infer_batch_size):
                 batch_numpy = suggestions[i:i+self.infer_batch_size]
                 current_batch_size = len(batch_numpy)
 
-                # Use a slice of the buffer if the current batch is smaller
                 batch_tensor = self.infer_batch_buffer[:current_batch_size]
                 batch_tensor.copy_(torch.from_numpy(batch_numpy))
 
                 try:
                     # Score and cost prediction
-                    pred_y_mean = self.likelihood_score(self.gp_score(batch_tensor)).mean.cpu()
-                    pred_c_mean = self.likelihood_cost(self.gp_cost(batch_tensor)).mean.cpu()
-
+                    pred_y_mean, _ = self.gp_score.predict(batch_tensor)
+                    pred_c_mean, _ = self.gp_cost.predict(batch_tensor)
                 except RuntimeError:
                     # Handle numerical errors during GP prediction
-                    pred_y_mean, pred_c_mean = torch.zeros(current_batch_size)
+                    pred_y_mean = torch.zeros(current_batch_size, dtype=torch.float64)
+                    pred_c_mean = torch.zeros(current_batch_size, dtype=torch.float64)
 
-                gp_y_norm_list.append(pred_y_mean.cpu())
-                gp_log_c_norm_list.append(pred_c_mean.cpu())
-
+                gp_y_norm_list.append(pred_y_mean)
+                gp_log_c_norm_list.append(pred_c_mean)
                 del pred_y_mean, pred_c_mean
 
         # Concatenate results from all batches

--- a/pufferlib/sweep.py
+++ b/pufferlib/sweep.py
@@ -590,6 +590,22 @@ class Protein:
         self.gp_cost_buffer = torch.empty(self.gp_max_obs, dtype=torch.float64, device=self.device)
         self.infer_batch_buffer = torch.empty(self.infer_batch_size, self.hyperparameters.num, dtype=torch.float64, device=self.device)
 
+    _CUDA_ATTRS = ('gp_score', 'gp_cost', 'score_opt', 'cost_opt',
+                    'gp_params_buffer', 'gp_score_buffer',
+                    'gp_cost_buffer', 'infer_batch_buffer')
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        for attr in self._CUDA_ATTRS:
+            state.pop(attr, None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        for attr in self._CUDA_ATTRS:
+            if attr not in self.__dict__:
+                self.__dict__[attr] = None
+
     def to(self, device):
         self.device = torch.device(device)
         for attr in ('gp_score', 'gp_cost',

--- a/src/bindings.cu
+++ b/src/bindings.cu
@@ -4,6 +4,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 #include "pufferlib.cu"
+#include "gp_cuda.cu"
 
 #define _PUFFER_STRINGIFY(x) #x
 #define PUFFER_STRINGIFY(x) _PUFFER_STRINGIFY(x)
@@ -465,6 +466,157 @@ std::unique_ptr<PuffeRL> create_pufferl(py::dict args) {
     return pufferl;
 }
 
+// ---------------------------------------------------------------------------
+// CUDA GP wrapper
+// ---------------------------------------------------------------------------
+
+using gp_arr = py::array_t<float, py::array::c_style | py::array::forcecast>;
+
+class PyGP {
+    GaussianProcess *gp_;
+
+    void check() const {
+        if (!gp_) throw std::runtime_error("GaussianProcess object is invalid");
+    }
+
+    static int check_X(py::buffer_info &buf, int dim) {
+        if (buf.ndim == 1) {
+            if (dim != 1) throw std::invalid_argument("1-D X requires dim=1");
+            return (int)buf.shape[0];
+        }
+        if (buf.ndim == 2) {
+            if ((int)buf.shape[1] != dim)
+                throw std::invalid_argument(
+                    "X has " + std::to_string(buf.shape[1]) +
+                    " cols, expected " + std::to_string(dim));
+            return (int)buf.shape[0];
+        }
+        throw std::invalid_argument("X must be 1-D or 2-D");
+    }
+
+public:
+    PyGP(int dim, int capacity,
+           float lengthscale, float outputscale, float noise, float offset)
+        : gp_(gp_create(dim, capacity,
+                          gp_kernel_matern32_linear(dim, lengthscale, outputscale, offset),
+                          noise))
+    {
+        if (!gp_) throw std::runtime_error("gp_create failed");
+    }
+    explicit PyGP(GaussianProcess *raw) : gp_(raw) {}
+    ~PyGP() { if (gp_) gp_destroy(gp_); }
+    PyGP(const PyGP &)            = delete;
+    PyGP &operator=(const PyGP &) = delete;
+    PyGP(PyGP &&o) noexcept : gp_(o.gp_) { o.gp_ = nullptr; }
+    PyGP &operator=(PyGP &&o) noexcept {
+        if (gp_) gp_destroy(gp_); gp_ = o.gp_; o.gp_ = nullptr; return *this;
+    }
+
+    void fit(gp_arr X, gp_arr y) {
+        check();
+        auto xbuf = X.request(), ybuf = y.request();
+        int n = check_X(xbuf, gp_->dim);
+        if ((int)ybuf.shape[0] != n) throw std::invalid_argument("X and y length mismatch");
+        int rc = gp_fit(gp_, (const float *)xbuf.ptr, (const float *)ybuf.ptr, n, 0);
+        if (rc == -1) throw std::runtime_error("n exceeds capacity");
+        if (rc == -2) throw std::runtime_error("Cholesky factorisation failed");
+    }
+    void recompute() { check(); gp_recompute(gp_, 0); }
+
+    py::tuple predict(gp_arr X, bool noise = false) {
+        check();
+        auto buf = X.request();
+        int m = check_X(buf, gp_->dim);
+        auto means = py::array_t<float>(m);
+        auto vars  = py::array_t<float>(m);
+        gp_predict(gp_, (const float *)buf.ptr,
+                     (float *)means.request().ptr,
+                     (float *)vars.request().ptr, m, 0);
+        if (noise) {
+            float sn = gp_get_noise(gp_);
+            float *vp = (float *)vars.request().ptr;
+            for (int i = 0; i < m; i++) vp[i] += sn;
+        }
+        return py::make_tuple(means, vars);
+    }
+
+    float log_marginal_likelihood() const { check(); return gp_marginal_log_likelihood(gp_); }
+
+    py::tuple mll_grad() const {
+        check();
+        int np = gp_->kernel->n_params, d = gp_->dim;
+        float d_raw_noise;
+        std::vector<float> kg((size_t)np);
+        gp_mll_grad(gp_, &d_raw_noise, kg.data(), 0);
+        py::list lst;
+        for (int i = 0; i < d; i++) lst.append(kg[i]);
+        lst.append(kg[np - 2]);
+        lst.append(d_raw_noise);
+        lst.append(kg[np - 1]);
+        return py::tuple(lst);
+    }
+
+    py::array_t<float> lengthscale() const {
+        check(); int d = gp_->dim;
+        py::array_t<float> res(d);
+        auto buf = res.mutable_unchecked<1>();
+        for (int i = 0; i < d; i++) buf(i) = gp_kernel_get_lengthscale(gp_->kernel, i);
+        return res;
+    }
+    float outputscale() const { check(); return gp_kernel_get_outputscale(gp_->kernel); }
+    float gp_noise()    const { check(); return gp_get_noise(gp_); }
+    float offset()      const { check(); return gp_kernel_get_offset(gp_->kernel); }
+
+    void set_lengthscale(gp_arr v) {
+        check(); auto buf = v.request();
+        if ((int)buf.shape[0] != gp_->dim)
+            throw std::invalid_argument("wrong lengthscale size: expected " + std::to_string(gp_->dim));
+        const float *p = (const float *)buf.ptr;
+        for (int i = 0; i < gp_->dim; i++) gp_kernel_set_lengthscale(gp_->kernel, i, p[i]);
+    }
+    void set_outputscale(float v) { check(); gp_kernel_set_outputscale(gp_->kernel, v); }
+    void set_gp_noise   (float v) { check(); gp_set_noise(gp_, v); }
+    void set_offset     (float v) { check(); gp_kernel_set_offset(gp_->kernel, v); }
+
+    py::array_t<float> raw_lengthscale() const {
+        check(); int d = gp_->dim;
+        py::array_t<float> res(d);
+        auto buf = res.mutable_unchecked<1>();
+        for (int i = 0; i < d; i++) buf(i) = gp_->kernel->raw_params[i];
+        return res;
+    }
+    float raw_outputscale() const { check(); return gp_->kernel->raw_params[gp_->kernel->n_params - 2]; }
+    float raw_noise()       const { check(); return gp_->raw_noise; }
+    float raw_offset()      const { check(); return gp_->kernel->raw_params[gp_->kernel->n_params - 1]; }
+
+    void set_raw_lengthscale(gp_arr v) {
+        check(); auto buf = v.request();
+        if ((int)buf.shape[0] != gp_->dim)
+            throw std::invalid_argument("wrong lengthscale size: expected " + std::to_string(gp_->dim));
+        const float *p = (const float *)buf.ptr;
+        for (int i = 0; i < gp_->dim; i++) gp_->kernel->raw_params[i] = p[i];
+    }
+    void set_raw_outputscale(float v) { check(); gp_->kernel->raw_params[gp_->kernel->n_params - 2] = v; }
+    void set_raw_noise      (float v) { check(); gp_->raw_noise = v; }
+    void set_raw_offset     (float v) { check(); gp_->kernel->raw_params[gp_->kernel->n_params - 1] = v; }
+
+    int   n()               const { check(); return gp_->n; }
+    int   dim()             const { check(); return gp_->dim; }
+    int   capacity()        const { check(); return gp_->cap; }
+    float dedup_threshold() const { check(); return gp_->dedup_threshold; }
+    void set_dedup_threshold(float v) { check(); gp_->dedup_threshold = v; }
+
+    void save(const std::string &path) const {
+        check();
+        if (gp_save(gp_, path.c_str()) != 0) throw std::runtime_error("save failed: " + path);
+    }
+    static PyGP load(const std::string &path, int extra_cap = 0) {
+        GaussianProcess *raw = gp_load(path.c_str(), extra_cap);
+        if (!raw) throw std::runtime_error("load failed: " + path);
+        return PyGP(raw);
+    }
+};
+
 PYBIND11_MODULE(_C, m) {
     // Multi-GPU: generate NCCL unique ID (call on rank 0, pass bytes to all ranks)
     m.def("get_nccl_id", []() {
@@ -630,5 +782,92 @@ PYBIND11_MODULE(_C, m) {
         .def_readonly("last_log_time", &PuffeRL::last_log_time)
         .def("num_params", [](PuffeRL& self) -> int64_t {
             return numel(self.master_weights.shape);
+        });
+
+    // CUDA GP regression
+    py::class_<PyGP>(m, "GaussianProcess")
+        .def(py::init<int, int, float, float, float, float>(),
+             py::arg("dim"), py::arg("capacity"),
+             py::arg("lengthscale") = 1.0,
+             py::arg("outputscale") = 1.0,
+             py::arg("noise")       = 1e-2,
+             py::arg("offset")      = 1.0)
+        .def("fit",       &PyGP::fit,       py::arg("X"), py::arg("y"))
+        .def("recompute", &PyGP::recompute)
+        .def("predict",   &PyGP::predict,   py::arg("X"), py::arg("noise") = false)
+        .def("mll_grad",  &PyGP::mll_grad)
+        .def_property("lengthscale", &PyGP::lengthscale, &PyGP::set_lengthscale)
+        .def_property("outputscale", &PyGP::outputscale, &PyGP::set_outputscale)
+        .def_property("noise",       &PyGP::gp_noise,    &PyGP::set_gp_noise)
+        .def_property("offset",      &PyGP::offset,      &PyGP::set_offset)
+        .def_property("raw_lengthscale",  &PyGP::raw_lengthscale, &PyGP::set_raw_lengthscale)
+        .def_property("raw_outputscale",  &PyGP::raw_outputscale, &PyGP::set_raw_outputscale)
+        .def_property("raw_noise",        &PyGP::raw_noise,       &PyGP::set_raw_noise)
+        .def_property("raw_offset",       &PyGP::raw_offset,      &PyGP::set_raw_offset)
+        .def_property_readonly("log_marginal_likelihood", &PyGP::log_marginal_likelihood)
+        .def_property_readonly("n",        &PyGP::n)
+        .def_property_readonly("dim",      &PyGP::dim)
+        .def_property_readonly("capacity", &PyGP::capacity)
+        .def_property("dedup_threshold",   &PyGP::dedup_threshold, &PyGP::set_dedup_threshold)
+        .def("save",        &PyGP::save, py::arg("path"))
+        .def_static("load", &PyGP::load, py::arg("path"), py::arg("extra_cap") = 0)
+        .def(py::pickle(
+            [](const PyGP &g) {
+                py::dict state;
+                state["dim"] = g.dim();
+                state["capacity"] = g.capacity();
+                state["dedup_threshold"] = g.dedup_threshold();
+                state["raw_noise"] = g.raw_noise();
+                state["raw_lengthscale"] = g.raw_lengthscale();
+                state["raw_outputscale"] = g.raw_outputscale();
+                state["raw_offset"] = g.raw_offset();
+                if (g.n() > 0) {
+                    char tmppath[] = "/tmp/pufferlib_gp_XXXXXX";
+                    int fd = mkstemp(tmppath);
+                    if (fd < 0) throw std::runtime_error("pickle: mkstemp failed");
+                    close(fd);
+                    try { g.save(std::string(tmppath)); }
+                    catch (...) { remove(tmppath); throw; }
+                    FILE *fp = fopen(tmppath, "rb");
+                    if (!fp) { remove(tmppath); throw std::runtime_error("pickle: fopen failed"); }
+                    fseek(fp, 0, SEEK_END); long sz = ftell(fp); fseek(fp, 0, SEEK_SET);
+                    std::string buf((size_t)sz, '\0');
+                    fread(&buf[0], 1, (size_t)sz, fp); fclose(fp); remove(tmppath);
+                    state["data"] = py::bytes(buf.data(), (size_t)sz);
+                }
+                return state;
+            },
+            [](py::dict state) {
+                int dim = state["dim"].cast<int>();
+                int cap = state["capacity"].cast<int>();
+                float dedup = state["dedup_threshold"].cast<float>();
+                if (state.contains("data")) {
+                    py::bytes blob = state["data"].cast<py::bytes>();
+                    const char *ptr = PyBytes_AS_STRING(blob.ptr());
+                    Py_ssize_t len = PyBytes_GET_SIZE(blob.ptr());
+                    char tmppath[] = "/tmp/pufferlib_gp_XXXXXX";
+                    int fd = mkstemp(tmppath);
+                    if (fd < 0) throw std::runtime_error("unpickle: mkstemp failed");
+                    ssize_t written = write(fd, ptr, (size_t)len); close(fd);
+                    if (written != len) { remove(tmppath); throw std::runtime_error("unpickle: write failed"); }
+                    int n; memcpy(&n, ptr + 8, sizeof(int));
+                    int extra_cap = cap > n ? cap - n : 0;
+                    PyGP gp(nullptr);
+                    try { gp = PyGP::load(std::string(tmppath), extra_cap); }
+                    catch (...) { remove(tmppath); throw; }
+                    remove(tmppath); gp.set_dedup_threshold(dedup); return gp;
+                }
+                PyGP gp(dim, cap, 1.0f, 1.0f, 1e-2f, 1.0f);
+                gp.set_raw_noise(state["raw_noise"].cast<float>());
+                gp.set_raw_lengthscale(state["raw_lengthscale"].cast<gp_arr>());
+                gp.set_raw_outputscale(state["raw_outputscale"].cast<float>());
+                gp.set_raw_offset(state["raw_offset"].cast<float>());
+                gp.set_dedup_threshold(dedup); return gp;
+            }
+        ))
+        .def("__repr__", [](const PyGP &g) {
+            return "<GaussianProcess dim=" + std::to_string(g.dim()) +
+                   " n=" + std::to_string(g.n()) +
+                   " cap=" + std::to_string(g.capacity()) + ">";
         });
 }

--- a/src/bindings.cu
+++ b/src/bindings.cu
@@ -5,6 +5,7 @@
 #include <pybind11/numpy.h>
 #include "pufferlib.cu"
 #include "gp_cuda.cu"
+#include "protein.cu"
 
 #define _PUFFER_STRINGIFY(x) #x
 #define PUFFER_STRINGIFY(x) _PUFFER_STRINGIFY(x)
@@ -617,6 +618,304 @@ public:
     }
 };
 
+// ---------------------------------------------------------------------------
+// Protein sweep wrapper
+// ---------------------------------------------------------------------------
+
+static float resolve_scale(const std::string &dist, float min_v, float max_v,
+                           const py::object &scale_obj) {
+    if (py::isinstance<py::str>(scale_obj)) {
+        std::string s = scale_obj.cast<std::string>();
+        if (s == "time")
+            return 1.0f / (log2f(max_v) - log2f(min_v));
+        return 0.5f; // "auto"
+    }
+    return scale_obj.cast<float>();
+}
+
+struct FlatKey {
+    std::vector<std::string> path;
+};
+
+class PyProtein {
+    ProteinSweep *sw_;
+    std::vector<FlatKey> keys_;
+    std::vector<Space> spaces_;
+    int cost_idx_;
+
+    PyProtein() : sw_(nullptr), cost_idx_(-1) {}
+
+    void check() const {
+        if (!sw_ || !sw_->hypers)
+            throw std::runtime_error("Protein: suggest/observe unavailable (pickled stub)");
+    }
+
+    static py::object dict_get(py::dict d, const FlatKey &fk) {
+        py::object cur = d;
+        for (auto &seg : fk.path)
+            cur = cur.attr("__getitem__")(py::str(seg));
+        return cur;
+    }
+
+    static void dict_set(py::dict d, const FlatKey &fk, float val) {
+        py::object cur = d;
+        for (size_t i = 0; i + 1 < fk.path.size(); i++)
+            cur = cur.attr("__getitem__")(py::str(fk.path[i]));
+        cur.attr("__setitem__")(py::str(fk.path.back()), py::float_(val));
+    }
+
+    void build_spaces(py::dict param_dict, const std::set<std::string> &skip,
+                      const std::set<std::string> *only,
+                      std::vector<std::string> &prefix) {
+        for (auto item : param_dict) {
+            std::string name = item.first.cast<std::string>();
+            if (skip.count(name)) continue;
+            py::object val = item.second.cast<py::object>();
+            if (!py::isinstance<py::dict>(val)) continue;
+            py::dict pd = val.cast<py::dict>();
+
+            bool has_sub = false;
+            for (auto sub : pd)
+                if (py::isinstance<py::dict>(sub.second)) { has_sub = true; break; }
+            if (has_sub) {
+                prefix.push_back(name);
+                build_spaces(pd, skip, only, prefix);
+                prefix.pop_back();
+                continue;
+            }
+
+            if (only && !only->empty()) {
+                bool found = false;
+                for (auto &k : *only)
+                    if (name.find(k) != std::string::npos) { found = true; break; }
+                if (!found) continue;
+            }
+
+            std::string dist = pd["distribution"].cast<std::string>();
+            float mn = pd["min"].cast<float>();
+            float mx = pd["max"].cast<float>();
+            float sc = resolve_scale(dist, mn, mx, pd["scale"]);
+            int is_int = 0;
+
+            SpaceType st;
+            if (dist == "uniform") { st = SPACE_LINEAR; }
+            else if (dist == "int_uniform") { st = SPACE_LINEAR; is_int = 1; }
+            else if (dist == "uniform_pow2") { st = SPACE_POW2; is_int = 1; }
+            else if (dist == "log_normal") { st = SPACE_LOG; }
+            else if (dist == "logit_normal") { st = SPACE_LOGIT; }
+            else throw std::runtime_error("Unknown distribution: " + dist);
+
+            Space sp;
+            space_init(&sp, st, mn, mx, sc, is_int);
+            spaces_.push_back(sp);
+
+            FlatKey fk;
+            fk.path = prefix;
+            fk.path.push_back(name);
+            keys_.push_back(fk);
+        }
+    }
+
+public:
+    PyProtein(py::dict sweep_config) : sw_(nullptr), cost_idx_(-1) {
+        static const std::set<std::string> skip = {
+            "method", "metric", "metric_distribution", "goal",
+            "downsample", "use_gpu", "prune_pareto", "sweep_only",
+            "max_suggestion_cost", "early_stop_quantile", "gpus",
+            "max_runs", "match_enemy_model_path", "match_num_games",
+            "match_enemy_hidden_size", "match_enemy_num_layers"};
+
+        std::set<std::string> only_set;
+        const std::set<std::string> *only_ptr = nullptr;
+        if (sweep_config.contains("sweep_only")) {
+            std::string raw = sweep_config["sweep_only"].cast<std::string>();
+            std::istringstream ss(raw);
+            std::string tok;
+            while (std::getline(ss, tok, ',')) {
+                size_t a = tok.find_first_not_of(' ');
+                size_t b = tok.find_last_not_of(' ');
+                if (a != std::string::npos) only_set.insert(tok.substr(a, b - a + 1));
+            }
+            only_ptr = &only_set;
+        }
+
+        std::vector<std::string> prefix;
+        build_spaces(sweep_config, skip, only_ptr, prefix);
+
+        int dim = (int)spaces_.size();
+        if (dim == 0) throw std::runtime_error("No sweep parameters found");
+
+        std::string goal = sweep_config.contains("goal")
+            ? sweep_config["goal"].cast<std::string>() : "maximize";
+        int opt_dir = (goal == "maximize") ? 1 : -1;
+
+        std::string cost_param = "train/total_timesteps";
+        for (int i = 0; i < dim; i++) {
+            std::string flat;
+            for (size_t j = 0; j < keys_[i].path.size(); j++) {
+                if (j) flat += "/";
+                flat += keys_[i].path[j];
+            }
+            if (flat == cost_param) { cost_idx_ = i; break; }
+        }
+
+        Hyperparameters *hypers = hyperparameters_create(
+            spaces_.data(), dim, cost_idx_, opt_dir);
+
+        bool prune_p = sweep_config.contains("prune_pareto")
+            ? sweep_config["prune_pareto"].cast<bool>() : true;
+        float max_cost = sweep_config.contains("max_suggestion_cost")
+            ? sweep_config["max_suggestion_cost"].cast<float>() : 3600.0f;
+        float eq = sweep_config.contains("early_stop_quantile")
+            ? sweep_config["early_stop_quantile"].cast<float>() : 0.3f;
+        int downsample = sweep_config.contains("downsample")
+            ? sweep_config["downsample"].cast<int>() : 5;
+        int max_runs = sweep_config.contains("max_runs")
+            ? sweep_config["max_runs"].cast<int>() : 1200;
+        std::string mdist = sweep_config.contains("metric_distribution")
+            ? sweep_config["metric_distribution"].cast<std::string>() : "linear";
+        int use_logit = (mdist == "percentile") ? 1 : 0;
+
+        int success_cap = max_runs * downsample * 2;
+        if (success_cap < 8192) success_cap = 8192;
+
+        sw_ = protein_sweep_create(hypers,
+            10, 256, 50, 0.001f, 50, 750, 4096,
+            downsample == 1, prune_p, use_logit,
+            1.0f, max_cost, 0.1f, -0.8f, eq,
+            success_cap, 1024, 5, 73ULL);
+    }
+
+    ~PyProtein() { if (sw_) protein_sweep_destroy(sw_); }
+    PyProtein(const PyProtein &) = delete;
+    PyProtein &operator=(const PyProtein &) = delete;
+    PyProtein(PyProtein &&o) noexcept
+        : sw_(o.sw_), keys_(std::move(o.keys_)),
+          spaces_(std::move(o.spaces_)), cost_idx_(o.cost_idx_) { o.sw_ = nullptr; }
+
+    py::tuple suggest(py::dict fill, py::object fixed_total_timesteps) {
+        check();
+        int dim = sw_->hypers->num;
+        float fixed_cost_norm = NAN;
+        if (!fixed_total_timesteps.is_none() && cost_idx_ >= 0) {
+            float ts = fixed_total_timesteps.cast<float>();
+            fixed_cost_norm = space_normalize(&spaces_[(size_t)cost_idx_], ts);
+        }
+
+        std::vector<float> out((size_t)dim);
+        ProteinSweepInfo info = protein_sweep_suggest(sw_, out.data(), fixed_cost_norm);
+
+        for (int i = 0; i < dim; i++) {
+            float val = space_unnormalize(&spaces_[(size_t)i], out[(size_t)i]);
+            dict_set(fill, keys_[(size_t)i], val);
+        }
+
+        py::dict info_dict;
+        if (!info.is_random) {
+            info_dict["score"] = info.predicted_score;
+            info_dict["cost"] = info.predicted_cost;
+            info_dict["rating"] = info.rating;
+            info_dict["score_loss"] = info.score_loss;
+            info_dict["cost_loss"] = info.cost_loss;
+        }
+        return py::make_tuple(fill, info_dict);
+    }
+
+    void observe(py::dict hypers, float score, float cost, bool is_failure) {
+        check();
+        int dim = sw_->hypers->num;
+        std::vector<float> norm((size_t)dim);
+        for (int i = 0; i < dim; i++) {
+            float val = dict_get(hypers, keys_[(size_t)i]).cast<float>();
+            norm[(size_t)i] = space_normalize(&spaces_[(size_t)i], val);
+        }
+        protein_sweep_observe(sw_, norm.data(), score, cost, is_failure ? 1 : 0);
+    }
+
+    bool early_stop(py::dict logs, const std::string &target_key) {
+        if (!sw_) throw std::runtime_error("Protein object not initialised");
+        if (logs.contains("loss")) {
+            py::dict loss = logs["loss"].cast<py::dict>();
+            for (auto item : loss) {
+                float v = item.second.cast<float>();
+                if (std::isnan(v)) {
+                    logs["is_loss_nan"] = true;
+                    return true;
+                }
+            }
+        }
+        if (!logs.contains("uptime")) return false;
+        py::dict env;
+        if (logs.contains("env")) env = logs["env"].cast<py::dict>();
+        std::string full_key = target_key;
+        if (full_key.substr(0, 4) == "env/") full_key = full_key.substr(4);
+        if (!env.contains(full_key.c_str())) return false;
+
+        float metric_val = env[full_key.c_str()].cast<float>();
+        float cost_val = logs["uptime"].cast<float>();
+
+        protein_sweep_add_running(sw_, metric_val);
+        float running_mean = protein_sweep_running_mean(sw_);
+
+        float threshold = protein_sweep_get_threshold(sw_, cost_val);
+        logs["early_stop_threshold"] = std::max(threshold, -5.0f);
+
+        float check_score = std::max(running_mean, metric_val);
+        if (protein_sweep_should_stop(sw_, check_score, cost_val)) {
+            logs["is_loss_nan"] = false;
+            return true;
+        }
+        return false;
+    }
+
+    py::dict getstate() const {
+        check();
+        py::dict state;
+        state["cost_model_A"] = sw_->cost_model.A;
+        state["cost_model_B"] = sw_->cost_model.B;
+        state["cost_model_max_score"] = sw_->cost_model.max_score;
+        state["cost_model_upper"] = sw_->cost_model.upper_cost_threshold;
+        state["cost_model_quantile"] = sw_->cost_model.quantile;
+        state["cost_model_min_samples"] = sw_->cost_model.min_samples;
+        state["cost_model_fitted"] = sw_->cost_model.is_fitted;
+        state["upper_cost_threshold"] = sw_->upper_cost_threshold;
+        state["use_logit"] = sw_->use_logit;
+        py::list buf;
+        for (int i = 0; i < sw_->running_len; i++) {
+            int idx = (sw_->running_pos - sw_->running_len + i + PROTEIN_RUNNING_BUF_CAP)
+                % PROTEIN_RUNNING_BUF_CAP;
+            buf.append(sw_->running_buf[idx]);
+        }
+        state["running_buf"] = buf;
+        return state;
+    }
+
+    void setstate(py::dict state) {
+        if (sw_) { protein_sweep_destroy(sw_); sw_ = nullptr; }
+        sw_ = (ProteinSweep*)calloc(1, sizeof(ProteinSweep));
+        sw_->cost_model.A = state["cost_model_A"].cast<float>();
+        sw_->cost_model.B = state["cost_model_B"].cast<float>();
+        sw_->cost_model.max_score = state["cost_model_max_score"].cast<float>();
+        sw_->cost_model.upper_cost_threshold = state["cost_model_upper"].cast<float>();
+        sw_->cost_model.quantile = state["cost_model_quantile"].cast<float>();
+        sw_->cost_model.min_samples = state["cost_model_min_samples"].cast<int>();
+        sw_->cost_model.is_fitted = state["cost_model_fitted"].cast<int>();
+        sw_->upper_cost_threshold = state["upper_cost_threshold"].cast<float>();
+        sw_->use_logit = state["use_logit"].cast<int>();
+        py::list buf = state["running_buf"].cast<py::list>();
+        sw_->running_len = (int)buf.size();
+        sw_->running_pos = sw_->running_len % PROTEIN_RUNNING_BUF_CAP;
+        for (int i = 0; i < sw_->running_len; i++)
+            sw_->running_buf[i] = buf[i].cast<float>();
+    }
+
+    static PyProtein from_pickle(py::dict state) {
+        PyProtein p;
+        p.setstate(state);
+        return p;
+    }
+};
+
 PYBIND11_MODULE(_C, m) {
     // Multi-GPU: generate NCCL unique ID (call on rank 0, pass bytes to all ranks)
     m.def("get_nccl_id", []() {
@@ -870,4 +1169,19 @@ PYBIND11_MODULE(_C, m) {
                    " n=" + std::to_string(g.n()) +
                    " cap=" + std::to_string(g.capacity()) + ">";
         });
+
+    // Protein sweep
+    py::class_<PyProtein>(m, "Protein")
+        .def(py::init<py::dict>(), py::arg("sweep_config"))
+        .def("suggest", &PyProtein::suggest,
+             py::arg("fill"), py::arg("fixed_total_timesteps") = py::none())
+        .def("observe", &PyProtein::observe,
+             py::arg("hypers"), py::arg("score"), py::arg("cost"),
+             py::arg("is_failure") = false)
+        .def("early_stop", &PyProtein::early_stop,
+             py::arg("logs"), py::arg("target_key"))
+        .def(py::pickle(
+            [](const PyProtein &p) { return p.getstate(); },
+            &PyProtein::from_pickle
+        ));
 }

--- a/src/gp_cuda.cu
+++ b/src/gp_cuda.cu
@@ -17,88 +17,52 @@
 
 #include "gp_cuda_kernel.cu"
 
-#define CUSOLVER_CHECK(call)                                                  \
-    do {                                                                      \
-        cusolverStatus_t _s = (call);                                         \
-        if (_s != CUSOLVER_STATUS_SUCCESS) {                                  \
-            fprintf(stderr, "cuSOLVER error %s:%d: %d\n", __FILE__, __LINE__, \
-                (int)_s);                                                     \
-            abort();                                                          \
-        }                                                                     \
-    } while (0)
-
-// -- GaussianProcess struct
-// -------------------------------------------------------------
+// clang-format off
+static inline void _cusolver_check(cusolverStatus_t s, const char* f, int l) {
+    if (s != CUSOLVER_STATUS_SUCCESS) { fprintf(stderr, "cuSOLVER error %s:%d: %d\n", f, l, (int)s); abort(); }
+}
+#define CUSOLVER_CHECK(call) _cusolver_check((call), __FILE__, __LINE__)
+// clang-format on
 
 typedef struct {
     int dim, n, cap;
-    float* d_X;
-    float* d_y;
-    float* d_L;
-    float* d_alpha;
-    float* d_work;
+    float *d_X;
+    float *d_y;
+    float *d_L;
+    float *d_alpha;
+    float *d_work;
     int lwork;
-    int* d_info;
+    int *d_info;
     float raw_noise;
     float dedup_threshold;
     cublasHandle_t cublas;
     cusolverDnHandle_t cusolver;
-    GPKernel* kernel;
+    GPKernel *kernel;
 } GaussianProcess;
 
-GaussianProcess* gp_create(int dim, int cap, GPKernel* kernel, float noise);
-void gp_destroy(GaussianProcess* gp);
-float gp_get_noise(const GaussianProcess* gp);
-void gp_set_noise(GaussianProcess* gp, float v);
-int gp_fit(GaussianProcess* gp, const float* X, const float* y, int n,
-    cudaStream_t stream);
-int gp_recompute(GaussianProcess* gp, cudaStream_t stream);
-void gp_predict(const GaussianProcess* gp, const float* Xs, float* means,
-    float* vars, int m, cudaStream_t stream);
-float gp_marginal_log_likelihood(const GaussianProcess* gp);
-void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
-    float* kernel_grads, cudaStream_t stream);
-int gp_save(const GaussianProcess* gp, const char* path);
-GaussianProcess* gp_load(const char* path, int extra_cap);
-
-// -- utility device kernels --------------------------------------------------
-
-__global__ void gp_k_add_diag(float* A, int n, float val)
-{
+__global__ void gp_k_add_diag(float *A, int n, float val) {
     int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         A[(size_t)i * (n + 1)] += val;
 }
 
-__global__ void gp_k_extract_diag(const float* A, float* d, int n)
-{
+__global__ void gp_k_extract_diag(const float *A, float *d, int n) {
     int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         d[i] = A[(size_t)i * (n + 1)];
 }
 
-__global__ void gp_k_col_sqnorms(const float* V, float* sqnorms, int n, int m)
-{
+__global__ void gp_k_var_from_chol(float *vars, const float *V, int n, int m) {
     int j = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (j >= m)
         return;
     float sq = 0.0;
-    const float* col = V + (size_t)j * n;
+    const float *col = V + (size_t)j * n;
     for (int i = 0; i < n; i++)
         sq += col[i] * col[i];
-    sqnorms[j] = sq;
-}
-
-__global__ void gp_k_var_subtract(float* vars, const float* sqnorms, int m)
-{
-    int j = blockIdx.x * BLOCK_SIZE + threadIdx.x;
-    if (j >= m)
-        return;
-    float v = vars[j] - sqnorms[j];
+    float v = vars[j] - sq;
     vars[j] = v > 0.0 ? v : 0.0;
 }
-
-// -- host-side near-duplicate filter -----------------------------------------
 
 #define KD_LEAF 16
 
@@ -107,25 +71,23 @@ typedef struct {
     float split_val;
 } KDNode;
 typedef struct {
-    const float* X;
+    const float *X;
     int n, dim, n_nodes;
-    int* idx;
-    KDNode* nodes;
+    int *idx;
+    KDNode *nodes;
 } KDTree;
 
 static int g_kd_split_dim, g_kd_d;
-static const float* g_kd_X;
+static const float *g_kd_X;
 
-static int kd_cmp_fn(const void* a, const void* b)
-{
-    float va = g_kd_X[*(const int*)a * g_kd_d + g_kd_split_dim];
-    float vb = g_kd_X[*(const int*)b * g_kd_d + g_kd_split_dim];
+static int kd_cmp_fn(const void *a, const void *b) {
+    float va = g_kd_X[*(const int *)a * g_kd_d + g_kd_split_dim];
+    float vb = g_kd_X[*(const int *)b * g_kd_d + g_kd_split_dim];
     return (va > vb) - (va < vb);
 }
 
-static void kd_build(KDTree* t, int node, int lo, int hi)
-{
-    KDNode* nd = &t->nodes[node];
+static void kd_build(KDTree *t, int node, int lo, int hi) {
+    KDNode *nd = &t->nodes[node];
     nd->lo = lo;
     nd->hi = hi;
     nd->left = nd->right = -1;
@@ -163,31 +125,18 @@ static void kd_build(KDTree* t, int node, int lo, int hi)
     kd_build(t, rn, mid, hi);
 }
 
-static KDTree kd_create(const float* X, int n, int dim)
-{
-    KDTree t;
-    t.X = X;
-    t.n = n;
-    t.dim = dim;
-    t.n_nodes = 1;
-    t.idx = (int*)malloc(n * sizeof(int));
-    t.nodes = (KDNode*)malloc(2 * n * sizeof(KDNode));
+static KDTree kd_create(const float *X, int n, int dim) {
+    KDTree t = {.X = X, .n = n, .dim = dim, .n_nodes = 1};
+    t.idx = (int *)malloc(n * sizeof(int));
+    t.nodes = (KDNode *)malloc(2 * n * sizeof(KDNode));
     for (int i = 0; i < n; i++)
         t.idx[i] = i;
     kd_build(&t, 0, 0, n);
     return t;
 }
 
-static void kd_destroy(KDTree* t)
-{
-    free(t->idx);
-    free(t->nodes);
-}
-
-static void kd_query_ball(const KDTree* t, int node, const float* q, float r,
-    float r2, int* out, int* cnt)
-{
-    const KDNode* nd = &t->nodes[node];
+static void kd_query_ball(const KDTree *t, int node, const float *q, float r, float r2, int *out, int *cnt) {
+    const KDNode *nd = &t->nodes[node];
     if (nd->split_dim < 0) {
         for (int i = nd->lo; i < nd->hi; i++) {
             int p = t->idx[i];
@@ -208,9 +157,7 @@ static void kd_query_ball(const KDTree* t, int node, const float* q, float r,
         kd_query_ball(t, nd->right, q, r, r2, out, cnt);
 }
 
-static int gp_filter_near_duplicates(const float* X, int n, int dim,
-    float threshold, int* kept_indices)
-{
+static int gp_filter_near_duplicates(const float *X, int n, int dim, float threshold, int *kept_indices) {
     if (n <= 0)
         return 0;
     if (n == 1) {
@@ -219,8 +166,8 @@ static int gp_filter_near_duplicates(const float* X, int n, int dim,
     }
 
     KDTree tree = kd_create(X, n, dim);
-    int* keep = (int*)malloc(n * sizeof(int));
-    int* nearby = (int*)malloc(n * sizeof(int));
+    int *keep = (int *)malloc(n * sizeof(int));
+    int *nearby = (int *)malloc(n * sizeof(int));
     float r2 = threshold * threshold;
     for (int i = 0; i < n; i++)
         keep[i] = 1;
@@ -242,26 +189,16 @@ static int gp_filter_near_duplicates(const float* X, int n, int dim,
 
     free(nearby);
     free(keep);
-    kd_destroy(&tree);
+    free(tree.idx);
+    free(tree.nodes);
     return count;
 }
 
-// -- hyperparameter access ---------------------------------------------------
+float gp_get_noise(const GaussianProcess *gp) { return softplus(gp->raw_noise); }
+void gp_set_noise(GaussianProcess *gp, float v) { gp->raw_noise = inv_softplus(v); }
 
-float gp_get_noise(const GaussianProcess* gp)
-{
-    return softplus(gp->raw_noise);
-}
-void gp_set_noise(GaussianProcess* gp, float v)
-{
-    gp->raw_noise = inv_softplus(v);
-}
-
-// -- lifecycle ---------------------------------------------------------------
-
-GaussianProcess* gp_create(int dim, int cap, GPKernel* kernel, float noise)
-{
-    GaussianProcess* gp = (GaussianProcess*)calloc(1, sizeof(GaussianProcess));
+GaussianProcess *gp_create(int dim, int cap, GPKernel *kernel, float noise) {
+    GaussianProcess *gp = (GaussianProcess *)calloc(1, sizeof(GaussianProcess));
     gp->dim = dim;
     gp->cap = cap;
     gp->kernel = kernel;
@@ -276,8 +213,7 @@ GaussianProcess* gp_create(int dim, int cap, GPKernel* kernel, float noise)
     return gp;
 }
 
-void gp_destroy(GaussianProcess* gp)
-{
+void gp_destroy(GaussianProcess *gp) {
     if (!gp)
         return;
     cudaFree(gp->d_X);
@@ -293,55 +229,33 @@ void gp_destroy(GaussianProcess* gp)
     free(gp);
 }
 
-// -- internal helpers --------------------------------------------------------
-
-static int run_potrf(GaussianProcess* gp, float* d_K, int n,
-    cudaStream_t stream)
-{
+static int run_potrf(GaussianProcess *gp, float *d_K, int n, cudaStream_t stream) {
     CUSOLVER_CHECK(cusolverDnSetStream(gp->cusolver, stream));
     int lwork = 0;
-    CUSOLVER_CHECK(cusolverDnSpotrf_bufferSize(
-        gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K, n, &lwork));
+    CUSOLVER_CHECK(cusolverDnSpotrf_bufferSize(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K, n, &lwork));
     if (lwork > gp->lwork) {
         cudaFree(gp->d_work);
         CUDA_CHECK(cudaMalloc(&gp->d_work, (size_t)lwork * sizeof(float)));
         gp->lwork = lwork;
     }
-    CUSOLVER_CHECK(cusolverDnSpotrf(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K,
-        n, gp->d_work, gp->lwork, gp->d_info));
-
+    CUSOLVER_CHECK(
+        cusolverDnSpotrf(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K, n, gp->d_work, gp->lwork, gp->d_info));
     int h_info;
-    CUDA_CHECK(cudaMemcpyAsync(&h_info, gp->d_info, sizeof(int),
-        cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaMemcpyAsync(&h_info, gp->d_info, sizeof(int), cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaStreamSynchronize(stream));
     return h_info;
 }
 
-static void solve_alpha(GaussianProcess* gp, const float* d_L, int n,
-    float* d_alpha, cudaStream_t stream)
-{
-    CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
-    CUBLAS_CHECK(cublasStrsv(gp->cublas, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
-        CUBLAS_DIAG_NON_UNIT, n, d_L, n, d_alpha, 1));
-    CUBLAS_CHECK(cublasStrsv(gp->cublas, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_T,
-        CUBLAS_DIAG_NON_UNIT, n, d_L, n, d_alpha, 1));
-}
-
-// -- training ----------------------------------------------------------------
-
-int gp_recompute(GaussianProcess* gp, cudaStream_t stream)
-{
+int gp_recompute(GaussianProcess *gp, cudaStream_t stream) {
     int n = gp->n;
     if (n == 0)
         return 0;
 
-    gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp),
-        gp->d_L, stream);
+    gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp), gp->d_L, stream);
 
     int info = run_potrf(gp, gp->d_L, n, stream);
     if (info != 0) {
-        gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp),
-            gp->d_L, stream);
+        gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp), gp->d_L, stream);
         gp_k_add_diag<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(gp->d_L, n, 1e-8);
         CUDA_CHECK(cudaGetLastError());
         info = run_potrf(gp, gp->d_L, n, stream);
@@ -349,86 +263,65 @@ int gp_recompute(GaussianProcess* gp, cudaStream_t stream)
             return -2;
     }
 
-    CUDA_CHECK(cudaMemcpyAsync(gp->d_alpha, gp->d_y, (size_t)n * sizeof(float),
-        cudaMemcpyDeviceToDevice, stream));
-    solve_alpha(gp, gp->d_L, n, gp->d_alpha, stream);
+    CUDA_CHECK(cudaMemcpyAsync(gp->d_alpha, gp->d_y, (size_t)n * sizeof(float), cudaMemcpyDeviceToDevice, stream));
+    CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
+    CUBLAS_CHECK(cublasStrsv(gp->cublas, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N, CUBLAS_DIAG_NON_UNIT, n, gp->d_L, n,
+                             gp->d_alpha, 1));
+    CUBLAS_CHECK(cublasStrsv(gp->cublas, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_T, CUBLAS_DIAG_NON_UNIT, n, gp->d_L, n,
+                             gp->d_alpha, 1));
     return 0;
 }
 
-int gp_fit(GaussianProcess* gp, const float* X, const float* y, int n,
-    cudaStream_t stream)
-{
+int gp_fit(GaussianProcess *gp, const float *X, const float *y, int n, cudaStream_t stream) {
     if (n > gp->cap)
         return -1;
 
     if (gp->dedup_threshold > 0.0 && n > 1) {
-        int* idx = (int*)malloc(n * sizeof(int));
+        int *idx = (int *)malloc(n * sizeof(int));
         int n_kept = gp_filter_near_duplicates(X, n, gp->dim, gp->dedup_threshold, idx);
-        float* X_c = (float*)malloc((size_t)n_kept * gp->dim * sizeof(float));
-        float* y_c = (float*)malloc((size_t)n_kept * sizeof(float));
+        float *X_c = (float *)malloc((size_t)n_kept * gp->dim * sizeof(float));
+        float *y_c = (float *)malloc((size_t)n_kept * sizeof(float));
         for (int i = 0; i < n_kept; i++) {
             memcpy(&X_c[i * gp->dim], &X[idx[i] * gp->dim], gp->dim * sizeof(float));
             y_c[i] = y[idx[i]];
         }
         free(idx);
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X_c,
-            (size_t)n_kept * gp->dim * sizeof(float),
-            cudaMemcpyHostToDevice, stream));
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y_c, (size_t)n_kept * sizeof(float),
-            cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(
+            cudaMemcpyAsync(gp->d_X, X_c, (size_t)n_kept * gp->dim * sizeof(float), cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y_c, (size_t)n_kept * sizeof(float), cudaMemcpyHostToDevice, stream));
         free(X_c);
         free(y_c);
         gp->n = n_kept;
     } else {
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X, (size_t)n * gp->dim * sizeof(float),
-            cudaMemcpyHostToDevice, stream));
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y, (size_t)n * sizeof(float),
-            cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X, (size_t)n * gp->dim * sizeof(float), cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y, (size_t)n * sizeof(float), cudaMemcpyHostToDevice, stream));
         gp->n = n;
     }
     return gp_recompute(gp, stream);
 }
 
-// -- prediction --------------------------------------------------------------
-
-static void predict_dev(const GaussianProcess* gp, const float* d_Xte,
-    float* d_means, float* d_vars, int m,
-    cudaStream_t stream)
-{
+static void predict_dev(const GaussianProcess *gp, const float *d_Xte, float *d_means, float *d_vars, int m,
+                        cudaStream_t stream) {
     int n = gp->n, d = gp->dim;
     const float one = 1.0, zero = 0.0;
     CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
 
-    float* d_Ks;
+    float *d_Ks;
     CUDA_CHECK(cudaMallocAsync(&d_Ks, (size_t)n * m * sizeof(float), stream));
     gp->kernel->build_Ks(gp->kernel, gp->d_X, d_Xte, n, m, d, d_Ks, stream);
-
-    CUBLAS_CHECK(cublasSgemv(gp->cublas, CUBLAS_OP_T, n, m, &one, d_Ks, n,
-        gp->d_alpha, 1, &zero, d_means, 1));
+    CUBLAS_CHECK(cublasSgemv(gp->cublas, CUBLAS_OP_T, n, m, &one, d_Ks, n, gp->d_alpha, 1, &zero, d_means, 1));
 
     if (d_vars) {
         gp->kernel->build_kself_batch(gp->kernel, d_Xte, m, d, d_vars, stream);
-
-        CUBLAS_CHECK(cublasStrsm(
-            gp->cublas, CUBLAS_SIDE_LEFT, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
-            CUBLAS_DIAG_NON_UNIT, n, m, &one, gp->d_L, n, d_Ks, n));
-        float* d_sqnorms;
-        CUDA_CHECK(cudaMallocAsync(&d_sqnorms, (size_t)m * sizeof(float), stream));
-        gp_k_col_sqnorms<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_Ks, d_sqnorms, n,
-            m);
+        CUBLAS_CHECK(cublasStrsm(gp->cublas, CUBLAS_SIDE_LEFT, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
+                                 CUBLAS_DIAG_NON_UNIT, n, m, &one, gp->d_L, n, d_Ks, n));
+        gp_k_var_from_chol<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_vars, d_Ks, n, m);
         CUDA_CHECK(cudaGetLastError());
-        gp_k_var_subtract<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_vars, d_sqnorms,
-            m);
-        CUDA_CHECK(cudaGetLastError());
-        CUDA_CHECK(cudaFreeAsync(d_sqnorms, stream));
     }
-
     CUDA_CHECK(cudaFreeAsync(d_Ks, stream));
 }
 
-void gp_predict(const GaussianProcess* gp, const float* Xs, float* means,
-    float* vars, int m, cudaStream_t stream)
-{
+void gp_predict(const GaussianProcess *gp, const float *Xs, float *means, float *vars, int m, cudaStream_t stream) {
     int n = gp->n;
     if (n == 0) {
         for (int j = 0; j < m; j++) {
@@ -439,11 +332,9 @@ void gp_predict(const GaussianProcess* gp, const float* Xs, float* means,
         return;
     }
 
-    float* d_Xte;
-    CUDA_CHECK(
-        cudaMallocAsync(&d_Xte, (size_t)m * gp->dim * sizeof(float), stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_Xte, Xs, (size_t)m * gp->dim * sizeof(float),
-        cudaMemcpyHostToDevice, stream));
+    float *d_Xte;
+    CUDA_CHECK(cudaMallocAsync(&d_Xte, (size_t)m * gp->dim * sizeof(float), stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_Xte, Xs, (size_t)m * gp->dim * sizeof(float), cudaMemcpyHostToDevice, stream));
 
     float *d_means, *d_vars = NULL;
     CUDA_CHECK(cudaMallocAsync(&d_means, (size_t)m * sizeof(float), stream));
@@ -452,39 +343,31 @@ void gp_predict(const GaussianProcess* gp, const float* Xs, float* means,
 
     predict_dev(gp, d_Xte, d_means, d_vars, m, stream);
     CUDA_CHECK(cudaFreeAsync(d_Xte, stream));
-
-    CUDA_CHECK(cudaMemcpyAsync(means, d_means, (size_t)m * sizeof(float),
-        cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaMemcpyAsync(means, d_means, (size_t)m * sizeof(float), cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaFreeAsync(d_means, stream));
     if (vars) {
-        CUDA_CHECK(cudaMemcpyAsync(vars, d_vars, (size_t)m * sizeof(float),
-            cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK(cudaMemcpyAsync(vars, d_vars, (size_t)m * sizeof(float), cudaMemcpyDeviceToHost, stream));
         CUDA_CHECK(cudaFreeAsync(d_vars, stream));
     }
     CUDA_CHECK(cudaStreamSynchronize(stream));
 }
 
-// -- likelihood and gradients ------------------------------------------------
-
-float gp_marginal_log_likelihood(const GaussianProcess* gp)
-{
+float gp_marginal_log_likelihood(const GaussianProcess *gp) {
     int n = gp->n;
     if (n == 0)
         return 0.0;
 
     CUBLAS_CHECK(cublasSetStream(gp->cublas, 0));
     float data_fit;
-    CUBLAS_CHECK(
-        cublasSdot(gp->cublas, n, gp->d_y, 1, gp->d_alpha, 1, &data_fit));
+    CUBLAS_CHECK(cublasSdot(gp->cublas, n, gp->d_y, 1, gp->d_alpha, 1, &data_fit));
 
-    float* d_diag;
+    float *d_diag;
     CUDA_CHECK(cudaMalloc(&d_diag, (size_t)n * sizeof(float)));
     gp_k_extract_diag<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(gp->d_L, d_diag, n);
     CUDA_CHECK(cudaGetLastError());
 
-    float* h_diag = (float*)malloc(n * sizeof(float));
-    CUDA_CHECK(cudaMemcpy(h_diag, d_diag, (size_t)n * sizeof(float),
-        cudaMemcpyDeviceToHost));
+    float *h_diag = (float *)malloc(n * sizeof(float));
+    CUDA_CHECK(cudaMemcpy(h_diag, d_diag, (size_t)n * sizeof(float), cudaMemcpyDeviceToHost));
     CUDA_CHECK(cudaFree(d_diag));
 
     float log_det = 0.0;
@@ -495,9 +378,7 @@ float gp_marginal_log_likelihood(const GaussianProcess* gp)
     return (-0.5 * data_fit - log_det - 0.5 * n * log(2.0 * M_PI)) / n;
 }
 
-void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
-    float* kernel_grads, cudaStream_t stream)
-{
+void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_grads, cudaStream_t stream) {
     int n = gp->n;
     if (n == 0) {
         if (d_raw_noise)
@@ -511,19 +392,16 @@ void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
     CUSOLVER_CHECK(cusolverDnSetStream(gp->cusolver, stream));
     CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
 
-    float* d_Kinv;
+    float *d_Kinv;
     CUDA_CHECK(cudaMallocAsync(&d_Kinv, (size_t)n * n * sizeof(float), stream));
     CUDA_CHECK(cudaMemsetAsync(d_Kinv, 0, (size_t)n * n * sizeof(float), stream));
     gp_k_add_diag<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_Kinv, n, 1.0);
     CUDA_CHECK(cudaGetLastError());
-
-    CUSOLVER_CHECK(cusolverDnSpotrs(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, n,
-        gp->d_L, n, d_Kinv, n, gp->d_info));
+    CUSOLVER_CHECK(cusolverDnSpotrs(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, n, gp->d_L, n, d_Kinv, n, gp->d_info));
 
     if (d_raw_noise) {
         float term1, term2;
-        CUBLAS_CHECK(
-            cublasSdot(gp->cublas, n, gp->d_alpha, 1, gp->d_alpha, 1, &term1));
+        CUBLAS_CHECK(cublasSdot(gp->cublas, n, gp->d_alpha, 1, gp->d_alpha, 1, &term1));
         CUBLAS_CHECK(cublasSasum(gp->cublas, n, d_Kinv, n + 1, &term2));
         *d_raw_noise = 0.5 * (term1 - term2) * softplus_grad(gp->raw_noise) / n;
     }
@@ -531,50 +409,39 @@ void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
     if (kernel_grads) {
         for (int i = 0; i < gp->kernel->n_params; i++)
             kernel_grads[i] = 0.0;
-        gp->kernel->mll_grad(gp->kernel, gp->d_X, n, gp->dim, gp->cublas, stream,
-            gp->d_alpha, d_Kinv, kernel_grads);
+        gp->kernel->mll_grad(gp->kernel, gp->d_X, n, gp->dim, gp->cublas, stream, gp->d_alpha, d_Kinv, kernel_grads);
         for (int i = 0; i < gp->kernel->n_params; i++)
             kernel_grads[i] /= n;
     }
-
     CUDA_CHECK(cudaFreeAsync(d_Kinv, stream));
 }
 
-// -- kernel registry for gp_load ---------------------------------------------
-
 typedef struct {
-    const char* tag;
-    GPKernel* (*make)(float*, int);
+    const char *tag;
+    GPKernel *(*make)(float *, int);
 } KernelFactory;
 
-static GPKernel* kf_matern32lin(float* rp, int np)
-{
+static GPKernel *kf_matern32lin(float *rp, int np) {
     int dim = np - 2;
-    GPKernel* k = gp_kernel_matern32_linear(dim, 1.0, 1.0, 1.0);
+    GPKernel *k = gp_kernel_matern32_linear(dim, 1.0, 1.0, 1.0);
     memcpy(k->raw_params, rp, (size_t)np * sizeof(float));
     return k;
 }
 
-static const KernelFactory kernel_registry[] = {
-    { GP_KERNEL_TAG_MATERN32_LINEAR, kf_matern32lin }, { NULL, NULL }
-};
+static const KernelFactory kernel_registry[] = {{GP_KERNEL_TAG_MATERN32_LINEAR, kf_matern32lin}, {NULL, NULL}};
 
-static GPKernel* kernel_from_tag(const char* tag, float* rp, int np)
-{
+static GPKernel *kernel_from_tag(const char *tag, float *rp, int np) {
     for (int i = 0; kernel_registry[i].tag; i++)
         if (memcmp(tag, kernel_registry[i].tag, 4) == 0)
             return kernel_registry[i].make(rp, np);
     return NULL;
 }
 
-// -- save / load -------------------------------------------------------------
-
-int gp_save(const GaussianProcess* gp, const char* path)
-{
+int gp_save(const GaussianProcess *gp, const char *path) {
     if (gp->n == 0)
         return -1;
     CUDA_CHECK(cudaDeviceSynchronize());
-    FILE* f = fopen(path, "wb");
+    FILE *f = fopen(path, "wb");
     if (!f)
         return -1;
 
@@ -587,44 +454,27 @@ int gp_save(const GaussianProcess* gp, const char* path)
     fwrite(&np, sizeof(int), 1, f);
     fwrite(gp->kernel->raw_params, sizeof(float), np, f);
 
-    float* h_X = (float*)malloc((size_t)n * dim * sizeof(float));
-    float* h_y = (float*)malloc((size_t)n * sizeof(float));
-    float* h_L = (float*)malloc((size_t)n * n * sizeof(float));
-    float* h_alpha = (float*)malloc((size_t)n * sizeof(float));
-    CUDA_CHECK(cudaMemcpy(h_X, gp->d_X, (size_t)n * dim * sizeof(float),
-        cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(h_y, gp->d_y, (size_t)n * sizeof(float),
-        cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(h_L, gp->d_L, (size_t)n * n * sizeof(float),
-        cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(h_alpha, gp->d_alpha, (size_t)n * sizeof(float),
-        cudaMemcpyDeviceToHost));
+    const float *d_ptrs[] = {gp->d_X, gp->d_y, gp->d_L, gp->d_alpha};
+    const size_t sizes[] = {(size_t)n * dim, (size_t)n, (size_t)n * n, (size_t)n};
+    for (int i = 0; i < 4; i++) {
+        float *h = (float *)malloc(sizes[i] * sizeof(float));
+        CUDA_CHECK(cudaMemcpy(h, d_ptrs[i], sizes[i] * sizeof(float), cudaMemcpyDeviceToHost));
+        fwrite(h, sizeof(float), sizes[i], f);
+        free(h);
+    }
 
-    fwrite(h_X, sizeof(float), (size_t)n * dim, f);
-    fwrite(h_y, sizeof(float), n, f);
-    fwrite(h_L, sizeof(float), (size_t)n * n, f);
-    fwrite(h_alpha, sizeof(float), n, f);
-
-    free(h_X);
-    free(h_y);
-    free(h_L);
-    free(h_alpha);
     fclose(f);
     return 0;
 }
 
-GaussianProcess* gp_load(const char* path, int extra_cap)
-{
-    GaussianProcess* gp = NULL;
-    float *h_X = NULL, *h_y = NULL;
-    float *h_L = NULL, *h_alpha = NULL;
-
-    FILE* f = fopen(path, "rb");
+GaussianProcess *gp_load(const char *path, int extra_cap) {
+    GaussianProcess *gp = NULL;
+    FILE *f = fopen(path, "rb");
     if (!f)
         return NULL;
 
-#define RD(ptr, sz, cnt)                         \
-    if (fread(ptr, sz, cnt, f) != (size_t)(cnt)) \
+#define RD(ptr, sz, cnt)                                                                                               \
+    if (fread(ptr, sz, cnt, f) != (size_t)(cnt))                                                                       \
     break
 
     do {
@@ -635,22 +485,20 @@ GaussianProcess* gp_load(const char* path, int extra_cap)
         RD(magic, 1, 4);
         if (memcmp(magic, "GC04", 4) != 0)
             break;
-
         RD(&dim, sizeof(int), 1);
         RD(&n, sizeof(int), 1);
         RD(&rn, sizeof(float), 1);
         RD(ktag, 1, 4);
         RD(&np, sizeof(int), 1);
 
-        float* rp = (float*)malloc((size_t)np * sizeof(float));
+        float *rp = (float *)malloc((size_t)np * sizeof(float));
         if (!rp)
             break;
         if (fread(rp, sizeof(float), np, f) != (size_t)np) {
             free(rp);
             break;
         }
-
-        GPKernel* k = kernel_from_tag(ktag, rp, np);
+        GPKernel *k = kernel_from_tag(ktag, rp, np);
         free(rp);
         if (!k)
             break;
@@ -660,38 +508,27 @@ GaussianProcess* gp_load(const char* path, int extra_cap)
         gp->raw_noise = rn;
         gp->n = n;
 
-        h_X = (float*)malloc((size_t)n * dim * sizeof(float));
-        h_y = (float*)malloc((size_t)n * sizeof(float));
-        h_L = (float*)malloc((size_t)n * n * sizeof(float));
-        h_alpha = (float*)malloc((size_t)n * sizeof(float));
+        float *d_ptrs[] = {gp->d_X, gp->d_y, gp->d_L, gp->d_alpha};
+        const size_t sizes[] = {(size_t)n * dim, (size_t)n, (size_t)n * n, (size_t)n};
+        int ok = 1;
+        for (int i = 0; i < 4 && ok; i++) {
+            float *h = (float *)malloc(sizes[i] * sizeof(float));
+            if (fread(h, sizeof(float), sizes[i], f) != sizes[i]) {
+                free(h);
+                ok = 0;
+            } else {
+                CUDA_CHECK(cudaMemcpy(d_ptrs[i], h, sizes[i] * sizeof(float), cudaMemcpyHostToDevice));
+                free(h);
+            }
+        }
+        if (!ok)
+            break;
 
-        RD(h_X, sizeof(float), (size_t)n * dim);
-        RD(h_y, sizeof(float), n);
-        RD(h_L, sizeof(float), (size_t)n * n);
-        RD(h_alpha, sizeof(float), n);
-
-        CUDA_CHECK(cudaMemcpy(gp->d_X, h_X, (size_t)n * dim * sizeof(float),
-            cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(gp->d_y, h_y, (size_t)n * sizeof(float),
-            cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(gp->d_L, h_L, (size_t)n * n * sizeof(float),
-            cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(gp->d_alpha, h_alpha, (size_t)n * sizeof(float),
-            cudaMemcpyHostToDevice));
-
-        free(h_X);
-        free(h_y);
-        free(h_L);
-        free(h_alpha);
         fclose(f);
         return gp;
     } while (0);
 
 #undef RD
-    free(h_X);
-    free(h_y);
-    free(h_L);
-    free(h_alpha);
     if (gp)
         gp_destroy(gp);
     fclose(f);

--- a/src/gp_cuda.cu
+++ b/src/gp_cuda.cu
@@ -65,21 +65,21 @@ GaussianProcess* gp_load(const char* path, int extra_cap);
 
 __global__ void gp_k_add_diag(float* A, int n, float val)
 {
-    int i = blockIdx.x * 256 + threadIdx.x;
+    int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         A[(size_t)i * (n + 1)] += val;
 }
 
 __global__ void gp_k_extract_diag(const float* A, float* d, int n)
 {
-    int i = blockIdx.x * 256 + threadIdx.x;
+    int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         d[i] = A[(size_t)i * (n + 1)];
 }
 
 __global__ void gp_k_col_sqnorms(const float* V, float* sqnorms, int n, int m)
 {
-    int j = blockIdx.x * 256 + threadIdx.x;
+    int j = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (j >= m)
         return;
     float sq = 0.0;
@@ -91,7 +91,7 @@ __global__ void gp_k_col_sqnorms(const float* V, float* sqnorms, int n, int m)
 
 __global__ void gp_k_var_subtract(float* vars, const float* sqnorms, int m)
 {
-    int j = blockIdx.x * 256 + threadIdx.x;
+    int j = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (j >= m)
         return;
     float v = vars[j] - sqnorms[j];
@@ -342,7 +342,7 @@ int gp_recompute(GaussianProcess* gp, cudaStream_t stream)
     if (info != 0) {
         gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp),
             gp->d_L, stream);
-        gp_k_add_diag<<<(n + 255) / 256, 256, 0, stream>>>(gp->d_L, n, 1e-8);
+        gp_k_add_diag<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(gp->d_L, n, 1e-8);
         CUDA_CHECK(cudaGetLastError());
         info = run_potrf(gp, gp->d_L, n, stream);
         if (info != 0)
@@ -414,10 +414,10 @@ static void predict_dev(const GaussianProcess* gp, const float* d_Xte,
             CUBLAS_DIAG_NON_UNIT, n, m, &one, gp->d_L, n, d_Ks, n));
         float* d_sqnorms;
         CUDA_CHECK(cudaMallocAsync(&d_sqnorms, (size_t)m * sizeof(float), stream));
-        gp_k_col_sqnorms<<<(m + 255) / 256, 256, 0, stream>>>(d_Ks, d_sqnorms, n,
+        gp_k_col_sqnorms<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_Ks, d_sqnorms, n,
             m);
         CUDA_CHECK(cudaGetLastError());
-        gp_k_var_subtract<<<(m + 255) / 256, 256, 0, stream>>>(d_vars, d_sqnorms,
+        gp_k_var_subtract<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_vars, d_sqnorms,
             m);
         CUDA_CHECK(cudaGetLastError());
         CUDA_CHECK(cudaFreeAsync(d_sqnorms, stream));
@@ -479,7 +479,7 @@ float gp_marginal_log_likelihood(const GaussianProcess* gp)
 
     float* d_diag;
     CUDA_CHECK(cudaMalloc(&d_diag, (size_t)n * sizeof(float)));
-    gp_k_extract_diag<<<(n + 255) / 256, 256>>>(gp->d_L, d_diag, n);
+    gp_k_extract_diag<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(gp->d_L, d_diag, n);
     CUDA_CHECK(cudaGetLastError());
 
     float* h_diag = (float*)malloc(n * sizeof(float));
@@ -514,7 +514,7 @@ void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
     float* d_Kinv;
     CUDA_CHECK(cudaMallocAsync(&d_Kinv, (size_t)n * n * sizeof(float), stream));
     CUDA_CHECK(cudaMemsetAsync(d_Kinv, 0, (size_t)n * n * sizeof(float), stream));
-    gp_k_add_diag<<<(n + 255) / 256, 256, 0, stream>>>(d_Kinv, n, 1.0);
+    gp_k_add_diag<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_Kinv, n, 1.0);
     CUDA_CHECK(cudaGetLastError());
 
     CUSOLVER_CHECK(cusolverDnSpotrs(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, n,

--- a/src/gp_cuda.cu
+++ b/src/gp_cuda.cu
@@ -40,6 +40,20 @@ typedef struct {
     GPKernel *kernel;
 } GaussianProcess;
 
+GaussianProcess *gp_create(int dim, int cap, GPKernel *kernel, float noise);
+void gp_destroy(GaussianProcess *gp);
+float gp_get_noise(const GaussianProcess *gp);
+void gp_set_noise(GaussianProcess *gp, float v);
+int gp_fit(GaussianProcess *gp, const float *X, const float *y, int n, cudaStream_t stream);
+int gp_recompute(GaussianProcess *gp, cudaStream_t stream);
+void gp_predict(const GaussianProcess *gp, const float *Xs, float *means, float *vars, int m, cudaStream_t stream);
+void gp_predict_d(const GaussianProcess *gp, const float *d_Xs, float *d_means, float *d_vars, int m,
+                  cudaStream_t stream);
+float gp_marginal_log_likelihood(const GaussianProcess *gp);
+void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_grads, cudaStream_t stream);
+int gp_save(const GaussianProcess *gp, const char *path);
+GaussianProcess *gp_load(const char *path, int extra_cap);
+
 __global__ void gp_k_add_diag(float *A, int n, float val) {
     int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
@@ -350,6 +364,17 @@ void gp_predict(const GaussianProcess *gp, const float *Xs, float *means, float 
         CUDA_CHECK(cudaFreeAsync(d_vars, stream));
     }
     CUDA_CHECK(cudaStreamSynchronize(stream));
+}
+
+void gp_predict_d(const GaussianProcess *gp, const float *d_Xs, float *d_means, float *d_vars, int m,
+                  cudaStream_t stream) {
+    if (gp->n == 0) {
+        CUDA_CHECK(cudaMemsetAsync(d_means, 0, (size_t)m * sizeof(float), stream));
+        if (d_vars)
+            gp->kernel->build_kself_batch(gp->kernel, d_Xs, m, gp->dim, d_vars, stream);
+        return;
+    }
+    predict_dev(gp, d_Xs, d_means, d_vars, m, stream);
 }
 
 float gp_marginal_log_likelihood(const GaussianProcess *gp) {

--- a/src/gp_cuda.cu
+++ b/src/gp_cuda.cu
@@ -8,83 +8,92 @@
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
 #include <cusolverDn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "gp_cuda_kernel.cu"
 
-#define CUSOLVER_CHECK(call) do { \
-    cusolverStatus_t _s = (call); \
-    if (_s != CUSOLVER_STATUS_SUCCESS) { \
-        fprintf(stderr, "cuSOLVER error %s:%d: %d\n", __FILE__, __LINE__, (int)_s); \
-        abort(); \
-    } \
-} while (0)
+#define CUSOLVER_CHECK(call)                                                  \
+    do {                                                                      \
+        cusolverStatus_t _s = (call);                                         \
+        if (_s != CUSOLVER_STATUS_SUCCESS) {                                  \
+            fprintf(stderr, "cuSOLVER error %s:%d: %d\n", __FILE__, __LINE__, \
+                (int)_s);                                                     \
+            abort();                                                          \
+        }                                                                     \
+    } while (0)
 
-// -- GaussianProcess struct -------------------------------------------------------------
+// -- GaussianProcess struct
+// -------------------------------------------------------------
 
 typedef struct {
     int dim, n, cap;
-    float *d_X;
-    float *d_y;
-    float *d_L;
-    float *d_alpha;
-    float *d_work;
+    float* d_X;
+    float* d_y;
+    float* d_L;
+    float* d_alpha;
+    float* d_work;
     int lwork;
-    int *d_info;
+    int* d_info;
     float raw_noise;
     float dedup_threshold;
     cublasHandle_t cublas;
     cusolverDnHandle_t cusolver;
-    GPKernel *kernel;
+    GPKernel* kernel;
 } GaussianProcess;
 
-GaussianProcess *gp_create  (int dim, int cap, GPKernel *kernel, float noise);
-void  gp_destroy (GaussianProcess *gp);
-float gp_get_noise(const GaussianProcess *gp);
-void   gp_set_noise(GaussianProcess *gp, float v);
-int  gp_fit      (GaussianProcess *gp, const float *X, const float *y, int n, cudaStream_t stream);
-int  gp_recompute(GaussianProcess *gp, cudaStream_t stream);
-void gp_predict(const GaussianProcess *gp, const float *Xs,
-                  float *means, float *vars, int m, cudaStream_t stream);
-float gp_marginal_log_likelihood(const GaussianProcess *gp);
-void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_grads,
-                   cudaStream_t stream);
-int   gp_save(const GaussianProcess *gp, const char *path);
-GaussianProcess *gp_load(const char *path, int extra_cap);
+GaussianProcess* gp_create(int dim, int cap, GPKernel* kernel, float noise);
+void gp_destroy(GaussianProcess* gp);
+float gp_get_noise(const GaussianProcess* gp);
+void gp_set_noise(GaussianProcess* gp, float v);
+int gp_fit(GaussianProcess* gp, const float* X, const float* y, int n,
+    cudaStream_t stream);
+int gp_recompute(GaussianProcess* gp, cudaStream_t stream);
+void gp_predict(const GaussianProcess* gp, const float* Xs, float* means,
+    float* vars, int m, cudaStream_t stream);
+float gp_marginal_log_likelihood(const GaussianProcess* gp);
+void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
+    float* kernel_grads, cudaStream_t stream);
+int gp_save(const GaussianProcess* gp, const char* path);
+GaussianProcess* gp_load(const char* path, int extra_cap);
 
 // -- utility device kernels --------------------------------------------------
 
-__global__ void gp_k_add_diag(float *A, int n, float val)
+__global__ void gp_k_add_diag(float* A, int n, float val)
 {
     int i = blockIdx.x * 256 + threadIdx.x;
-    if (i < n) A[(size_t)i * (n + 1)] += val;
+    if (i < n)
+        A[(size_t)i * (n + 1)] += val;
 }
 
-__global__ void gp_k_extract_diag(const float *A, float *d, int n)
+__global__ void gp_k_extract_diag(const float* A, float* d, int n)
 {
     int i = blockIdx.x * 256 + threadIdx.x;
-    if (i < n) d[i] = A[(size_t)i * (n + 1)];
+    if (i < n)
+        d[i] = A[(size_t)i * (n + 1)];
 }
 
-__global__ void gp_k_col_sqnorms(const float *V, float *sqnorms, int n, int m)
+__global__ void gp_k_col_sqnorms(const float* V, float* sqnorms, int n, int m)
 {
     int j = blockIdx.x * 256 + threadIdx.x;
-    if (j >= m) return;
+    if (j >= m)
+        return;
     float sq = 0.0;
-    const float *col = V + (size_t)j * n;
-    for (int i = 0; i < n; i++) sq += col[i] * col[i];
+    const float* col = V + (size_t)j * n;
+    for (int i = 0; i < n; i++)
+        sq += col[i] * col[i];
     sqnorms[j] = sq;
 }
 
-__global__ void gp_k_var_subtract(float *vars, const float *sqnorms, int m)
+__global__ void gp_k_var_subtract(float* vars, const float* sqnorms, int m)
 {
     int j = blockIdx.x * 256 + threadIdx.x;
-    if (j >= m) return;
+    if (j >= m)
+        return;
     float v = vars[j] - sqnorms[j];
     vars[j] = v > 0.0 ? v : 0.0;
 }
@@ -93,145 +102,201 @@ __global__ void gp_k_var_subtract(float *vars, const float *sqnorms, int m)
 
 #define KD_LEAF 16
 
-typedef struct { int lo, hi, left, right, split_dim; float split_val; } KDNode;
-typedef struct { const float *X; int n, dim, n_nodes; int *idx; KDNode *nodes; } KDTree;
+typedef struct {
+    int lo, hi, left, right, split_dim;
+    float split_val;
+} KDNode;
+typedef struct {
+    const float* X;
+    int n, dim, n_nodes;
+    int* idx;
+    KDNode* nodes;
+} KDTree;
 
-static int          g_kd_split_dim, g_kd_d;
-static const float *g_kd_X;
+static int g_kd_split_dim, g_kd_d;
+static const float* g_kd_X;
 
-static int kd_cmp_fn(const void *a, const void *b)
+static int kd_cmp_fn(const void* a, const void* b)
 {
-    float va = g_kd_X[*(const int *)a * g_kd_d + g_kd_split_dim];
-    float vb = g_kd_X[*(const int *)b * g_kd_d + g_kd_split_dim];
+    float va = g_kd_X[*(const int*)a * g_kd_d + g_kd_split_dim];
+    float vb = g_kd_X[*(const int*)b * g_kd_d + g_kd_split_dim];
     return (va > vb) - (va < vb);
 }
 
-static void kd_build(KDTree *t, int node, int lo, int hi)
+static void kd_build(KDTree* t, int node, int lo, int hi)
 {
-    KDNode *nd = &t->nodes[node];
-    nd->lo = lo; nd->hi = hi; nd->left = nd->right = -1; nd->split_dim = -1;
-    if (hi - lo <= KD_LEAF) return;
+    KDNode* nd = &t->nodes[node];
+    nd->lo = lo;
+    nd->hi = hi;
+    nd->left = nd->right = -1;
+    nd->split_dim = -1;
+    if (hi - lo <= KD_LEAF)
+        return;
 
-    int best = 0; float spread = -1.0;
+    int best = 0;
+    float spread = -1.0;
     for (int k = 0; k < t->dim; k++) {
         float mn = t->X[t->idx[lo] * t->dim + k], mx = mn;
         for (int i = lo + 1; i < hi; i++) {
             float v = t->X[t->idx[i] * t->dim + k];
-            if (v < mn) mn = v;
-            if (v > mx) mx = v;
+            if (v < mn)
+                mn = v;
+            if (v > mx)
+                mx = v;
         }
-        if (mx - mn > spread) { spread = mx - mn; best = k; }
+        if (mx - mn > spread) {
+            spread = mx - mn;
+            best = k;
+        }
     }
     int mid = (lo + hi) / 2;
-    g_kd_split_dim = best; g_kd_d = t->dim; g_kd_X = t->X;
+    g_kd_split_dim = best;
+    g_kd_d = t->dim;
+    g_kd_X = t->X;
     qsort(t->idx + lo, hi - lo, sizeof(int), kd_cmp_fn);
     nd->split_dim = best;
     nd->split_val = t->X[t->idx[mid] * t->dim + best];
     int ln = t->n_nodes++, rn = t->n_nodes++;
-    nd->left = ln; nd->right = rn;
+    nd->left = ln;
+    nd->right = rn;
     kd_build(t, ln, lo, mid);
     kd_build(t, rn, mid, hi);
 }
 
-static KDTree kd_create(const float *X, int n, int dim)
+static KDTree kd_create(const float* X, int n, int dim)
 {
     KDTree t;
-    t.X = X; t.n = n; t.dim = dim; t.n_nodes = 1;
-    t.idx   = (int    *)malloc(n * sizeof(int));
-    t.nodes = (KDNode *)malloc(2 * n * sizeof(KDNode));
-    for (int i = 0; i < n; i++) t.idx[i] = i;
+    t.X = X;
+    t.n = n;
+    t.dim = dim;
+    t.n_nodes = 1;
+    t.idx = (int*)malloc(n * sizeof(int));
+    t.nodes = (KDNode*)malloc(2 * n * sizeof(KDNode));
+    for (int i = 0; i < n; i++)
+        t.idx[i] = i;
     kd_build(&t, 0, 0, n);
     return t;
 }
 
-static void kd_destroy(KDTree *t) { free(t->idx); free(t->nodes); }
-
-static void kd_query_ball(const KDTree *t, int node, const float *q,
-                           float r, float r2, int *out, int *cnt)
+static void kd_destroy(KDTree* t)
 {
-    const KDNode *nd = &t->nodes[node];
+    free(t->idx);
+    free(t->nodes);
+}
+
+static void kd_query_ball(const KDTree* t, int node, const float* q, float r,
+    float r2, int* out, int* cnt)
+{
+    const KDNode* nd = &t->nodes[node];
     if (nd->split_dim < 0) {
         for (int i = nd->lo; i < nd->hi; i++) {
-            int p = t->idx[i]; float sq = 0.0;
+            int p = t->idx[i];
+            float sq = 0.0;
             for (int k = 0; k < t->dim; k++) {
-                float df = q[k] - t->X[p * t->dim + k]; sq += df * df;
+                float df = q[k] - t->X[p * t->dim + k];
+                sq += df * df;
             }
-            if (sq <= r2) out[(*cnt)++] = p;
+            if (sq <= r2)
+                out[(*cnt)++] = p;
         }
         return;
     }
     float dv = q[nd->split_dim] - nd->split_val;
-    if (nd->left  >= 0 && dv <=  r) kd_query_ball(t, nd->left,  q, r, r2, out, cnt);
-    if (nd->right >= 0 && dv >= -r) kd_query_ball(t, nd->right, q, r, r2, out, cnt);
+    if (nd->left >= 0 && dv <= r)
+        kd_query_ball(t, nd->left, q, r, r2, out, cnt);
+    if (nd->right >= 0 && dv >= -r)
+        kd_query_ball(t, nd->right, q, r, r2, out, cnt);
 }
 
-static int gp_filter_near_duplicates(const float *X, int n, int dim,
-                                        float threshold, int *kept_indices)
+static int gp_filter_near_duplicates(const float* X, int n, int dim,
+    float threshold, int* kept_indices)
 {
-    if (n <= 0) return 0;
-    if (n == 1) { kept_indices[0] = 0; return 1; }
+    if (n <= 0)
+        return 0;
+    if (n == 1) {
+        kept_indices[0] = 0;
+        return 1;
+    }
 
-    KDTree tree   = kd_create(X, n, dim);
-    int   *keep   = (int *)malloc(n * sizeof(int));
-    int   *nearby = (int *)malloc(n * sizeof(int));
-    float r2     = threshold * threshold;
-    for (int i = 0; i < n; i++) keep[i] = 1;
+    KDTree tree = kd_create(X, n, dim);
+    int* keep = (int*)malloc(n * sizeof(int));
+    int* nearby = (int*)malloc(n * sizeof(int));
+    float r2 = threshold * threshold;
+    for (int i = 0; i < n; i++)
+        keep[i] = 1;
 
     for (int i = n - 1; i >= 0; i--) {
-        if (!keep[i]) continue;
+        if (!keep[i])
+            continue;
         int cnt = 0;
         kd_query_ball(&tree, 0, &X[(size_t)i * dim], threshold, r2, nearby, &cnt);
         for (int j = 0; j < cnt; j++)
-            if (nearby[j] != i) keep[nearby[j]] = 0;
+            if (nearby[j] != i)
+                keep[nearby[j]] = 0;
     }
 
     int count = 0;
     for (int i = 0; i < n; i++)
-        if (keep[i]) kept_indices[count++] = i;
+        if (keep[i])
+            kept_indices[count++] = i;
 
-    free(nearby); free(keep); kd_destroy(&tree);
+    free(nearby);
+    free(keep);
+    kd_destroy(&tree);
     return count;
 }
 
 // -- hyperparameter access ---------------------------------------------------
 
-float gp_get_noise(const GaussianProcess *gp) { return softplus(gp->raw_noise);   }
-void   gp_set_noise(GaussianProcess *gp, float v) { gp->raw_noise = inv_softplus(v); }
+float gp_get_noise(const GaussianProcess* gp)
+{
+    return softplus(gp->raw_noise);
+}
+void gp_set_noise(GaussianProcess* gp, float v)
+{
+    gp->raw_noise = inv_softplus(v);
+}
 
 // -- lifecycle ---------------------------------------------------------------
 
-GaussianProcess *gp_create(int dim, int cap, GPKernel *kernel, float noise)
+GaussianProcess* gp_create(int dim, int cap, GPKernel* kernel, float noise)
 {
-    GaussianProcess *gp  = (GaussianProcess *)calloc(1, sizeof(GaussianProcess));
-    gp->dim   = dim;
-    gp->cap   = cap;
+    GaussianProcess* gp = (GaussianProcess*)calloc(1, sizeof(GaussianProcess));
+    gp->dim = dim;
+    gp->cap = cap;
     gp->kernel = kernel;
     gp_set_noise(gp, noise);
-    CUDA_CHECK(cudaMalloc(&gp->d_X,     (size_t)cap * dim * sizeof(float)));
-    CUDA_CHECK(cudaMalloc(&gp->d_y,     (size_t)cap       * sizeof(float)));
-    CUDA_CHECK(cudaMalloc(&gp->d_L,     (size_t)cap * cap * sizeof(float)));
-    CUDA_CHECK(cudaMalloc(&gp->d_alpha, (size_t)cap       * sizeof(float)));
-    CUDA_CHECK(cudaMalloc(&gp->d_info,  sizeof(int)));
-    CUBLAS_CHECK  (cublasCreate    (&gp->cublas));
+    CUDA_CHECK(cudaMalloc(&gp->d_X, (size_t)cap * dim * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_y, (size_t)cap * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_L, (size_t)cap * cap * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_alpha, (size_t)cap * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_info, sizeof(int)));
+    CUBLAS_CHECK(cublasCreate(&gp->cublas));
     CUSOLVER_CHECK(cusolverDnCreate(&gp->cusolver));
     return gp;
 }
 
-void gp_destroy(GaussianProcess *gp)
+void gp_destroy(GaussianProcess* gp)
 {
-    if (!gp) return;
-    cudaFree(gp->d_X); cudaFree(gp->d_y);
-    cudaFree(gp->d_L); cudaFree(gp->d_alpha);
-    cudaFree(gp->d_work); cudaFree(gp->d_info);
-    cublasDestroy    (gp->cublas);
+    if (!gp)
+        return;
+    cudaFree(gp->d_X);
+    cudaFree(gp->d_y);
+    cudaFree(gp->d_L);
+    cudaFree(gp->d_alpha);
+    cudaFree(gp->d_work);
+    cudaFree(gp->d_info);
+    cublasDestroy(gp->cublas);
     cusolverDnDestroy(gp->cusolver);
-    if (gp->kernel && gp->kernel->destroy) gp->kernel->destroy(gp->kernel);
+    if (gp->kernel && gp->kernel->destroy)
+        gp->kernel->destroy(gp->kernel);
     free(gp);
 }
 
 // -- internal helpers --------------------------------------------------------
 
-static int run_potrf(GaussianProcess *gp, float *d_K, int n, cudaStream_t stream)
+static int run_potrf(GaussianProcess* gp, float* d_K, int n,
+    cudaStream_t stream)
 {
     CUSOLVER_CHECK(cusolverDnSetStream(gp->cusolver, stream));
     int lwork = 0;
@@ -242,84 +307,83 @@ static int run_potrf(GaussianProcess *gp, float *d_K, int n, cudaStream_t stream
         CUDA_CHECK(cudaMalloc(&gp->d_work, (size_t)lwork * sizeof(float)));
         gp->lwork = lwork;
     }
-    CUSOLVER_CHECK(cusolverDnSpotrf(
-        gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K, n,
-        gp->d_work, gp->lwork, gp->d_info));
+    CUSOLVER_CHECK(cusolverDnSpotrf(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K,
+        n, gp->d_work, gp->lwork, gp->d_info));
 
     int h_info;
     CUDA_CHECK(cudaMemcpyAsync(&h_info, gp->d_info, sizeof(int),
-                               cudaMemcpyDeviceToHost, stream));
+        cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaStreamSynchronize(stream));
     return h_info;
 }
 
-static void solve_alpha(GaussianProcess *gp, const float *d_L, int n, float *d_alpha,
-                        cudaStream_t stream)
+static void solve_alpha(GaussianProcess* gp, const float* d_L, int n,
+    float* d_alpha, cudaStream_t stream)
 {
     CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
-    CUBLAS_CHECK(cublasStrsv(gp->cublas,
-        CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N, CUBLAS_DIAG_NON_UNIT,
-        n, d_L, n, d_alpha, 1));
-    CUBLAS_CHECK(cublasStrsv(gp->cublas,
-        CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_T, CUBLAS_DIAG_NON_UNIT,
-        n, d_L, n, d_alpha, 1));
+    CUBLAS_CHECK(cublasStrsv(gp->cublas, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
+        CUBLAS_DIAG_NON_UNIT, n, d_L, n, d_alpha, 1));
+    CUBLAS_CHECK(cublasStrsv(gp->cublas, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_T,
+        CUBLAS_DIAG_NON_UNIT, n, d_L, n, d_alpha, 1));
 }
 
 // -- training ----------------------------------------------------------------
 
-int gp_recompute(GaussianProcess *gp, cudaStream_t stream)
+int gp_recompute(GaussianProcess* gp, cudaStream_t stream)
 {
     int n = gp->n;
-    if (n == 0) return 0;
+    if (n == 0)
+        return 0;
 
-    gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp), gp->d_L, stream);
+    gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp),
+        gp->d_L, stream);
 
     int info = run_potrf(gp, gp->d_L, n, stream);
     if (info != 0) {
-        gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp), gp->d_L, stream);
+        gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp),
+            gp->d_L, stream);
         gp_k_add_diag<<<(n + 255) / 256, 256, 0, stream>>>(gp->d_L, n, 1e-8);
         CUDA_CHECK(cudaGetLastError());
         info = run_potrf(gp, gp->d_L, n, stream);
-        if (info != 0) return -2;
+        if (info != 0)
+            return -2;
     }
 
-    CUDA_CHECK(cudaMemcpyAsync(gp->d_alpha, gp->d_y,
-                               (size_t)n * sizeof(float), cudaMemcpyDeviceToDevice, stream));
+    CUDA_CHECK(cudaMemcpyAsync(gp->d_alpha, gp->d_y, (size_t)n * sizeof(float),
+        cudaMemcpyDeviceToDevice, stream));
     solve_alpha(gp, gp->d_L, n, gp->d_alpha, stream);
     return 0;
 }
 
-int gp_fit(GaussianProcess *gp, const float *X, const float *y, int n, cudaStream_t stream)
+int gp_fit(GaussianProcess* gp, const float* X, const float* y, int n,
+    cudaStream_t stream)
 {
-    if (n > gp->cap) return -1;
+    if (n > gp->cap)
+        return -1;
 
     if (gp->dedup_threshold > 0.0 && n > 1) {
-        int    *idx    = (int *)malloc(n * sizeof(int));
-        int     n_kept = gp_filter_near_duplicates(X, n, gp->dim,
-                                                   gp->dedup_threshold, idx);
-        float *X_c    = (float *)malloc((size_t)n_kept * gp->dim * sizeof(float));
-        float *y_c    = (float *)malloc((size_t)n_kept * sizeof(float));
+        int* idx = (int*)malloc(n * sizeof(int));
+        int n_kept = gp_filter_near_duplicates(X, n, gp->dim, gp->dedup_threshold, idx);
+        float* X_c = (float*)malloc((size_t)n_kept * gp->dim * sizeof(float));
+        float* y_c = (float*)malloc((size_t)n_kept * sizeof(float));
         for (int i = 0; i < n_kept; i++) {
-            memcpy(&X_c[i * gp->dim], &X[idx[i] * gp->dim],
-                   gp->dim * sizeof(float));
+            memcpy(&X_c[i * gp->dim], &X[idx[i] * gp->dim], gp->dim * sizeof(float));
             y_c[i] = y[idx[i]];
         }
         free(idx);
         CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X_c,
-                                   (size_t)n_kept * gp->dim * sizeof(float),
-                                   cudaMemcpyHostToDevice, stream));
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y_c,
-                                   (size_t)n_kept * sizeof(float),
-                                   cudaMemcpyHostToDevice, stream));
-        free(X_c); free(y_c);
+            (size_t)n_kept * gp->dim * sizeof(float),
+            cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y_c, (size_t)n_kept * sizeof(float),
+            cudaMemcpyHostToDevice, stream));
+        free(X_c);
+        free(y_c);
         gp->n = n_kept;
     } else {
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X,
-                                   (size_t)n * gp->dim * sizeof(float),
-                                   cudaMemcpyHostToDevice, stream));
-        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y,
-                                   (size_t)n * sizeof(float),
-                                   cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X, (size_t)n * gp->dim * sizeof(float),
+            cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y, (size_t)n * sizeof(float),
+            cudaMemcpyHostToDevice, stream));
         gp->n = n;
     }
     return gp_recompute(gp, stream);
@@ -327,31 +391,34 @@ int gp_fit(GaussianProcess *gp, const float *X, const float *y, int n, cudaStrea
 
 // -- prediction --------------------------------------------------------------
 
-static void predict_dev(const GaussianProcess *gp, const float *d_Xte,
-                        float *d_means, float *d_vars, int m, cudaStream_t stream)
+static void predict_dev(const GaussianProcess* gp, const float* d_Xte,
+    float* d_means, float* d_vars, int m,
+    cudaStream_t stream)
 {
     int n = gp->n, d = gp->dim;
     const float one = 1.0, zero = 0.0;
     CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
 
-    float *d_Ks;
+    float* d_Ks;
     CUDA_CHECK(cudaMallocAsync(&d_Ks, (size_t)n * m * sizeof(float), stream));
     gp->kernel->build_Ks(gp->kernel, gp->d_X, d_Xte, n, m, d, d_Ks, stream);
 
-    CUBLAS_CHECK(cublasSgemv(gp->cublas, CUBLAS_OP_T, n, m,
-                             &one, d_Ks, n, gp->d_alpha, 1, &zero, d_means, 1));
+    CUBLAS_CHECK(cublasSgemv(gp->cublas, CUBLAS_OP_T, n, m, &one, d_Ks, n,
+        gp->d_alpha, 1, &zero, d_means, 1));
 
     if (d_vars) {
         gp->kernel->build_kself_batch(gp->kernel, d_Xte, m, d, d_vars, stream);
 
-        CUBLAS_CHECK(cublasStrsm(gp->cublas,
-            CUBLAS_SIDE_LEFT, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
+        CUBLAS_CHECK(cublasStrsm(
+            gp->cublas, CUBLAS_SIDE_LEFT, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
             CUBLAS_DIAG_NON_UNIT, n, m, &one, gp->d_L, n, d_Ks, n));
-        float *d_sqnorms;
+        float* d_sqnorms;
         CUDA_CHECK(cudaMallocAsync(&d_sqnorms, (size_t)m * sizeof(float), stream));
-        gp_k_col_sqnorms<<<(m + 255) / 256, 256, 0, stream>>>(d_Ks, d_sqnorms, n, m);
+        gp_k_col_sqnorms<<<(m + 255) / 256, 256, 0, stream>>>(d_Ks, d_sqnorms, n,
+            m);
         CUDA_CHECK(cudaGetLastError());
-        gp_k_var_subtract<<<(m + 255) / 256, 256, 0, stream>>>(d_vars, d_sqnorms, m);
+        gp_k_var_subtract<<<(m + 255) / 256, 256, 0, stream>>>(d_vars, d_sqnorms,
+            m);
         CUDA_CHECK(cudaGetLastError());
         CUDA_CHECK(cudaFreeAsync(d_sqnorms, stream));
     }
@@ -359,36 +426,39 @@ static void predict_dev(const GaussianProcess *gp, const float *d_Xte,
     CUDA_CHECK(cudaFreeAsync(d_Ks, stream));
 }
 
-void gp_predict(const GaussianProcess *gp, const float *Xs, float *means, float *vars,
-                  int m, cudaStream_t stream)
+void gp_predict(const GaussianProcess* gp, const float* Xs, float* means,
+    float* vars, int m, cudaStream_t stream)
 {
     int n = gp->n;
     if (n == 0) {
         for (int j = 0; j < m; j++) {
             means[j] = 0.0;
-            if (vars) vars[j] = gp->kernel->k_self(gp->kernel, &Xs[j * gp->dim], gp->dim);
+            if (vars)
+                vars[j] = gp->kernel->k_self(gp->kernel, &Xs[j * gp->dim], gp->dim);
         }
         return;
     }
 
-    float *d_Xte;
-    CUDA_CHECK(cudaMallocAsync(&d_Xte, (size_t)m * gp->dim * sizeof(float), stream));
+    float* d_Xte;
+    CUDA_CHECK(
+        cudaMallocAsync(&d_Xte, (size_t)m * gp->dim * sizeof(float), stream));
     CUDA_CHECK(cudaMemcpyAsync(d_Xte, Xs, (size_t)m * gp->dim * sizeof(float),
-                               cudaMemcpyHostToDevice, stream));
+        cudaMemcpyHostToDevice, stream));
 
     float *d_means, *d_vars = NULL;
     CUDA_CHECK(cudaMallocAsync(&d_means, (size_t)m * sizeof(float), stream));
-    if (vars) CUDA_CHECK(cudaMallocAsync(&d_vars, (size_t)m * sizeof(float), stream));
+    if (vars)
+        CUDA_CHECK(cudaMallocAsync(&d_vars, (size_t)m * sizeof(float), stream));
 
     predict_dev(gp, d_Xte, d_means, d_vars, m, stream);
     CUDA_CHECK(cudaFreeAsync(d_Xte, stream));
 
     CUDA_CHECK(cudaMemcpyAsync(means, d_means, (size_t)m * sizeof(float),
-                               cudaMemcpyDeviceToHost, stream));
+        cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaFreeAsync(d_means, stream));
     if (vars) {
         CUDA_CHECK(cudaMemcpyAsync(vars, d_vars, (size_t)m * sizeof(float),
-                                   cudaMemcpyDeviceToHost, stream));
+            cudaMemcpyDeviceToHost, stream));
         CUDA_CHECK(cudaFreeAsync(d_vars, stream));
     }
     CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -396,67 +466,75 @@ void gp_predict(const GaussianProcess *gp, const float *Xs, float *means, float 
 
 // -- likelihood and gradients ------------------------------------------------
 
-float gp_marginal_log_likelihood(const GaussianProcess *gp)
+float gp_marginal_log_likelihood(const GaussianProcess* gp)
 {
     int n = gp->n;
-    if (n == 0) return 0.0;
+    if (n == 0)
+        return 0.0;
 
     CUBLAS_CHECK(cublasSetStream(gp->cublas, 0));
     float data_fit;
-    CUBLAS_CHECK(cublasSdot(gp->cublas, n, gp->d_y, 1, gp->d_alpha, 1, &data_fit));
+    CUBLAS_CHECK(
+        cublasSdot(gp->cublas, n, gp->d_y, 1, gp->d_alpha, 1, &data_fit));
 
-    float *d_diag;
+    float* d_diag;
     CUDA_CHECK(cudaMalloc(&d_diag, (size_t)n * sizeof(float)));
     gp_k_extract_diag<<<(n + 255) / 256, 256>>>(gp->d_L, d_diag, n);
     CUDA_CHECK(cudaGetLastError());
 
-    float *h_diag = (float *)malloc(n * sizeof(float));
+    float* h_diag = (float*)malloc(n * sizeof(float));
     CUDA_CHECK(cudaMemcpy(h_diag, d_diag, (size_t)n * sizeof(float),
-                          cudaMemcpyDeviceToHost));
+        cudaMemcpyDeviceToHost));
     CUDA_CHECK(cudaFree(d_diag));
 
     float log_det = 0.0;
-    for (int i = 0; i < n; i++) log_det += log(h_diag[i]);
+    for (int i = 0; i < n; i++)
+        log_det += log(h_diag[i]);
     free(h_diag);
 
     return (-0.5 * data_fit - log_det - 0.5 * n * log(2.0 * M_PI)) / n;
 }
 
-void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_grads,
-                   cudaStream_t stream)
+void gp_mll_grad(const GaussianProcess* gp, float* d_raw_noise,
+    float* kernel_grads, cudaStream_t stream)
 {
     int n = gp->n;
     if (n == 0) {
-        if (d_raw_noise) *d_raw_noise = 0.0;
+        if (d_raw_noise)
+            *d_raw_noise = 0.0;
         if (kernel_grads)
-            for (int i = 0; i < gp->kernel->n_params; i++) kernel_grads[i] = 0.0;
+            for (int i = 0; i < gp->kernel->n_params; i++)
+                kernel_grads[i] = 0.0;
         return;
     }
 
     CUSOLVER_CHECK(cusolverDnSetStream(gp->cusolver, stream));
     CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
 
-    float *d_Kinv;
+    float* d_Kinv;
     CUDA_CHECK(cudaMallocAsync(&d_Kinv, (size_t)n * n * sizeof(float), stream));
     CUDA_CHECK(cudaMemsetAsync(d_Kinv, 0, (size_t)n * n * sizeof(float), stream));
     gp_k_add_diag<<<(n + 255) / 256, 256, 0, stream>>>(d_Kinv, n, 1.0);
     CUDA_CHECK(cudaGetLastError());
 
-    CUSOLVER_CHECK(cusolverDnSpotrs(gp->cusolver, CUBLAS_FILL_MODE_LOWER,
-                                    n, n, gp->d_L, n, d_Kinv, n, gp->d_info));
+    CUSOLVER_CHECK(cusolverDnSpotrs(gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, n,
+        gp->d_L, n, d_Kinv, n, gp->d_info));
 
     if (d_raw_noise) {
         float term1, term2;
-        CUBLAS_CHECK(cublasSdot (gp->cublas, n, gp->d_alpha, 1, gp->d_alpha, 1, &term1));
+        CUBLAS_CHECK(
+            cublasSdot(gp->cublas, n, gp->d_alpha, 1, gp->d_alpha, 1, &term1));
         CUBLAS_CHECK(cublasSasum(gp->cublas, n, d_Kinv, n + 1, &term2));
         *d_raw_noise = 0.5 * (term1 - term2) * softplus_grad(gp->raw_noise) / n;
     }
 
     if (kernel_grads) {
-        for (int i = 0; i < gp->kernel->n_params; i++) kernel_grads[i] = 0.0;
-        gp->kernel->mll_grad(gp->kernel, gp->d_X, n, gp->dim,
-                             gp->cublas, stream, gp->d_alpha, d_Kinv, kernel_grads);
-        for (int i = 0; i < gp->kernel->n_params; i++) kernel_grads[i] /= n;
+        for (int i = 0; i < gp->kernel->n_params; i++)
+            kernel_grads[i] = 0.0;
+        gp->kernel->mll_grad(gp->kernel, gp->d_X, n, gp->dim, gp->cublas, stream,
+            gp->d_alpha, d_Kinv, kernel_grads);
+        for (int i = 0; i < gp->kernel->n_params; i++)
+            kernel_grads[i] /= n;
     }
 
     CUDA_CHECK(cudaFreeAsync(d_Kinv, stream));
@@ -464,22 +542,24 @@ void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_gr
 
 // -- kernel registry for gp_load ---------------------------------------------
 
-typedef struct { const char *tag; GPKernel *(*make)(float *, int); } KernelFactory;
+typedef struct {
+    const char* tag;
+    GPKernel* (*make)(float*, int);
+} KernelFactory;
 
-static GPKernel *kf_matern32lin(float *rp, int np)
+static GPKernel* kf_matern32lin(float* rp, int np)
 {
     int dim = np - 2;
-    GPKernel *k = gp_kernel_matern32_linear(dim, 1.0, 1.0, 1.0);
+    GPKernel* k = gp_kernel_matern32_linear(dim, 1.0, 1.0, 1.0);
     memcpy(k->raw_params, rp, (size_t)np * sizeof(float));
     return k;
 }
 
 static const KernelFactory kernel_registry[] = {
-    { GP_KERNEL_TAG_MATERN32_LINEAR, kf_matern32lin },
-    { NULL, NULL }
+    { GP_KERNEL_TAG_MATERN32_LINEAR, kf_matern32lin }, { NULL, NULL }
 };
 
-static GPKernel *kernel_from_tag(const char *tag, float *rp, int np)
+static GPKernel* kernel_from_tag(const char* tag, float* rp, int np)
 {
     for (int i = 0; kernel_registry[i].tag; i++)
         if (memcmp(tag, kernel_registry[i].tag, 4) == 0)
@@ -489,103 +569,131 @@ static GPKernel *kernel_from_tag(const char *tag, float *rp, int np)
 
 // -- save / load -------------------------------------------------------------
 
-int gp_save(const GaussianProcess *gp, const char *path)
+int gp_save(const GaussianProcess* gp, const char* path)
 {
-    if (gp->n == 0) return -1;
+    if (gp->n == 0)
+        return -1;
     CUDA_CHECK(cudaDeviceSynchronize());
-    FILE *f = fopen(path, "wb");
-    if (!f) return -1;
+    FILE* f = fopen(path, "wb");
+    if (!f)
+        return -1;
 
     int n = gp->n, dim = gp->dim, np = gp->kernel->n_params;
-    fwrite("GC04",                  1,              4,  f);
-    fwrite(&dim,                    sizeof(int),    1,  f);
-    fwrite(&n,                      sizeof(int),    1,  f);
-    fwrite(&gp->raw_noise,          sizeof(float), 1,  f);
-    fwrite(gp->kernel->tag,         1,              4,  f);
-    fwrite(&np,                     sizeof(int),    1,  f);
-    fwrite(gp->kernel->raw_params,  sizeof(float), np, f);
+    fwrite("GC04", 1, 4, f);
+    fwrite(&dim, sizeof(int), 1, f);
+    fwrite(&n, sizeof(int), 1, f);
+    fwrite(&gp->raw_noise, sizeof(float), 1, f);
+    fwrite(gp->kernel->tag, 1, 4, f);
+    fwrite(&np, sizeof(int), 1, f);
+    fwrite(gp->kernel->raw_params, sizeof(float), np, f);
 
-    float *h_X     = (float *)malloc((size_t)n * dim * sizeof(float));
-    float *h_y     = (float *)malloc((size_t)n       * sizeof(float));
-    float *h_L     = (float *)malloc((size_t)n * n   * sizeof(float));
-    float *h_alpha = (float *)malloc((size_t)n       * sizeof(float));
-    CUDA_CHECK(cudaMemcpy(h_X,     gp->d_X,     (size_t)n * dim * sizeof(float), cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(h_y,     gp->d_y,     (size_t)n       * sizeof(float), cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(h_L,     gp->d_L,     (size_t)n * n   * sizeof(float), cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(h_alpha, gp->d_alpha, (size_t)n       * sizeof(float), cudaMemcpyDeviceToHost));
+    float* h_X = (float*)malloc((size_t)n * dim * sizeof(float));
+    float* h_y = (float*)malloc((size_t)n * sizeof(float));
+    float* h_L = (float*)malloc((size_t)n * n * sizeof(float));
+    float* h_alpha = (float*)malloc((size_t)n * sizeof(float));
+    CUDA_CHECK(cudaMemcpy(h_X, gp->d_X, (size_t)n * dim * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_y, gp->d_y, (size_t)n * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_L, gp->d_L, (size_t)n * n * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_alpha, gp->d_alpha, (size_t)n * sizeof(float),
+        cudaMemcpyDeviceToHost));
 
-    fwrite(h_X,     sizeof(float), (size_t)n * dim, f);
-    fwrite(h_y,     sizeof(float), n,               f);
-    fwrite(h_L,     sizeof(float), (size_t)n * n,   f);
-    fwrite(h_alpha, sizeof(float), n,               f);
+    fwrite(h_X, sizeof(float), (size_t)n * dim, f);
+    fwrite(h_y, sizeof(float), n, f);
+    fwrite(h_L, sizeof(float), (size_t)n * n, f);
+    fwrite(h_alpha, sizeof(float), n, f);
 
-    free(h_X); free(h_y); free(h_L); free(h_alpha);
+    free(h_X);
+    free(h_y);
+    free(h_L);
+    free(h_alpha);
     fclose(f);
     return 0;
 }
 
-GaussianProcess *gp_load(const char *path, int extra_cap)
+GaussianProcess* gp_load(const char* path, int extra_cap)
 {
-    GaussianProcess   *gp      = NULL;
-    float *h_X     = NULL, *h_y     = NULL;
-    float *h_L     = NULL, *h_alpha = NULL;
+    GaussianProcess* gp = NULL;
+    float *h_X = NULL, *h_y = NULL;
+    float *h_L = NULL, *h_alpha = NULL;
 
-    FILE *f = fopen(path, "rb");
-    if (!f) return NULL;
+    FILE* f = fopen(path, "rb");
+    if (!f)
+        return NULL;
 
-#define RD(ptr, sz, cnt) \
-    if (fread(ptr, sz, cnt, f) != (size_t)(cnt)) break
+#define RD(ptr, sz, cnt)                         \
+    if (fread(ptr, sz, cnt, f) != (size_t)(cnt)) \
+    break
 
     do {
-        char   magic[4], ktag[4];
-        int    dim, n, np;
+        char magic[4], ktag[4];
+        int dim, n, np;
         float rn;
 
         RD(magic, 1, 4);
-        if (memcmp(magic, "GC04", 4) != 0) break;
+        if (memcmp(magic, "GC04", 4) != 0)
+            break;
 
-        RD(&dim,  sizeof(int),    1);
-        RD(&n,    sizeof(int),    1);
-        RD(&rn,   sizeof(float), 1);
-        RD(ktag,  1, 4);
-        RD(&np,   sizeof(int),    1);
+        RD(&dim, sizeof(int), 1);
+        RD(&n, sizeof(int), 1);
+        RD(&rn, sizeof(float), 1);
+        RD(ktag, 1, 4);
+        RD(&np, sizeof(int), 1);
 
-        float *rp = (float *)malloc((size_t)np * sizeof(float));
-        if (!rp) break;
-        if (fread(rp, sizeof(float), np, f) != (size_t)np) { free(rp); break; }
+        float* rp = (float*)malloc((size_t)np * sizeof(float));
+        if (!rp)
+            break;
+        if (fread(rp, sizeof(float), np, f) != (size_t)np) {
+            free(rp);
+            break;
+        }
 
-        GPKernel *k = kernel_from_tag(ktag, rp, np);
+        GPKernel* k = kernel_from_tag(ktag, rp, np);
         free(rp);
-        if (!k) break;
+        if (!k)
+            break;
 
         int cap = n + (extra_cap > 0 ? extra_cap : 0);
         gp = gp_create(dim, cap, k, 1.0);
         gp->raw_noise = rn;
         gp->n = n;
 
-        h_X     = (float *)malloc((size_t)n * dim * sizeof(float));
-        h_y     = (float *)malloc((size_t)n       * sizeof(float));
-        h_L     = (float *)malloc((size_t)n * n   * sizeof(float));
-        h_alpha = (float *)malloc((size_t)n       * sizeof(float));
+        h_X = (float*)malloc((size_t)n * dim * sizeof(float));
+        h_y = (float*)malloc((size_t)n * sizeof(float));
+        h_L = (float*)malloc((size_t)n * n * sizeof(float));
+        h_alpha = (float*)malloc((size_t)n * sizeof(float));
 
-        RD(h_X,     sizeof(float), (size_t)n * dim);
-        RD(h_y,     sizeof(float), n);
-        RD(h_L,     sizeof(float), (size_t)n * n);
+        RD(h_X, sizeof(float), (size_t)n * dim);
+        RD(h_y, sizeof(float), n);
+        RD(h_L, sizeof(float), (size_t)n * n);
         RD(h_alpha, sizeof(float), n);
 
-        CUDA_CHECK(cudaMemcpy(gp->d_X,     h_X,     (size_t)n * dim * sizeof(float), cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(gp->d_y,     h_y,     (size_t)n       * sizeof(float), cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(gp->d_L,     h_L,     (size_t)n * n   * sizeof(float), cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(gp->d_alpha, h_alpha, (size_t)n       * sizeof(float), cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_X, h_X, (size_t)n * dim * sizeof(float),
+            cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_y, h_y, (size_t)n * sizeof(float),
+            cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_L, h_L, (size_t)n * n * sizeof(float),
+            cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_alpha, h_alpha, (size_t)n * sizeof(float),
+            cudaMemcpyHostToDevice));
 
-        free(h_X); free(h_y); free(h_L); free(h_alpha);
+        free(h_X);
+        free(h_y);
+        free(h_L);
+        free(h_alpha);
         fclose(f);
         return gp;
     } while (0);
 
 #undef RD
-    free(h_X); free(h_y); free(h_L); free(h_alpha);
-    if (gp) gp_destroy(gp);
+    free(h_X);
+    free(h_y);
+    free(h_L);
+    free(h_alpha);
+    if (gp)
+        gp_destroy(gp);
     fclose(f);
     return NULL;
 }

--- a/src/gp_cuda.cu
+++ b/src/gp_cuda.cu
@@ -1,0 +1,593 @@
+// Exact GP regression, CUDA (cuBLAS/cuSOLVER).
+
+#ifndef GP_CUDA_CU
+#define GP_CUDA_CU
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <cusolverDn.h>
+
+#include "gp_cuda_kernel.cu"
+
+#define CUSOLVER_CHECK(call) do { \
+    cusolverStatus_t _s = (call); \
+    if (_s != CUSOLVER_STATUS_SUCCESS) { \
+        fprintf(stderr, "cuSOLVER error %s:%d: %d\n", __FILE__, __LINE__, (int)_s); \
+        abort(); \
+    } \
+} while (0)
+
+// -- GaussianProcess struct -------------------------------------------------------------
+
+typedef struct {
+    int dim, n, cap;
+    float *d_X;
+    float *d_y;
+    float *d_L;
+    float *d_alpha;
+    float *d_work;
+    int lwork;
+    int *d_info;
+    float raw_noise;
+    float dedup_threshold;
+    cublasHandle_t cublas;
+    cusolverDnHandle_t cusolver;
+    GPKernel *kernel;
+} GaussianProcess;
+
+GaussianProcess *gp_create  (int dim, int cap, GPKernel *kernel, float noise);
+void  gp_destroy (GaussianProcess *gp);
+float gp_get_noise(const GaussianProcess *gp);
+void   gp_set_noise(GaussianProcess *gp, float v);
+int  gp_fit      (GaussianProcess *gp, const float *X, const float *y, int n, cudaStream_t stream);
+int  gp_recompute(GaussianProcess *gp, cudaStream_t stream);
+void gp_predict(const GaussianProcess *gp, const float *Xs,
+                  float *means, float *vars, int m, cudaStream_t stream);
+float gp_marginal_log_likelihood(const GaussianProcess *gp);
+void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_grads,
+                   cudaStream_t stream);
+int   gp_save(const GaussianProcess *gp, const char *path);
+GaussianProcess *gp_load(const char *path, int extra_cap);
+
+// -- utility device kernels --------------------------------------------------
+
+__global__ void gp_k_add_diag(float *A, int n, float val)
+{
+    int i = blockIdx.x * 256 + threadIdx.x;
+    if (i < n) A[(size_t)i * (n + 1)] += val;
+}
+
+__global__ void gp_k_extract_diag(const float *A, float *d, int n)
+{
+    int i = blockIdx.x * 256 + threadIdx.x;
+    if (i < n) d[i] = A[(size_t)i * (n + 1)];
+}
+
+__global__ void gp_k_col_sqnorms(const float *V, float *sqnorms, int n, int m)
+{
+    int j = blockIdx.x * 256 + threadIdx.x;
+    if (j >= m) return;
+    float sq = 0.0;
+    const float *col = V + (size_t)j * n;
+    for (int i = 0; i < n; i++) sq += col[i] * col[i];
+    sqnorms[j] = sq;
+}
+
+__global__ void gp_k_var_subtract(float *vars, const float *sqnorms, int m)
+{
+    int j = blockIdx.x * 256 + threadIdx.x;
+    if (j >= m) return;
+    float v = vars[j] - sqnorms[j];
+    vars[j] = v > 0.0 ? v : 0.0;
+}
+
+// -- host-side near-duplicate filter -----------------------------------------
+
+#define KD_LEAF 16
+
+typedef struct { int lo, hi, left, right, split_dim; float split_val; } KDNode;
+typedef struct { const float *X; int n, dim, n_nodes; int *idx; KDNode *nodes; } KDTree;
+
+static int          g_kd_split_dim, g_kd_d;
+static const float *g_kd_X;
+
+static int kd_cmp_fn(const void *a, const void *b)
+{
+    float va = g_kd_X[*(const int *)a * g_kd_d + g_kd_split_dim];
+    float vb = g_kd_X[*(const int *)b * g_kd_d + g_kd_split_dim];
+    return (va > vb) - (va < vb);
+}
+
+static void kd_build(KDTree *t, int node, int lo, int hi)
+{
+    KDNode *nd = &t->nodes[node];
+    nd->lo = lo; nd->hi = hi; nd->left = nd->right = -1; nd->split_dim = -1;
+    if (hi - lo <= KD_LEAF) return;
+
+    int best = 0; float spread = -1.0;
+    for (int k = 0; k < t->dim; k++) {
+        float mn = t->X[t->idx[lo] * t->dim + k], mx = mn;
+        for (int i = lo + 1; i < hi; i++) {
+            float v = t->X[t->idx[i] * t->dim + k];
+            if (v < mn) mn = v;
+            if (v > mx) mx = v;
+        }
+        if (mx - mn > spread) { spread = mx - mn; best = k; }
+    }
+    int mid = (lo + hi) / 2;
+    g_kd_split_dim = best; g_kd_d = t->dim; g_kd_X = t->X;
+    qsort(t->idx + lo, hi - lo, sizeof(int), kd_cmp_fn);
+    nd->split_dim = best;
+    nd->split_val = t->X[t->idx[mid] * t->dim + best];
+    int ln = t->n_nodes++, rn = t->n_nodes++;
+    nd->left = ln; nd->right = rn;
+    kd_build(t, ln, lo, mid);
+    kd_build(t, rn, mid, hi);
+}
+
+static KDTree kd_create(const float *X, int n, int dim)
+{
+    KDTree t;
+    t.X = X; t.n = n; t.dim = dim; t.n_nodes = 1;
+    t.idx   = (int    *)malloc(n * sizeof(int));
+    t.nodes = (KDNode *)malloc(2 * n * sizeof(KDNode));
+    for (int i = 0; i < n; i++) t.idx[i] = i;
+    kd_build(&t, 0, 0, n);
+    return t;
+}
+
+static void kd_destroy(KDTree *t) { free(t->idx); free(t->nodes); }
+
+static void kd_query_ball(const KDTree *t, int node, const float *q,
+                           float r, float r2, int *out, int *cnt)
+{
+    const KDNode *nd = &t->nodes[node];
+    if (nd->split_dim < 0) {
+        for (int i = nd->lo; i < nd->hi; i++) {
+            int p = t->idx[i]; float sq = 0.0;
+            for (int k = 0; k < t->dim; k++) {
+                float df = q[k] - t->X[p * t->dim + k]; sq += df * df;
+            }
+            if (sq <= r2) out[(*cnt)++] = p;
+        }
+        return;
+    }
+    float dv = q[nd->split_dim] - nd->split_val;
+    if (nd->left  >= 0 && dv <=  r) kd_query_ball(t, nd->left,  q, r, r2, out, cnt);
+    if (nd->right >= 0 && dv >= -r) kd_query_ball(t, nd->right, q, r, r2, out, cnt);
+}
+
+static int gp_filter_near_duplicates(const float *X, int n, int dim,
+                                        float threshold, int *kept_indices)
+{
+    if (n <= 0) return 0;
+    if (n == 1) { kept_indices[0] = 0; return 1; }
+
+    KDTree tree   = kd_create(X, n, dim);
+    int   *keep   = (int *)malloc(n * sizeof(int));
+    int   *nearby = (int *)malloc(n * sizeof(int));
+    float r2     = threshold * threshold;
+    for (int i = 0; i < n; i++) keep[i] = 1;
+
+    for (int i = n - 1; i >= 0; i--) {
+        if (!keep[i]) continue;
+        int cnt = 0;
+        kd_query_ball(&tree, 0, &X[(size_t)i * dim], threshold, r2, nearby, &cnt);
+        for (int j = 0; j < cnt; j++)
+            if (nearby[j] != i) keep[nearby[j]] = 0;
+    }
+
+    int count = 0;
+    for (int i = 0; i < n; i++)
+        if (keep[i]) kept_indices[count++] = i;
+
+    free(nearby); free(keep); kd_destroy(&tree);
+    return count;
+}
+
+// -- hyperparameter access ---------------------------------------------------
+
+float gp_get_noise(const GaussianProcess *gp) { return softplus(gp->raw_noise);   }
+void   gp_set_noise(GaussianProcess *gp, float v) { gp->raw_noise = inv_softplus(v); }
+
+// -- lifecycle ---------------------------------------------------------------
+
+GaussianProcess *gp_create(int dim, int cap, GPKernel *kernel, float noise)
+{
+    GaussianProcess *gp  = (GaussianProcess *)calloc(1, sizeof(GaussianProcess));
+    gp->dim   = dim;
+    gp->cap   = cap;
+    gp->kernel = kernel;
+    gp_set_noise(gp, noise);
+    CUDA_CHECK(cudaMalloc(&gp->d_X,     (size_t)cap * dim * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_y,     (size_t)cap       * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_L,     (size_t)cap * cap * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_alpha, (size_t)cap       * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&gp->d_info,  sizeof(int)));
+    CUBLAS_CHECK  (cublasCreate    (&gp->cublas));
+    CUSOLVER_CHECK(cusolverDnCreate(&gp->cusolver));
+    return gp;
+}
+
+void gp_destroy(GaussianProcess *gp)
+{
+    if (!gp) return;
+    cudaFree(gp->d_X); cudaFree(gp->d_y);
+    cudaFree(gp->d_L); cudaFree(gp->d_alpha);
+    cudaFree(gp->d_work); cudaFree(gp->d_info);
+    cublasDestroy    (gp->cublas);
+    cusolverDnDestroy(gp->cusolver);
+    if (gp->kernel && gp->kernel->destroy) gp->kernel->destroy(gp->kernel);
+    free(gp);
+}
+
+// -- internal helpers --------------------------------------------------------
+
+static int run_potrf(GaussianProcess *gp, float *d_K, int n, cudaStream_t stream)
+{
+    CUSOLVER_CHECK(cusolverDnSetStream(gp->cusolver, stream));
+    int lwork = 0;
+    CUSOLVER_CHECK(cusolverDnSpotrf_bufferSize(
+        gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K, n, &lwork));
+    if (lwork > gp->lwork) {
+        cudaFree(gp->d_work);
+        CUDA_CHECK(cudaMalloc(&gp->d_work, (size_t)lwork * sizeof(float)));
+        gp->lwork = lwork;
+    }
+    CUSOLVER_CHECK(cusolverDnSpotrf(
+        gp->cusolver, CUBLAS_FILL_MODE_LOWER, n, d_K, n,
+        gp->d_work, gp->lwork, gp->d_info));
+
+    int h_info;
+    CUDA_CHECK(cudaMemcpyAsync(&h_info, gp->d_info, sizeof(int),
+                               cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+    return h_info;
+}
+
+static void solve_alpha(GaussianProcess *gp, const float *d_L, int n, float *d_alpha,
+                        cudaStream_t stream)
+{
+    CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
+    CUBLAS_CHECK(cublasStrsv(gp->cublas,
+        CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N, CUBLAS_DIAG_NON_UNIT,
+        n, d_L, n, d_alpha, 1));
+    CUBLAS_CHECK(cublasStrsv(gp->cublas,
+        CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_T, CUBLAS_DIAG_NON_UNIT,
+        n, d_L, n, d_alpha, 1));
+}
+
+// -- training ----------------------------------------------------------------
+
+int gp_recompute(GaussianProcess *gp, cudaStream_t stream)
+{
+    int n = gp->n;
+    if (n == 0) return 0;
+
+    gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp), gp->d_L, stream);
+
+    int info = run_potrf(gp, gp->d_L, n, stream);
+    if (info != 0) {
+        gp->kernel->build_K(gp->kernel, gp->d_X, n, gp->dim, gp_get_noise(gp), gp->d_L, stream);
+        gp_k_add_diag<<<(n + 255) / 256, 256, 0, stream>>>(gp->d_L, n, 1e-8);
+        CUDA_CHECK(cudaGetLastError());
+        info = run_potrf(gp, gp->d_L, n, stream);
+        if (info != 0) return -2;
+    }
+
+    CUDA_CHECK(cudaMemcpyAsync(gp->d_alpha, gp->d_y,
+                               (size_t)n * sizeof(float), cudaMemcpyDeviceToDevice, stream));
+    solve_alpha(gp, gp->d_L, n, gp->d_alpha, stream);
+    return 0;
+}
+
+int gp_fit(GaussianProcess *gp, const float *X, const float *y, int n, cudaStream_t stream)
+{
+    if (n > gp->cap) return -1;
+
+    if (gp->dedup_threshold > 0.0 && n > 1) {
+        int    *idx    = (int *)malloc(n * sizeof(int));
+        int     n_kept = gp_filter_near_duplicates(X, n, gp->dim,
+                                                   gp->dedup_threshold, idx);
+        float *X_c    = (float *)malloc((size_t)n_kept * gp->dim * sizeof(float));
+        float *y_c    = (float *)malloc((size_t)n_kept * sizeof(float));
+        for (int i = 0; i < n_kept; i++) {
+            memcpy(&X_c[i * gp->dim], &X[idx[i] * gp->dim],
+                   gp->dim * sizeof(float));
+            y_c[i] = y[idx[i]];
+        }
+        free(idx);
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X_c,
+                                   (size_t)n_kept * gp->dim * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y_c,
+                                   (size_t)n_kept * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream));
+        free(X_c); free(y_c);
+        gp->n = n_kept;
+    } else {
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_X, X,
+                                   (size_t)n * gp->dim * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(gp->d_y, y,
+                                   (size_t)n * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream));
+        gp->n = n;
+    }
+    return gp_recompute(gp, stream);
+}
+
+// -- prediction --------------------------------------------------------------
+
+static void predict_dev(const GaussianProcess *gp, const float *d_Xte,
+                        float *d_means, float *d_vars, int m, cudaStream_t stream)
+{
+    int n = gp->n, d = gp->dim;
+    const float one = 1.0, zero = 0.0;
+    CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
+
+    float *d_Ks;
+    CUDA_CHECK(cudaMallocAsync(&d_Ks, (size_t)n * m * sizeof(float), stream));
+    gp->kernel->build_Ks(gp->kernel, gp->d_X, d_Xte, n, m, d, d_Ks, stream);
+
+    CUBLAS_CHECK(cublasSgemv(gp->cublas, CUBLAS_OP_T, n, m,
+                             &one, d_Ks, n, gp->d_alpha, 1, &zero, d_means, 1));
+
+    if (d_vars) {
+        gp->kernel->build_kself_batch(gp->kernel, d_Xte, m, d, d_vars, stream);
+
+        CUBLAS_CHECK(cublasStrsm(gp->cublas,
+            CUBLAS_SIDE_LEFT, CUBLAS_FILL_MODE_LOWER, CUBLAS_OP_N,
+            CUBLAS_DIAG_NON_UNIT, n, m, &one, gp->d_L, n, d_Ks, n));
+        float *d_sqnorms;
+        CUDA_CHECK(cudaMallocAsync(&d_sqnorms, (size_t)m * sizeof(float), stream));
+        gp_k_col_sqnorms<<<(m + 255) / 256, 256, 0, stream>>>(d_Ks, d_sqnorms, n, m);
+        CUDA_CHECK(cudaGetLastError());
+        gp_k_var_subtract<<<(m + 255) / 256, 256, 0, stream>>>(d_vars, d_sqnorms, m);
+        CUDA_CHECK(cudaGetLastError());
+        CUDA_CHECK(cudaFreeAsync(d_sqnorms, stream));
+    }
+
+    CUDA_CHECK(cudaFreeAsync(d_Ks, stream));
+}
+
+void gp_predict(const GaussianProcess *gp, const float *Xs, float *means, float *vars,
+                  int m, cudaStream_t stream)
+{
+    int n = gp->n;
+    if (n == 0) {
+        for (int j = 0; j < m; j++) {
+            means[j] = 0.0;
+            if (vars) vars[j] = gp->kernel->k_self(gp->kernel, &Xs[j * gp->dim], gp->dim);
+        }
+        return;
+    }
+
+    float *d_Xte;
+    CUDA_CHECK(cudaMallocAsync(&d_Xte, (size_t)m * gp->dim * sizeof(float), stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_Xte, Xs, (size_t)m * gp->dim * sizeof(float),
+                               cudaMemcpyHostToDevice, stream));
+
+    float *d_means, *d_vars = NULL;
+    CUDA_CHECK(cudaMallocAsync(&d_means, (size_t)m * sizeof(float), stream));
+    if (vars) CUDA_CHECK(cudaMallocAsync(&d_vars, (size_t)m * sizeof(float), stream));
+
+    predict_dev(gp, d_Xte, d_means, d_vars, m, stream);
+    CUDA_CHECK(cudaFreeAsync(d_Xte, stream));
+
+    CUDA_CHECK(cudaMemcpyAsync(means, d_means, (size_t)m * sizeof(float),
+                               cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaFreeAsync(d_means, stream));
+    if (vars) {
+        CUDA_CHECK(cudaMemcpyAsync(vars, d_vars, (size_t)m * sizeof(float),
+                                   cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK(cudaFreeAsync(d_vars, stream));
+    }
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+}
+
+// -- likelihood and gradients ------------------------------------------------
+
+float gp_marginal_log_likelihood(const GaussianProcess *gp)
+{
+    int n = gp->n;
+    if (n == 0) return 0.0;
+
+    CUBLAS_CHECK(cublasSetStream(gp->cublas, 0));
+    float data_fit;
+    CUBLAS_CHECK(cublasSdot(gp->cublas, n, gp->d_y, 1, gp->d_alpha, 1, &data_fit));
+
+    float *d_diag;
+    CUDA_CHECK(cudaMalloc(&d_diag, (size_t)n * sizeof(float)));
+    gp_k_extract_diag<<<(n + 255) / 256, 256>>>(gp->d_L, d_diag, n);
+    CUDA_CHECK(cudaGetLastError());
+
+    float *h_diag = (float *)malloc(n * sizeof(float));
+    CUDA_CHECK(cudaMemcpy(h_diag, d_diag, (size_t)n * sizeof(float),
+                          cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaFree(d_diag));
+
+    float log_det = 0.0;
+    for (int i = 0; i < n; i++) log_det += log(h_diag[i]);
+    free(h_diag);
+
+    return (-0.5 * data_fit - log_det - 0.5 * n * log(2.0 * M_PI)) / n;
+}
+
+void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_grads,
+                   cudaStream_t stream)
+{
+    int n = gp->n;
+    if (n == 0) {
+        if (d_raw_noise) *d_raw_noise = 0.0;
+        if (kernel_grads)
+            for (int i = 0; i < gp->kernel->n_params; i++) kernel_grads[i] = 0.0;
+        return;
+    }
+
+    CUSOLVER_CHECK(cusolverDnSetStream(gp->cusolver, stream));
+    CUBLAS_CHECK(cublasSetStream(gp->cublas, stream));
+
+    float *d_Kinv;
+    CUDA_CHECK(cudaMallocAsync(&d_Kinv, (size_t)n * n * sizeof(float), stream));
+    CUDA_CHECK(cudaMemsetAsync(d_Kinv, 0, (size_t)n * n * sizeof(float), stream));
+    gp_k_add_diag<<<(n + 255) / 256, 256, 0, stream>>>(d_Kinv, n, 1.0);
+    CUDA_CHECK(cudaGetLastError());
+
+    CUSOLVER_CHECK(cusolverDnSpotrs(gp->cusolver, CUBLAS_FILL_MODE_LOWER,
+                                    n, n, gp->d_L, n, d_Kinv, n, gp->d_info));
+
+    if (d_raw_noise) {
+        float term1, term2;
+        CUBLAS_CHECK(cublasSdot (gp->cublas, n, gp->d_alpha, 1, gp->d_alpha, 1, &term1));
+        CUBLAS_CHECK(cublasSasum(gp->cublas, n, d_Kinv, n + 1, &term2));
+        *d_raw_noise = 0.5 * (term1 - term2) * softplus_grad(gp->raw_noise) / n;
+    }
+
+    if (kernel_grads) {
+        for (int i = 0; i < gp->kernel->n_params; i++) kernel_grads[i] = 0.0;
+        gp->kernel->mll_grad(gp->kernel, gp->d_X, n, gp->dim,
+                             gp->cublas, stream, gp->d_alpha, d_Kinv, kernel_grads);
+        for (int i = 0; i < gp->kernel->n_params; i++) kernel_grads[i] /= n;
+    }
+
+    CUDA_CHECK(cudaFreeAsync(d_Kinv, stream));
+}
+
+// -- kernel registry for gp_load ---------------------------------------------
+
+typedef struct { const char *tag; GPKernel *(*make)(float *, int); } KernelFactory;
+
+static GPKernel *kf_matern32lin(float *rp, int np)
+{
+    int dim = np - 2;
+    GPKernel *k = gp_kernel_matern32_linear(dim, 1.0, 1.0, 1.0);
+    memcpy(k->raw_params, rp, (size_t)np * sizeof(float));
+    return k;
+}
+
+static const KernelFactory kernel_registry[] = {
+    { GP_KERNEL_TAG_MATERN32_LINEAR, kf_matern32lin },
+    { NULL, NULL }
+};
+
+static GPKernel *kernel_from_tag(const char *tag, float *rp, int np)
+{
+    for (int i = 0; kernel_registry[i].tag; i++)
+        if (memcmp(tag, kernel_registry[i].tag, 4) == 0)
+            return kernel_registry[i].make(rp, np);
+    return NULL;
+}
+
+// -- save / load -------------------------------------------------------------
+
+int gp_save(const GaussianProcess *gp, const char *path)
+{
+    if (gp->n == 0) return -1;
+    CUDA_CHECK(cudaDeviceSynchronize());
+    FILE *f = fopen(path, "wb");
+    if (!f) return -1;
+
+    int n = gp->n, dim = gp->dim, np = gp->kernel->n_params;
+    fwrite("GC04",                  1,              4,  f);
+    fwrite(&dim,                    sizeof(int),    1,  f);
+    fwrite(&n,                      sizeof(int),    1,  f);
+    fwrite(&gp->raw_noise,          sizeof(float), 1,  f);
+    fwrite(gp->kernel->tag,         1,              4,  f);
+    fwrite(&np,                     sizeof(int),    1,  f);
+    fwrite(gp->kernel->raw_params,  sizeof(float), np, f);
+
+    float *h_X     = (float *)malloc((size_t)n * dim * sizeof(float));
+    float *h_y     = (float *)malloc((size_t)n       * sizeof(float));
+    float *h_L     = (float *)malloc((size_t)n * n   * sizeof(float));
+    float *h_alpha = (float *)malloc((size_t)n       * sizeof(float));
+    CUDA_CHECK(cudaMemcpy(h_X,     gp->d_X,     (size_t)n * dim * sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_y,     gp->d_y,     (size_t)n       * sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_L,     gp->d_L,     (size_t)n * n   * sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_alpha, gp->d_alpha, (size_t)n       * sizeof(float), cudaMemcpyDeviceToHost));
+
+    fwrite(h_X,     sizeof(float), (size_t)n * dim, f);
+    fwrite(h_y,     sizeof(float), n,               f);
+    fwrite(h_L,     sizeof(float), (size_t)n * n,   f);
+    fwrite(h_alpha, sizeof(float), n,               f);
+
+    free(h_X); free(h_y); free(h_L); free(h_alpha);
+    fclose(f);
+    return 0;
+}
+
+GaussianProcess *gp_load(const char *path, int extra_cap)
+{
+    GaussianProcess   *gp      = NULL;
+    float *h_X     = NULL, *h_y     = NULL;
+    float *h_L     = NULL, *h_alpha = NULL;
+
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+
+#define RD(ptr, sz, cnt) \
+    if (fread(ptr, sz, cnt, f) != (size_t)(cnt)) break
+
+    do {
+        char   magic[4], ktag[4];
+        int    dim, n, np;
+        float rn;
+
+        RD(magic, 1, 4);
+        if (memcmp(magic, "GC04", 4) != 0) break;
+
+        RD(&dim,  sizeof(int),    1);
+        RD(&n,    sizeof(int),    1);
+        RD(&rn,   sizeof(float), 1);
+        RD(ktag,  1, 4);
+        RD(&np,   sizeof(int),    1);
+
+        float *rp = (float *)malloc((size_t)np * sizeof(float));
+        if (!rp) break;
+        if (fread(rp, sizeof(float), np, f) != (size_t)np) { free(rp); break; }
+
+        GPKernel *k = kernel_from_tag(ktag, rp, np);
+        free(rp);
+        if (!k) break;
+
+        int cap = n + (extra_cap > 0 ? extra_cap : 0);
+        gp = gp_create(dim, cap, k, 1.0);
+        gp->raw_noise = rn;
+        gp->n = n;
+
+        h_X     = (float *)malloc((size_t)n * dim * sizeof(float));
+        h_y     = (float *)malloc((size_t)n       * sizeof(float));
+        h_L     = (float *)malloc((size_t)n * n   * sizeof(float));
+        h_alpha = (float *)malloc((size_t)n       * sizeof(float));
+
+        RD(h_X,     sizeof(float), (size_t)n * dim);
+        RD(h_y,     sizeof(float), n);
+        RD(h_L,     sizeof(float), (size_t)n * n);
+        RD(h_alpha, sizeof(float), n);
+
+        CUDA_CHECK(cudaMemcpy(gp->d_X,     h_X,     (size_t)n * dim * sizeof(float), cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_y,     h_y,     (size_t)n       * sizeof(float), cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_L,     h_L,     (size_t)n * n   * sizeof(float), cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(gp->d_alpha, h_alpha, (size_t)n       * sizeof(float), cudaMemcpyHostToDevice));
+
+        free(h_X); free(h_y); free(h_L); free(h_alpha);
+        fclose(f);
+        return gp;
+    } while (0);
+
+#undef RD
+    free(h_X); free(h_y); free(h_L); free(h_alpha);
+    if (gp) gp_destroy(gp);
+    fclose(f);
+    return NULL;
+}
+
+#endif // GP_CUDA_CU

--- a/src/gp_cuda.cu
+++ b/src/gp_cuda.cu
@@ -40,20 +40,6 @@ typedef struct {
     GPKernel *kernel;
 } GaussianProcess;
 
-GaussianProcess *gp_create(int dim, int cap, GPKernel *kernel, float noise);
-void gp_destroy(GaussianProcess *gp);
-float gp_get_noise(const GaussianProcess *gp);
-void gp_set_noise(GaussianProcess *gp, float v);
-int gp_fit(GaussianProcess *gp, const float *X, const float *y, int n, cudaStream_t stream);
-int gp_recompute(GaussianProcess *gp, cudaStream_t stream);
-void gp_predict(const GaussianProcess *gp, const float *Xs, float *means, float *vars, int m, cudaStream_t stream);
-void gp_predict_d(const GaussianProcess *gp, const float *d_Xs, float *d_means, float *d_vars, int m,
-                  cudaStream_t stream);
-float gp_marginal_log_likelihood(const GaussianProcess *gp);
-void gp_mll_grad(const GaussianProcess *gp, float *d_raw_noise, float *kernel_grads, cudaStream_t stream);
-int gp_save(const GaussianProcess *gp, const char *path);
-GaussianProcess *gp_load(const char *path, int extra_cap);
-
 __global__ void gp_k_add_diag(float *A, int n, float val) {
     int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)

--- a/src/gp_cuda_kernel.cu
+++ b/src/gp_cuda_kernel.cu
@@ -1,5 +1,4 @@
 // gp_cuda_kernel.cu -- Matern32+Linear GP covariance kernel (CUDA), ARD.
-//
 
 #ifndef GP_CUDA_KERNEL_CU
 #define GP_CUDA_KERNEL_CU
@@ -11,97 +10,69 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define CUDA_CHECK(call)                                                  \
-    do {                                                                  \
-        cudaError_t _e = (call);                                          \
-        if (_e != cudaSuccess) {                                          \
-            fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, \
-                cudaGetErrorString(_e));                                  \
-            abort();                                                      \
-        }                                                                 \
-    } while (0)
-
-#define CUBLAS_CHECK(call)                                                            \
-    do {                                                                              \
-        cublasStatus_t _s = (call);                                                   \
-        if (_s != CUBLAS_STATUS_SUCCESS) {                                            \
-            fprintf(stderr, "cuBLAS error %s:%d: %d\n", __FILE__, __LINE__, (int)_s); \
-            abort();                                                                  \
-        }                                                                             \
-    } while (0)
+// clang-format off
+static inline void _cuda_check(cudaError_t e, const char* f, int l) {
+    if (e != cudaSuccess) { fprintf(stderr, "CUDA error %s:%d: %s\n", f, l, cudaGetErrorString(e)); abort(); }
+}
+static inline void _cublas_check(cublasStatus_t s, const char* f, int l) {
+    if (s != CUBLAS_STATUS_SUCCESS) { fprintf(stderr, "cuBLAS error %s:%d: %d\n", f, l, (int)s); abort(); }
+}
+#define CUDA_CHECK(call) _cuda_check((call), __FILE__, __LINE__)
+#define CUBLAS_CHECK(call) _cublas_check((call), __FILE__, __LINE__)
+// clang-format on
 
 #define SP_LB 1e-4
 __host__ __device__ __forceinline__ float softplus(float x) { return (x > 20.0 ? x : log1p(exp(x))) + SP_LB; }
-__host__ __device__ __forceinline__ float inv_softplus(float x)
-{
+__host__ __device__ __forceinline__ float inv_softplus(float x) {
     float v = x - SP_LB;
     return v > 20.0 ? v : log(expm1(v));
 }
 __host__ __device__ __forceinline__ float softplus_grad(float x) { return 1.0 / (1.0 + exp(-x)); }
 
-// -- kernel struct -----------------------------------------------------------
-
 typedef struct GPKernel GPKernel;
 struct GPKernel {
     int n_params;
-    float* raw_params;
+    float *raw_params;
     char tag[4];
-
-    void (*build_K)(const GPKernel* k, const float* d_X, int n, int d,
-        float sigma_n, float* d_K, cudaStream_t stream);
-    void (*build_Ks)(const GPKernel* k, const float* d_Xtr, const float* d_Xte,
-        int n, int m, int d, float* d_Ks, cudaStream_t stream);
-    void (*build_kself_batch)(const GPKernel* k, const float* d_X, int m, int d,
-        float* d_out, cudaStream_t stream);
-    float (*k_self)(const GPKernel* k, const float* x, int d);
-    void (*mll_grad)(const GPKernel* k, const float* d_X, int n, int d,
-        cublasHandle_t cublas, cudaStream_t stream,
-        const float* d_alpha, const float* d_Kinv,
-        float* kernel_grads);
-    void (*destroy)(GPKernel* k);
+    void (*build_K)(const GPKernel *k, const float *d_X, int n, int d, float sigma_n, float *d_K, cudaStream_t stream);
+    void (*build_Ks)(const GPKernel *k, const float *d_Xtr, const float *d_Xte, int n, int m, int d, float *d_Ks,
+                     cudaStream_t stream);
+    void (*build_kself_batch)(const GPKernel *k, const float *d_X, int m, int d, float *d_out, cudaStream_t stream);
+    float (*k_self)(const GPKernel *k, const float *x, int d);
+    void (*mll_grad)(const GPKernel *k, const float *d_X, int n, int d, cublasHandle_t cublas, cudaStream_t stream,
+                     const float *d_alpha, const float *d_Kinv, float *kernel_grads);
+    void (*destroy)(GPKernel *k);
 };
 
 #define GP_KERNEL_TAG_MATERN32_LINEAR "M32L"
-
-GPKernel* gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
-    float offset);
-
-float gp_kernel_get_lengthscale(const GPKernel* k, int d);
-float gp_kernel_get_outputscale(const GPKernel* k);
-float gp_kernel_get_offset(const GPKernel* k);
-void gp_kernel_set_lengthscale(GPKernel* k, int d, float v);
-void gp_kernel_set_outputscale(GPKernel* k, float v);
-void gp_kernel_set_offset(GPKernel* k, float v);
-
-// -- kernel implementations --------------------------------------------------
-
 #define SF_IDX(np) ((np)-2)
 #define OFF_IDX(np) ((np)-1)
-
 #define GP_BLOCK 16
-
 #ifndef BLOCK_SIZE
 #define BLOCK_SIZE 256
 #endif
 
-inline int gp_grid(int n)
-{
-    return (n + GP_BLOCK - 1) / GP_BLOCK;
+inline int gp_grid(int n) { return (n + GP_BLOCK - 1) / GP_BLOCK; }
+
+typedef struct {
+    float sigma_f, offset;
+} KParams;
+
+static inline KParams kernel_params(const GPKernel *k) {
+    int np = k->n_params;
+    return (KParams){softplus(k->raw_params[SF_IDX(np)]), softplus(k->raw_params[OFF_IDX(np)])};
 }
 
-__global__ void matern32lin_k_build_K(
-    const float* __restrict__ X,
-    float* __restrict__ K,
-    const float* __restrict__ inv_ells,
-    int n, int d, float sigma_f, float sigma_n, float offset)
-{
+__global__ void matern32lin_k_kernel(const float *__restrict__ X1, const float *__restrict__ X2, float *__restrict__ K,
+                                     const float *__restrict__ inv_ells, int n, int m, int d, float sigma_f,
+                                     float diag_noise, float offset) {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= n)
+    if (row >= n || col >= m)
         return;
     float dot = 0.0, r2 = 0.0;
     for (int k = 0; k < d; k++) {
-        float xr = X[row * d + k], xc = X[col * d + k];
+        float xr = X1[row * d + k], xc = X2[col * d + k];
         dot += xr * xc;
         float diff = (xr - xc) * inv_ells[k];
         r2 += diff * diff;
@@ -110,41 +81,13 @@ __global__ void matern32lin_k_build_K(
         r2 = 0.0;
     float u = sqrt(3.0) * sqrt(r2);
     float val = sigma_f * (dot + offset + (1.0 + u) * exp(-u));
-    if (row == col)
-        val += sigma_n;
+    if (diag_noise != 0.0 && row == col)
+        val += diag_noise;
     K[col * n + row] = val;
 }
 
-__global__ void matern32lin_k_build_Ks(
-    const float* __restrict__ Xtr,
-    const float* __restrict__ Xte,
-    float* __restrict__ Ks,
-    const float* __restrict__ inv_ells,
-    int n, int m, int d, float sigma_f, float offset)
-{
-    int col = blockIdx.x * GP_BLOCK + threadIdx.x;
-    int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= m)
-        return;
-    float dot = 0.0, r2 = 0.0;
-    for (int k = 0; k < d; k++) {
-        float xr = Xtr[row * d + k], xc = Xte[col * d + k];
-        dot += xr * xc;
-        float diff = (xr - xc) * inv_ells[k];
-        r2 += diff * diff;
-    }
-    if (r2 < 0.0)
-        r2 = 0.0;
-    float u = sqrt(3.0) * sqrt(r2);
-    Ks[col * n + row] = sigma_f * (dot + offset + (1.0 + u) * exp(-u));
-}
-
-__global__ void matern32lin_k_build_D_ard(
-    const float* __restrict__ X,
-    float* __restrict__ D,
-    const float* __restrict__ inv_ells,
-    int n, int d)
-{
+__global__ void matern32lin_k_build_D_ard(const float *__restrict__ X, float *__restrict__ D,
+                                          const float *__restrict__ inv_ells, int n, int d) {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
     if (row >= n || col >= n)
@@ -157,12 +100,8 @@ __global__ void matern32lin_k_build_D_ard(
     D[col * n + row] = sq < 0.0 ? 0.0 : sq;
 }
 
-__global__ void matern32lin_k_compute_W(
-    const float* __restrict__ alpha,
-    const float* __restrict__ Kinv,
-    float* __restrict__ W,
-    int n)
-{
+__global__ void matern32lin_k_compute_W(const float *__restrict__ alpha, const float *__restrict__ Kinv,
+                                        float *__restrict__ W, int n) {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
     if (row >= n || col >= n)
@@ -170,33 +109,26 @@ __global__ void matern32lin_k_compute_W(
     W[col * n + row] = alpha[row] * alpha[col] - Kinv[col * n + row];
 }
 
-__global__ void matern32lin_k_dk_dell_d(
-    const float* __restrict__ X,
-    const float* __restrict__ D_ard,
-    float* __restrict__ out,
-    int n, int d, int dd, float sigma_f, float inv_ell_d3)
-{
+__global__ void matern32lin_k_dk_dell_d(const float *__restrict__ X, const float *__restrict__ D_ard,
+                                        float *__restrict__ out, int n, int d, int dd, float sigma_f,
+                                        float inv_ell_d3) {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
     if (row >= n || col >= n)
         return;
     float r2 = D_ard[col * n + row];
     float diff = X[row * d + dd] - X[col * d + dd];
-    out[col * n + row] = sigma_f * 3.0 * diff * diff * inv_ell_d3
-        * exp(-sqrt(3.0) * sqrt(r2));
+    out[col * n + row] = sigma_f * 3.0 * diff * diff * inv_ell_d3 * exp(-sqrt(3.0) * sqrt(r2));
 }
 
-__global__ void matern32lin_k_fill(float* v, int n, float val)
-{
+__global__ void matern32lin_k_fill(float *v, int n, float val) {
     int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         v[i] = val;
 }
 
-__global__ void matern32lin_k_kself_batch(
-    const float* __restrict__ X, float* __restrict__ out,
-    int m, int d, float sigma_f, float offset)
-{
+__global__ void matern32lin_k_kself_batch(const float *__restrict__ X, float *__restrict__ out, int m, int d,
+                                          float sigma_f, float offset) {
     int row = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (row >= m)
         return;
@@ -208,94 +140,70 @@ __global__ void matern32lin_k_kself_batch(
     out[row] = sigma_f * (norm2 + offset + 1.0);
 }
 
-// -- helpers -----------------------------------------------------------------
-
-static float* h2d(const float* h, int n, cudaStream_t stream)
-{
-    float* d;
+static float *h2d(const float *h, int n, cudaStream_t stream) {
+    float *d;
     CUDA_CHECK(cudaMallocAsync(&d, (size_t)n * sizeof(float), stream));
-    CUDA_CHECK(cudaMemcpyAsync(d, h, (size_t)n * sizeof(float),
-        cudaMemcpyHostToDevice, stream));
+    CUDA_CHECK(cudaMemcpyAsync(d, h, (size_t)n * sizeof(float), cudaMemcpyHostToDevice, stream));
     return d;
 }
 
-static float* device_inv_ells(const GPKernel* k, int d, cudaStream_t stream)
-{
-    float* h = (float*)malloc(d * sizeof(float));
+static float *device_inv_ells(const GPKernel *k, int d, cudaStream_t stream) {
+    float *h = (float *)malloc(d * sizeof(float));
     for (int i = 0; i < d; i++)
         h[i] = 1.0 / softplus(k->raw_params[i]);
-    float* dev = h2d(h, d, stream);
+    float *dev = h2d(h, d, stream);
     free(h);
     return dev;
 }
 
-// -- launcher functions ------------------------------------------------------
-
-static void matern32lin_build_K(const GPKernel* k, const float* d_X, int n, int d,
-    float sigma_n, float* d_K, cudaStream_t stream)
-{
-    int np = k->n_params;
-    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset = softplus(k->raw_params[OFF_IDX(np)]);
-    float* d_inv = device_inv_ells(k, d, stream);
+static void matern32lin_build_K(const GPKernel *k, const float *d_X, int n, int d, float sigma_n, float *d_K,
+                                cudaStream_t stream) {
+    KParams p = kernel_params(k);
+    float *d_inv = device_inv_ells(k, d, stream);
     dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(n), gp_grid(n));
-    matern32lin_k_build_K<<<grid, block, 0, stream>>>(d_X, d_K, d_inv, n, d, sigma_f, sigma_n, offset);
+    matern32lin_k_kernel<<<grid, block, 0, stream>>>(d_X, d_X, d_K, d_inv, n, n, d, p.sigma_f, sigma_n, p.offset);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaFreeAsync(d_inv, stream));
 }
 
-static void matern32lin_build_Ks(const GPKernel* k, const float* d_Xtr, const float* d_Xte,
-    int n, int m, int d, float* d_Ks, cudaStream_t stream)
-{
-    int np = k->n_params;
-    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset = softplus(k->raw_params[OFF_IDX(np)]);
-    float* d_inv = device_inv_ells(k, d, stream);
+static void matern32lin_build_Ks(const GPKernel *k, const float *d_Xtr, const float *d_Xte, int n, int m, int d,
+                                 float *d_Ks, cudaStream_t stream) {
+    KParams p = kernel_params(k);
+    float *d_inv = device_inv_ells(k, d, stream);
     dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(m), gp_grid(n));
-    matern32lin_k_build_Ks<<<grid, block, 0, stream>>>(d_Xtr, d_Xte, d_Ks, d_inv, n, m, d, sigma_f, offset);
+    matern32lin_k_kernel<<<grid, block, 0, stream>>>(d_Xtr, d_Xte, d_Ks, d_inv, n, m, d, p.sigma_f, 0.0, p.offset);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaFreeAsync(d_inv, stream));
 }
 
-static float matern32lin_k_self(const GPKernel* k, const float* x, int d)
-{
-    int np = k->n_params;
-    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset = softplus(k->raw_params[OFF_IDX(np)]);
+static float matern32lin_k_self(const GPKernel *k, const float *x, int d) {
+    KParams p = kernel_params(k);
     float norm2 = 0.0;
     for (int i = 0; i < d; i++)
         norm2 += x[i] * x[i];
-    return sigma_f * (norm2 + offset + 1.0);
+    return p.sigma_f * (norm2 + p.offset + 1.0);
 }
 
-static void matern32lin_build_kself_batch(const GPKernel* k, const float* d_X,
-    int m, int d, float* d_out, cudaStream_t stream)
-{
-    int np = k->n_params;
-    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset = softplus(k->raw_params[OFF_IDX(np)]);
-    matern32lin_k_kself_batch<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_X, d_out, m, d, sigma_f, offset);
+static void matern32lin_build_kself_batch(const GPKernel *k, const float *d_X, int m, int d, float *d_out,
+                                          cudaStream_t stream) {
+    KParams p = kernel_params(k);
+    matern32lin_k_kself_batch<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_X, d_out, m, d, p.sigma_f,
+                                                                                            p.offset);
     CUDA_CHECK(cudaGetLastError());
 }
 
-static void matern32lin_mll_grad(const GPKernel* k, const float* d_X, int n, int d,
-    cublasHandle_t cublas, cudaStream_t stream,
-    const float* d_alpha, const float* d_Kinv,
-    float* kernel_grads)
-{
+static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int d, cublasHandle_t cublas,
+                                 cudaStream_t stream, const float *d_alpha, const float *d_Kinv, float *kernel_grads) {
     int np = k->n_params;
-    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset = softplus(k->raw_params[OFF_IDX(np)]);
+    KParams p = kernel_params(k);
     const float one = 1.0, zero = 0.0;
-
     CUBLAS_CHECK(cublasSetStream(cublas, stream));
 
-    float* d_inv = device_inv_ells(k, d, stream);
+    float *d_inv = device_inv_ells(k, d, stream);
     float *d_D, *d_W, *d_temp;
     CUDA_CHECK(cudaMallocAsync(&d_D, (size_t)n * n * sizeof(float), stream));
     CUDA_CHECK(cudaMallocAsync(&d_W, (size_t)n * n * sizeof(float), stream));
     CUDA_CHECK(cudaMallocAsync(&d_temp, (size_t)n * n * sizeof(float), stream));
-
     dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(n), gp_grid(n));
 
     matern32lin_k_build_D_ard<<<grid, block, 0, stream>>>(d_X, d_D, d_inv, n, d);
@@ -306,37 +214,30 @@ static void matern32lin_mll_grad(const GPKernel* k, const float* d_X, int n, int
     for (int dd = 0; dd < d; dd++) {
         float ell_d = softplus(k->raw_params[dd]);
         float inv_ell3 = 1.0 / (ell_d * ell_d * ell_d);
-        matern32lin_k_dk_dell_d<<<grid, block, 0, stream>>>(d_X, d_D, d_temp, n, d, dd, sigma_f, inv_ell3);
+        matern32lin_k_dk_dell_d<<<grid, block, 0, stream>>>(d_X, d_D, d_temp, n, d, dd, p.sigma_f, inv_ell3);
         CUDA_CHECK(cudaGetLastError());
         float dot_val;
         CUBLAS_CHECK(cublasSdot(cublas, n * n, d_W, 1, d_temp, 1, &dot_val));
         kernel_grads[dd] = 0.5 * dot_val * softplus_grad(k->raw_params[dd]);
     }
 
-    matern32lin_k_build_K<<<grid, block, 0, stream>>>(d_X, d_temp, d_inv, n, d, sigma_f, 0.0, offset);
+    matern32lin_k_kernel<<<grid, block, 0, stream>>>(d_X, d_X, d_temp, d_inv, n, n, d, p.sigma_f, 0.0, p.offset);
     CUDA_CHECK(cudaGetLastError());
-    {
-        float dot_val;
-        CUBLAS_CHECK(cublasSdot(cublas, n * n, d_W, 1, d_temp, 1, &dot_val));
-        kernel_grads[SF_IDX(np)] = 0.5 * dot_val / sigma_f
-            * softplus_grad(k->raw_params[SF_IDX(np)]);
-    }
+    float dot_val;
+    CUBLAS_CHECK(cublasSdot(cublas, n * n, d_W, 1, d_temp, 1, &dot_val));
+    kernel_grads[SF_IDX(np)] = 0.5 * dot_val / p.sigma_f * softplus_grad(k->raw_params[SF_IDX(np)]);
 
-    {
-        float *d_ones, *d_wrow;
-        CUDA_CHECK(cudaMallocAsync(&d_ones, (size_t)n * sizeof(float), stream));
-        CUDA_CHECK(cudaMallocAsync(&d_wrow, (size_t)n * sizeof(float), stream));
-        matern32lin_k_fill<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_ones, n, 1.0);
-        CUDA_CHECK(cudaGetLastError());
-        float w_sum;
-        CUBLAS_CHECK(cublasSgemv(cublas, CUBLAS_OP_N, n, n,
-            &one, d_W, n, d_ones, 1, &zero, d_wrow, 1));
-        CUBLAS_CHECK(cublasSdot(cublas, n, d_wrow, 1, d_ones, 1, &w_sum));
-        kernel_grads[OFF_IDX(np)] = 0.5 * sigma_f * w_sum
-            * softplus_grad(k->raw_params[OFF_IDX(np)]);
-        CUDA_CHECK(cudaFreeAsync(d_ones, stream));
-        CUDA_CHECK(cudaFreeAsync(d_wrow, stream));
-    }
+    float *d_ones, *d_wrow;
+    CUDA_CHECK(cudaMallocAsync(&d_ones, (size_t)n * sizeof(float), stream));
+    CUDA_CHECK(cudaMallocAsync(&d_wrow, (size_t)n * sizeof(float), stream));
+    matern32lin_k_fill<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_ones, n, 1.0);
+    CUDA_CHECK(cudaGetLastError());
+    float w_sum;
+    CUBLAS_CHECK(cublasSgemv(cublas, CUBLAS_OP_N, n, n, &one, d_W, n, d_ones, 1, &zero, d_wrow, 1));
+    CUBLAS_CHECK(cublasSdot(cublas, n, d_wrow, 1, d_ones, 1, &w_sum));
+    kernel_grads[OFF_IDX(np)] = 0.5 * p.sigma_f * w_sum * softplus_grad(k->raw_params[OFF_IDX(np)]);
+    CUDA_CHECK(cudaFreeAsync(d_ones, stream));
+    CUDA_CHECK(cudaFreeAsync(d_wrow, stream));
 
     CUDA_CHECK(cudaFreeAsync(d_inv, stream));
     CUDA_CHECK(cudaFreeAsync(d_D, stream));
@@ -344,15 +245,13 @@ static void matern32lin_mll_grad(const GPKernel* k, const float* d_X, int n, int
     CUDA_CHECK(cudaFreeAsync(d_temp, stream));
 }
 
-static void matern32lin_destroy(GPKernel* k) { free(k); }
+static void matern32lin_destroy(GPKernel *k) { free(k); }
 
-GPKernel* gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
-    float offset)
-{
+GPKernel *gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale, float offset) {
     int n_params = dim + 2;
-    GPKernel* k = (GPKernel*)malloc(sizeof(GPKernel) + (size_t)n_params * sizeof(float));
+    GPKernel *k = (GPKernel *)malloc(sizeof(GPKernel) + (size_t)n_params * sizeof(float));
     k->n_params = n_params;
-    k->raw_params = (float*)(k + 1);
+    k->raw_params = (float *)(k + 1);
     memcpy(k->tag, GP_KERNEL_TAG_MATERN32_LINEAR, 4);
     for (int i = 0; i < dim; i++)
         k->raw_params[i] = inv_softplus(lengthscale);
@@ -367,11 +266,11 @@ GPKernel* gp_kernel_matern32_linear(int dim, float lengthscale, float outputscal
     return k;
 }
 
-float gp_kernel_get_lengthscale(const GPKernel* k, int d) { return softplus(k->raw_params[d]); }
-float gp_kernel_get_outputscale(const GPKernel* k) { return softplus(k->raw_params[SF_IDX(k->n_params)]); }
-float gp_kernel_get_offset(const GPKernel* k) { return softplus(k->raw_params[OFF_IDX(k->n_params)]); }
-void gp_kernel_set_lengthscale(GPKernel* k, int d, float v) { k->raw_params[d] = inv_softplus(v); }
-void gp_kernel_set_outputscale(GPKernel* k, float v) { k->raw_params[SF_IDX(k->n_params)] = inv_softplus(v); }
-void gp_kernel_set_offset(GPKernel* k, float v) { k->raw_params[OFF_IDX(k->n_params)] = inv_softplus(v); }
+float gp_kernel_get_lengthscale(const GPKernel *k, int d) { return softplus(k->raw_params[d]); }
+float gp_kernel_get_outputscale(const GPKernel *k) { return softplus(k->raw_params[SF_IDX(k->n_params)]); }
+float gp_kernel_get_offset(const GPKernel *k) { return softplus(k->raw_params[OFF_IDX(k->n_params)]); }
+void gp_kernel_set_lengthscale(GPKernel *k, int d, float v) { k->raw_params[d] = inv_softplus(v); }
+void gp_kernel_set_outputscale(GPKernel *k, float v) { k->raw_params[SF_IDX(k->n_params)] = inv_softplus(v); }
+void gp_kernel_set_offset(GPKernel *k, float v) { k->raw_params[OFF_IDX(k->n_params)] = inv_softplus(v); }
 
 #endif // GP_CUDA_KERNEL_CU

--- a/src/gp_cuda_kernel.cu
+++ b/src/gp_cuda_kernel.cu
@@ -1,0 +1,348 @@
+// gp_cuda_kernel.cu -- Matern32+Linear GP covariance kernel (CUDA), ARD.
+//
+
+#ifndef GP_CUDA_KERNEL_CU
+#define GP_CUDA_KERNEL_CU
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+
+#define CUDA_CHECK(call) do { \
+    cudaError_t _e = (call); \
+    if (_e != cudaSuccess) { \
+        fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, \
+                cudaGetErrorString(_e)); \
+        abort(); \
+    } \
+} while (0)
+
+#define CUBLAS_CHECK(call) do { \
+    cublasStatus_t _s = (call); \
+    if (_s != CUBLAS_STATUS_SUCCESS) { \
+        fprintf(stderr, "cuBLAS error %s:%d: %d\n", __FILE__, __LINE__, (int)_s); \
+        abort(); \
+    } \
+} while (0)
+
+#define SP_LB 1e-4
+__host__ __device__ __forceinline__ float softplus(float x)      { return (x > 20.0 ? x : log1p(exp(x))) + SP_LB; }
+__host__ __device__ __forceinline__ float inv_softplus(float x)  { float v = x - SP_LB; return v > 20.0 ? v : log(expm1(v)); }
+__host__ __device__ __forceinline__ float softplus_grad(float x) { return 1.0 / (1.0 + exp(-x)); }
+
+// -- kernel struct -----------------------------------------------------------
+
+typedef struct GPKernel GPKernel;
+struct GPKernel {
+    int     n_params;
+    float *raw_params;
+    char    tag[4];
+
+    void (*build_K)(const GPKernel *k, const float *d_X, int n, int d,
+                    float sigma_n, float *d_K, cudaStream_t stream);
+    void (*build_Ks)(const GPKernel *k, const float *d_Xtr, const float *d_Xte,
+                     int n, int m, int d, float *d_Ks, cudaStream_t stream);
+    void (*build_kself_batch)(const GPKernel *k, const float *d_X, int m, int d,
+                               float *d_out, cudaStream_t stream);
+    float (*k_self)(const GPKernel *k, const float *x, int d);
+    void (*mll_grad)(const GPKernel *k, const float *d_X, int n, int d,
+                     cublasHandle_t cublas, cudaStream_t stream,
+                     const float *d_alpha, const float *d_Kinv,
+                     float *kernel_grads);
+    void (*destroy)(GPKernel *k);
+};
+
+#define GP_KERNEL_TAG_MATERN32_LINEAR "M32L"
+
+GPKernel *gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
+                                        float offset);
+
+float gp_kernel_get_lengthscale(const GPKernel *k, int d);
+float gp_kernel_get_outputscale(const GPKernel *k);
+float gp_kernel_get_offset     (const GPKernel *k);
+void   gp_kernel_set_lengthscale(GPKernel *k, int d, float v);
+void   gp_kernel_set_outputscale(GPKernel *k, float v);
+void   gp_kernel_set_offset     (GPKernel *k, float v);
+
+// -- kernel implementations --------------------------------------------------
+
+#define SF_IDX(np)  ((np) - 2)
+#define OFF_IDX(np) ((np) - 1)
+
+#define GP_BLOCK 16
+inline int gp_grid(int n) { return (n + GP_BLOCK - 1) / GP_BLOCK; }
+
+__global__ void matern32lin_k_build_K(
+    const float * __restrict__ X,
+    float       * __restrict__ K,
+    const float * __restrict__ inv_ells,
+    int n, int d, float sigma_f, float sigma_n, float offset)
+{
+    int col = blockIdx.x * GP_BLOCK + threadIdx.x;
+    int row = blockIdx.y * GP_BLOCK + threadIdx.y;
+    if (row >= n || col >= n) return;
+    float dot = 0.0, r2 = 0.0;
+    for (int k = 0; k < d; k++) {
+        float xr = X[row * d + k], xc = X[col * d + k];
+        dot += xr * xc;
+        float diff = (xr - xc) * inv_ells[k];
+        r2 += diff * diff;
+    }
+    if (r2 < 0.0) r2 = 0.0;
+    float u   = sqrt(3.0) * sqrt(r2);
+    float val = sigma_f * (dot + offset + (1.0 + u) * exp(-u));
+    if (row == col) val += sigma_n;
+    K[col * n + row] = val;
+}
+
+__global__ void matern32lin_k_build_Ks(
+    const float * __restrict__ Xtr,
+    const float * __restrict__ Xte,
+    float       * __restrict__ Ks,
+    const float * __restrict__ inv_ells,
+    int n, int m, int d, float sigma_f, float offset)
+{
+    int col = blockIdx.x * GP_BLOCK + threadIdx.x;
+    int row = blockIdx.y * GP_BLOCK + threadIdx.y;
+    if (row >= n || col >= m) return;
+    float dot = 0.0, r2 = 0.0;
+    for (int k = 0; k < d; k++) {
+        float xr = Xtr[row * d + k], xc = Xte[col * d + k];
+        dot += xr * xc;
+        float diff = (xr - xc) * inv_ells[k];
+        r2 += diff * diff;
+    }
+    if (r2 < 0.0) r2 = 0.0;
+    float u = sqrt(3.0) * sqrt(r2);
+    Ks[col * n + row] = sigma_f * (dot + offset + (1.0 + u) * exp(-u));
+}
+
+__global__ void matern32lin_k_build_D_ard(
+    const float * __restrict__ X,
+    float       * __restrict__ D,
+    const float * __restrict__ inv_ells,
+    int n, int d)
+{
+    int col = blockIdx.x * GP_BLOCK + threadIdx.x;
+    int row = blockIdx.y * GP_BLOCK + threadIdx.y;
+    if (row >= n || col >= n) return;
+    float sq = 0.0;
+    for (int k = 0; k < d; k++) {
+        float diff = (X[row * d + k] - X[col * d + k]) * inv_ells[k];
+        sq += diff * diff;
+    }
+    D[col * n + row] = sq < 0.0 ? 0.0 : sq;
+}
+
+__global__ void matern32lin_k_compute_W(
+    const float * __restrict__ alpha,
+    const float * __restrict__ Kinv,
+    float       * __restrict__ W,
+    int n)
+{
+    int col = blockIdx.x * GP_BLOCK + threadIdx.x;
+    int row = blockIdx.y * GP_BLOCK + threadIdx.y;
+    if (row >= n || col >= n) return;
+    W[col * n + row] = alpha[row] * alpha[col] - Kinv[col * n + row];
+}
+
+__global__ void matern32lin_k_dk_dell_d(
+    const float * __restrict__ X,
+    const float * __restrict__ D_ard,
+    float       * __restrict__ out,
+    int n, int d, int dd, float sigma_f, float inv_ell_d3)
+{
+    int col = blockIdx.x * GP_BLOCK + threadIdx.x;
+    int row = blockIdx.y * GP_BLOCK + threadIdx.y;
+    if (row >= n || col >= n) return;
+    float r2   = D_ard[col * n + row];
+    float diff = X[row * d + dd] - X[col * d + dd];
+    out[col * n + row] = sigma_f * 3.0 * diff * diff * inv_ell_d3
+                       * exp(-sqrt(3.0) * sqrt(r2));
+}
+
+__global__ void matern32lin_k_fill(float *v, int n, float val)
+{
+    int i = blockIdx.x * 256 + threadIdx.x;
+    if (i < n) v[i] = val;
+}
+
+__global__ void matern32lin_k_kself_batch(
+    const float * __restrict__ X, float * __restrict__ out,
+    int m, int d, float sigma_f, float offset)
+{
+    int row = blockIdx.x * 256 + threadIdx.x;
+    if (row >= m) return;
+    float norm2 = 0.0;
+    for (int k = 0; k < d; k++) { float v = X[row * d + k]; norm2 += v * v; }
+    out[row] = sigma_f * (norm2 + offset + 1.0);
+}
+
+// -- helpers -----------------------------------------------------------------
+
+static float *h2d(const float *h, int n, cudaStream_t stream)
+{
+    float *d;
+    CUDA_CHECK(cudaMallocAsync(&d, (size_t)n * sizeof(float), stream));
+    CUDA_CHECK(cudaMemcpyAsync(d, h, (size_t)n * sizeof(float),
+                               cudaMemcpyHostToDevice, stream));
+    return d;
+}
+
+static float *device_inv_ells(const GPKernel *k, int d, cudaStream_t stream)
+{
+    float *h = (float *)malloc(d * sizeof(float));
+    for (int i = 0; i < d; i++) h[i] = 1.0 / softplus(k->raw_params[i]);
+    float *dev = h2d(h, d, stream);
+    free(h);
+    return dev;
+}
+
+// -- launcher functions ------------------------------------------------------
+
+static void matern32lin_build_K(const GPKernel *k, const float *d_X, int n, int d,
+                            float sigma_n, float *d_K, cudaStream_t stream)
+{
+    int    np      = k->n_params;
+    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
+    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    float *d_inv  = device_inv_ells(k, d, stream);
+    dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(n), gp_grid(n));
+    matern32lin_k_build_K<<<grid, block, 0, stream>>>(d_X, d_K, d_inv, n, d, sigma_f, sigma_n, offset);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaFreeAsync(d_inv, stream));
+}
+
+static void matern32lin_build_Ks(const GPKernel *k, const float *d_Xtr, const float *d_Xte,
+                             int n, int m, int d, float *d_Ks, cudaStream_t stream)
+{
+    int    np      = k->n_params;
+    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
+    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    float *d_inv  = device_inv_ells(k, d, stream);
+    dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(m), gp_grid(n));
+    matern32lin_k_build_Ks<<<grid, block, 0, stream>>>(d_Xtr, d_Xte, d_Ks, d_inv, n, m, d, sigma_f, offset);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaFreeAsync(d_inv, stream));
+}
+
+static float matern32lin_k_self(const GPKernel *k, const float *x, int d)
+{
+    int    np      = k->n_params;
+    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
+    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    float norm2   = 0.0;
+    for (int i = 0; i < d; i++) norm2 += x[i] * x[i];
+    return sigma_f * (norm2 + offset + 1.0);
+}
+
+static void matern32lin_build_kself_batch(const GPKernel *k, const float *d_X,
+                                      int m, int d, float *d_out, cudaStream_t stream)
+{
+    int    np      = k->n_params;
+    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
+    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    matern32lin_k_kself_batch<<<(m + 255) / 256, 256, 0, stream>>>(d_X, d_out, m, d, sigma_f, offset);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int d,
+                             cublasHandle_t cublas, cudaStream_t stream,
+                             const float *d_alpha, const float *d_Kinv,
+                             float *kernel_grads)
+{
+    int    np      = k->n_params;
+    float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
+    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    const float one = 1.0, zero = 0.0;
+
+    CUBLAS_CHECK(cublasSetStream(cublas, stream));
+
+    float *d_inv  = device_inv_ells(k, d, stream);
+    float *d_D, *d_W, *d_temp;
+    CUDA_CHECK(cudaMallocAsync(&d_D,    (size_t)n * n * sizeof(float), stream));
+    CUDA_CHECK(cudaMallocAsync(&d_W,    (size_t)n * n * sizeof(float), stream));
+    CUDA_CHECK(cudaMallocAsync(&d_temp, (size_t)n * n * sizeof(float), stream));
+
+    dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(n), gp_grid(n));
+
+    matern32lin_k_build_D_ard<<<grid, block, 0, stream>>>(d_X, d_D, d_inv, n, d);
+    CUDA_CHECK(cudaGetLastError());
+    matern32lin_k_compute_W<<<grid, block, 0, stream>>>(d_alpha, d_Kinv, d_W, n);
+    CUDA_CHECK(cudaGetLastError());
+
+    for (int dd = 0; dd < d; dd++) {
+        float ell_d    = softplus(k->raw_params[dd]);
+        float inv_ell3 = 1.0 / (ell_d * ell_d * ell_d);
+        matern32lin_k_dk_dell_d<<<grid, block, 0, stream>>>(d_X, d_D, d_temp, n, d, dd, sigma_f, inv_ell3);
+        CUDA_CHECK(cudaGetLastError());
+        float dot_val;
+        CUBLAS_CHECK(cublasSdot(cublas, n * n, d_W, 1, d_temp, 1, &dot_val));
+        kernel_grads[dd] = 0.5 * dot_val * softplus_grad(k->raw_params[dd]);
+    }
+
+    matern32lin_k_build_K<<<grid, block, 0, stream>>>(d_X, d_temp, d_inv, n, d, sigma_f, 0.0, offset);
+    CUDA_CHECK(cudaGetLastError());
+    {
+        float dot_val;
+        CUBLAS_CHECK(cublasSdot(cublas, n * n, d_W, 1, d_temp, 1, &dot_val));
+        kernel_grads[SF_IDX(np)] = 0.5 * dot_val / sigma_f
+                                 * softplus_grad(k->raw_params[SF_IDX(np)]);
+    }
+
+    {
+        float *d_ones, *d_wrow;
+        CUDA_CHECK(cudaMallocAsync(&d_ones, (size_t)n * sizeof(float), stream));
+        CUDA_CHECK(cudaMallocAsync(&d_wrow, (size_t)n * sizeof(float), stream));
+        matern32lin_k_fill<<<(n + 255) / 256, 256, 0, stream>>>(d_ones, n, 1.0);
+        CUDA_CHECK(cudaGetLastError());
+        float w_sum;
+        CUBLAS_CHECK(cublasSgemv(cublas, CUBLAS_OP_N, n, n,
+                                 &one, d_W, n, d_ones, 1, &zero, d_wrow, 1));
+        CUBLAS_CHECK(cublasSdot(cublas, n, d_wrow, 1, d_ones, 1, &w_sum));
+        kernel_grads[OFF_IDX(np)] = 0.5 * sigma_f * w_sum
+                                  * softplus_grad(k->raw_params[OFF_IDX(np)]);
+        CUDA_CHECK(cudaFreeAsync(d_ones, stream));
+        CUDA_CHECK(cudaFreeAsync(d_wrow, stream));
+    }
+
+    CUDA_CHECK(cudaFreeAsync(d_inv, stream));
+    CUDA_CHECK(cudaFreeAsync(d_D, stream));
+    CUDA_CHECK(cudaFreeAsync(d_W, stream));
+    CUDA_CHECK(cudaFreeAsync(d_temp, stream));
+}
+
+static void matern32lin_destroy(GPKernel *k) { free(k); }
+
+GPKernel *gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
+                                        float offset)
+{
+    int n_params = dim + 2;
+    GPKernel *k = (GPKernel *)malloc(sizeof(GPKernel) + (size_t)n_params * sizeof(float));
+    k->n_params   = n_params;
+    k->raw_params = (float *)(k + 1);
+    memcpy(k->tag, GP_KERNEL_TAG_MATERN32_LINEAR, 4);
+    for (int i = 0; i < dim; i++)
+        k->raw_params[i] = inv_softplus(lengthscale);
+    k->raw_params[SF_IDX(n_params)]  = inv_softplus(outputscale);
+    k->raw_params[OFF_IDX(n_params)] = inv_softplus(offset);
+    k->build_K          = matern32lin_build_K;
+    k->build_Ks         = matern32lin_build_Ks;
+    k->build_kself_batch = matern32lin_build_kself_batch;
+    k->k_self           = matern32lin_k_self;
+    k->mll_grad         = matern32lin_mll_grad;
+    k->destroy          = matern32lin_destroy;
+    return k;
+}
+
+float gp_kernel_get_lengthscale(const GPKernel *k, int d) { return softplus(k->raw_params[d]); }
+float gp_kernel_get_outputscale(const GPKernel *k) { return softplus(k->raw_params[SF_IDX(k->n_params)]);  }
+float gp_kernel_get_offset     (const GPKernel *k) { return softplus(k->raw_params[OFF_IDX(k->n_params)]); }
+void gp_kernel_set_lengthscale(GPKernel *k, int d, float v) { k->raw_params[d] = inv_softplus(v); }
+void gp_kernel_set_outputscale(GPKernel *k, float v) { k->raw_params[SF_IDX(k->n_params)]  = inv_softplus(v); }
+void gp_kernel_set_offset     (GPKernel *k, float v) { k->raw_params[OFF_IDX(k->n_params)] = inv_softplus(v); }
+
+#endif // GP_CUDA_KERNEL_CU

--- a/src/gp_cuda_kernel.cu
+++ b/src/gp_cuda_kernel.cu
@@ -4,86 +4,96 @@
 #ifndef GP_CUDA_KERNEL_CU
 #define GP_CUDA_KERNEL_CU
 
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <cublas_v2.h>
-#include <cuda_runtime.h>
 
-#define CUDA_CHECK(call) do { \
-    cudaError_t _e = (call); \
-    if (_e != cudaSuccess) { \
-        fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, \
-                cudaGetErrorString(_e)); \
-        abort(); \
-    } \
-} while (0)
+#define CUDA_CHECK(call)                                                  \
+    do {                                                                  \
+        cudaError_t _e = (call);                                          \
+        if (_e != cudaSuccess) {                                          \
+            fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, \
+                cudaGetErrorString(_e));                                  \
+            abort();                                                      \
+        }                                                                 \
+    } while (0)
 
-#define CUBLAS_CHECK(call) do { \
-    cublasStatus_t _s = (call); \
-    if (_s != CUBLAS_STATUS_SUCCESS) { \
-        fprintf(stderr, "cuBLAS error %s:%d: %d\n", __FILE__, __LINE__, (int)_s); \
-        abort(); \
-    } \
-} while (0)
+#define CUBLAS_CHECK(call)                                                            \
+    do {                                                                              \
+        cublasStatus_t _s = (call);                                                   \
+        if (_s != CUBLAS_STATUS_SUCCESS) {                                            \
+            fprintf(stderr, "cuBLAS error %s:%d: %d\n", __FILE__, __LINE__, (int)_s); \
+            abort();                                                                  \
+        }                                                                             \
+    } while (0)
 
 #define SP_LB 1e-4
-__host__ __device__ __forceinline__ float softplus(float x)      { return (x > 20.0 ? x : log1p(exp(x))) + SP_LB; }
-__host__ __device__ __forceinline__ float inv_softplus(float x)  { float v = x - SP_LB; return v > 20.0 ? v : log(expm1(v)); }
+__host__ __device__ __forceinline__ float softplus(float x) { return (x > 20.0 ? x : log1p(exp(x))) + SP_LB; }
+__host__ __device__ __forceinline__ float inv_softplus(float x)
+{
+    float v = x - SP_LB;
+    return v > 20.0 ? v : log(expm1(v));
+}
 __host__ __device__ __forceinline__ float softplus_grad(float x) { return 1.0 / (1.0 + exp(-x)); }
 
 // -- kernel struct -----------------------------------------------------------
 
 typedef struct GPKernel GPKernel;
 struct GPKernel {
-    int     n_params;
-    float *raw_params;
-    char    tag[4];
+    int n_params;
+    float* raw_params;
+    char tag[4];
 
-    void (*build_K)(const GPKernel *k, const float *d_X, int n, int d,
-                    float sigma_n, float *d_K, cudaStream_t stream);
-    void (*build_Ks)(const GPKernel *k, const float *d_Xtr, const float *d_Xte,
-                     int n, int m, int d, float *d_Ks, cudaStream_t stream);
-    void (*build_kself_batch)(const GPKernel *k, const float *d_X, int m, int d,
-                               float *d_out, cudaStream_t stream);
-    float (*k_self)(const GPKernel *k, const float *x, int d);
-    void (*mll_grad)(const GPKernel *k, const float *d_X, int n, int d,
-                     cublasHandle_t cublas, cudaStream_t stream,
-                     const float *d_alpha, const float *d_Kinv,
-                     float *kernel_grads);
-    void (*destroy)(GPKernel *k);
+    void (*build_K)(const GPKernel* k, const float* d_X, int n, int d,
+        float sigma_n, float* d_K, cudaStream_t stream);
+    void (*build_Ks)(const GPKernel* k, const float* d_Xtr, const float* d_Xte,
+        int n, int m, int d, float* d_Ks, cudaStream_t stream);
+    void (*build_kself_batch)(const GPKernel* k, const float* d_X, int m, int d,
+        float* d_out, cudaStream_t stream);
+    float (*k_self)(const GPKernel* k, const float* x, int d);
+    void (*mll_grad)(const GPKernel* k, const float* d_X, int n, int d,
+        cublasHandle_t cublas, cudaStream_t stream,
+        const float* d_alpha, const float* d_Kinv,
+        float* kernel_grads);
+    void (*destroy)(GPKernel* k);
 };
 
 #define GP_KERNEL_TAG_MATERN32_LINEAR "M32L"
 
-GPKernel *gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
-                                        float offset);
+GPKernel* gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
+    float offset);
 
-float gp_kernel_get_lengthscale(const GPKernel *k, int d);
-float gp_kernel_get_outputscale(const GPKernel *k);
-float gp_kernel_get_offset     (const GPKernel *k);
-void   gp_kernel_set_lengthscale(GPKernel *k, int d, float v);
-void   gp_kernel_set_outputscale(GPKernel *k, float v);
-void   gp_kernel_set_offset     (GPKernel *k, float v);
+float gp_kernel_get_lengthscale(const GPKernel* k, int d);
+float gp_kernel_get_outputscale(const GPKernel* k);
+float gp_kernel_get_offset(const GPKernel* k);
+void gp_kernel_set_lengthscale(GPKernel* k, int d, float v);
+void gp_kernel_set_outputscale(GPKernel* k, float v);
+void gp_kernel_set_offset(GPKernel* k, float v);
 
 // -- kernel implementations --------------------------------------------------
 
-#define SF_IDX(np)  ((np) - 2)
-#define OFF_IDX(np) ((np) - 1)
+#define SF_IDX(np) ((np)-2)
+#define OFF_IDX(np) ((np)-1)
 
 #define GP_BLOCK 16
-inline int gp_grid(int n) { return (n + GP_BLOCK - 1) / GP_BLOCK; }
+inline int gp_grid(int n)
+{
+    return (n + GP_BLOCK - 1) / GP_BLOCK;
+}
 
 __global__ void matern32lin_k_build_K(
-    const float * __restrict__ X,
-    float       * __restrict__ K,
-    const float * __restrict__ inv_ells,
+    const float* __restrict__ X,
+    float* __restrict__ K,
+    const float* __restrict__ inv_ells,
     int n, int d, float sigma_f, float sigma_n, float offset)
 {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= n) return;
+    if (row >= n || col >= n)
+        return;
     float dot = 0.0, r2 = 0.0;
     for (int k = 0; k < d; k++) {
         float xr = X[row * d + k], xc = X[col * d + k];
@@ -91,23 +101,26 @@ __global__ void matern32lin_k_build_K(
         float diff = (xr - xc) * inv_ells[k];
         r2 += diff * diff;
     }
-    if (r2 < 0.0) r2 = 0.0;
-    float u   = sqrt(3.0) * sqrt(r2);
+    if (r2 < 0.0)
+        r2 = 0.0;
+    float u = sqrt(3.0) * sqrt(r2);
     float val = sigma_f * (dot + offset + (1.0 + u) * exp(-u));
-    if (row == col) val += sigma_n;
+    if (row == col)
+        val += sigma_n;
     K[col * n + row] = val;
 }
 
 __global__ void matern32lin_k_build_Ks(
-    const float * __restrict__ Xtr,
-    const float * __restrict__ Xte,
-    float       * __restrict__ Ks,
-    const float * __restrict__ inv_ells,
+    const float* __restrict__ Xtr,
+    const float* __restrict__ Xte,
+    float* __restrict__ Ks,
+    const float* __restrict__ inv_ells,
     int n, int m, int d, float sigma_f, float offset)
 {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= m) return;
+    if (row >= n || col >= m)
+        return;
     float dot = 0.0, r2 = 0.0;
     for (int k = 0; k < d; k++) {
         float xr = Xtr[row * d + k], xc = Xte[col * d + k];
@@ -115,20 +128,22 @@ __global__ void matern32lin_k_build_Ks(
         float diff = (xr - xc) * inv_ells[k];
         r2 += diff * diff;
     }
-    if (r2 < 0.0) r2 = 0.0;
+    if (r2 < 0.0)
+        r2 = 0.0;
     float u = sqrt(3.0) * sqrt(r2);
     Ks[col * n + row] = sigma_f * (dot + offset + (1.0 + u) * exp(-u));
 }
 
 __global__ void matern32lin_k_build_D_ard(
-    const float * __restrict__ X,
-    float       * __restrict__ D,
-    const float * __restrict__ inv_ells,
+    const float* __restrict__ X,
+    float* __restrict__ D,
+    const float* __restrict__ inv_ells,
     int n, int d)
 {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= n) return;
+    if (row >= n || col >= n)
+        return;
     float sq = 0.0;
     for (int k = 0; k < d; k++) {
         float diff = (X[row * d + k] - X[col * d + k]) * inv_ells[k];
@@ -138,133 +153,142 @@ __global__ void matern32lin_k_build_D_ard(
 }
 
 __global__ void matern32lin_k_compute_W(
-    const float * __restrict__ alpha,
-    const float * __restrict__ Kinv,
-    float       * __restrict__ W,
+    const float* __restrict__ alpha,
+    const float* __restrict__ Kinv,
+    float* __restrict__ W,
     int n)
 {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= n) return;
+    if (row >= n || col >= n)
+        return;
     W[col * n + row] = alpha[row] * alpha[col] - Kinv[col * n + row];
 }
 
 __global__ void matern32lin_k_dk_dell_d(
-    const float * __restrict__ X,
-    const float * __restrict__ D_ard,
-    float       * __restrict__ out,
+    const float* __restrict__ X,
+    const float* __restrict__ D_ard,
+    float* __restrict__ out,
     int n, int d, int dd, float sigma_f, float inv_ell_d3)
 {
     int col = blockIdx.x * GP_BLOCK + threadIdx.x;
     int row = blockIdx.y * GP_BLOCK + threadIdx.y;
-    if (row >= n || col >= n) return;
-    float r2   = D_ard[col * n + row];
+    if (row >= n || col >= n)
+        return;
+    float r2 = D_ard[col * n + row];
     float diff = X[row * d + dd] - X[col * d + dd];
     out[col * n + row] = sigma_f * 3.0 * diff * diff * inv_ell_d3
-                       * exp(-sqrt(3.0) * sqrt(r2));
+        * exp(-sqrt(3.0) * sqrt(r2));
 }
 
-__global__ void matern32lin_k_fill(float *v, int n, float val)
+__global__ void matern32lin_k_fill(float* v, int n, float val)
 {
     int i = blockIdx.x * 256 + threadIdx.x;
-    if (i < n) v[i] = val;
+    if (i < n)
+        v[i] = val;
 }
 
 __global__ void matern32lin_k_kself_batch(
-    const float * __restrict__ X, float * __restrict__ out,
+    const float* __restrict__ X, float* __restrict__ out,
     int m, int d, float sigma_f, float offset)
 {
     int row = blockIdx.x * 256 + threadIdx.x;
-    if (row >= m) return;
+    if (row >= m)
+        return;
     float norm2 = 0.0;
-    for (int k = 0; k < d; k++) { float v = X[row * d + k]; norm2 += v * v; }
+    for (int k = 0; k < d; k++) {
+        float v = X[row * d + k];
+        norm2 += v * v;
+    }
     out[row] = sigma_f * (norm2 + offset + 1.0);
 }
 
 // -- helpers -----------------------------------------------------------------
 
-static float *h2d(const float *h, int n, cudaStream_t stream)
+static float* h2d(const float* h, int n, cudaStream_t stream)
 {
-    float *d;
+    float* d;
     CUDA_CHECK(cudaMallocAsync(&d, (size_t)n * sizeof(float), stream));
     CUDA_CHECK(cudaMemcpyAsync(d, h, (size_t)n * sizeof(float),
-                               cudaMemcpyHostToDevice, stream));
+        cudaMemcpyHostToDevice, stream));
     return d;
 }
 
-static float *device_inv_ells(const GPKernel *k, int d, cudaStream_t stream)
+static float* device_inv_ells(const GPKernel* k, int d, cudaStream_t stream)
 {
-    float *h = (float *)malloc(d * sizeof(float));
-    for (int i = 0; i < d; i++) h[i] = 1.0 / softplus(k->raw_params[i]);
-    float *dev = h2d(h, d, stream);
+    float* h = (float*)malloc(d * sizeof(float));
+    for (int i = 0; i < d; i++)
+        h[i] = 1.0 / softplus(k->raw_params[i]);
+    float* dev = h2d(h, d, stream);
     free(h);
     return dev;
 }
 
 // -- launcher functions ------------------------------------------------------
 
-static void matern32lin_build_K(const GPKernel *k, const float *d_X, int n, int d,
-                            float sigma_n, float *d_K, cudaStream_t stream)
+static void matern32lin_build_K(const GPKernel* k, const float* d_X, int n, int d,
+    float sigma_n, float* d_K, cudaStream_t stream)
 {
-    int    np      = k->n_params;
+    int np = k->n_params;
     float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
-    float *d_inv  = device_inv_ells(k, d, stream);
+    float offset = softplus(k->raw_params[OFF_IDX(np)]);
+    float* d_inv = device_inv_ells(k, d, stream);
     dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(n), gp_grid(n));
     matern32lin_k_build_K<<<grid, block, 0, stream>>>(d_X, d_K, d_inv, n, d, sigma_f, sigma_n, offset);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaFreeAsync(d_inv, stream));
 }
 
-static void matern32lin_build_Ks(const GPKernel *k, const float *d_Xtr, const float *d_Xte,
-                             int n, int m, int d, float *d_Ks, cudaStream_t stream)
+static void matern32lin_build_Ks(const GPKernel* k, const float* d_Xtr, const float* d_Xte,
+    int n, int m, int d, float* d_Ks, cudaStream_t stream)
 {
-    int    np      = k->n_params;
+    int np = k->n_params;
     float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
-    float *d_inv  = device_inv_ells(k, d, stream);
+    float offset = softplus(k->raw_params[OFF_IDX(np)]);
+    float* d_inv = device_inv_ells(k, d, stream);
     dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(m), gp_grid(n));
     matern32lin_k_build_Ks<<<grid, block, 0, stream>>>(d_Xtr, d_Xte, d_Ks, d_inv, n, m, d, sigma_f, offset);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaFreeAsync(d_inv, stream));
 }
 
-static float matern32lin_k_self(const GPKernel *k, const float *x, int d)
+static float matern32lin_k_self(const GPKernel* k, const float* x, int d)
 {
-    int    np      = k->n_params;
+    int np = k->n_params;
     float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
-    float norm2   = 0.0;
-    for (int i = 0; i < d; i++) norm2 += x[i] * x[i];
+    float offset = softplus(k->raw_params[OFF_IDX(np)]);
+    float norm2 = 0.0;
+    for (int i = 0; i < d; i++)
+        norm2 += x[i] * x[i];
     return sigma_f * (norm2 + offset + 1.0);
 }
 
-static void matern32lin_build_kself_batch(const GPKernel *k, const float *d_X,
-                                      int m, int d, float *d_out, cudaStream_t stream)
+static void matern32lin_build_kself_batch(const GPKernel* k, const float* d_X,
+    int m, int d, float* d_out, cudaStream_t stream)
 {
-    int    np      = k->n_params;
+    int np = k->n_params;
     float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    float offset = softplus(k->raw_params[OFF_IDX(np)]);
     matern32lin_k_kself_batch<<<(m + 255) / 256, 256, 0, stream>>>(d_X, d_out, m, d, sigma_f, offset);
     CUDA_CHECK(cudaGetLastError());
 }
 
-static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int d,
-                             cublasHandle_t cublas, cudaStream_t stream,
-                             const float *d_alpha, const float *d_Kinv,
-                             float *kernel_grads)
+static void matern32lin_mll_grad(const GPKernel* k, const float* d_X, int n, int d,
+    cublasHandle_t cublas, cudaStream_t stream,
+    const float* d_alpha, const float* d_Kinv,
+    float* kernel_grads)
 {
-    int    np      = k->n_params;
+    int np = k->n_params;
     float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
-    float offset  = softplus(k->raw_params[OFF_IDX(np)]);
+    float offset = softplus(k->raw_params[OFF_IDX(np)]);
     const float one = 1.0, zero = 0.0;
 
     CUBLAS_CHECK(cublasSetStream(cublas, stream));
 
-    float *d_inv  = device_inv_ells(k, d, stream);
+    float* d_inv = device_inv_ells(k, d, stream);
     float *d_D, *d_W, *d_temp;
-    CUDA_CHECK(cudaMallocAsync(&d_D,    (size_t)n * n * sizeof(float), stream));
-    CUDA_CHECK(cudaMallocAsync(&d_W,    (size_t)n * n * sizeof(float), stream));
+    CUDA_CHECK(cudaMallocAsync(&d_D, (size_t)n * n * sizeof(float), stream));
+    CUDA_CHECK(cudaMallocAsync(&d_W, (size_t)n * n * sizeof(float), stream));
     CUDA_CHECK(cudaMallocAsync(&d_temp, (size_t)n * n * sizeof(float), stream));
 
     dim3 block(GP_BLOCK, GP_BLOCK), grid(gp_grid(n), gp_grid(n));
@@ -275,7 +299,7 @@ static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int
     CUDA_CHECK(cudaGetLastError());
 
     for (int dd = 0; dd < d; dd++) {
-        float ell_d    = softplus(k->raw_params[dd]);
+        float ell_d = softplus(k->raw_params[dd]);
         float inv_ell3 = 1.0 / (ell_d * ell_d * ell_d);
         matern32lin_k_dk_dell_d<<<grid, block, 0, stream>>>(d_X, d_D, d_temp, n, d, dd, sigma_f, inv_ell3);
         CUDA_CHECK(cudaGetLastError());
@@ -290,7 +314,7 @@ static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int
         float dot_val;
         CUBLAS_CHECK(cublasSdot(cublas, n * n, d_W, 1, d_temp, 1, &dot_val));
         kernel_grads[SF_IDX(np)] = 0.5 * dot_val / sigma_f
-                                 * softplus_grad(k->raw_params[SF_IDX(np)]);
+            * softplus_grad(k->raw_params[SF_IDX(np)]);
     }
 
     {
@@ -301,10 +325,10 @@ static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int
         CUDA_CHECK(cudaGetLastError());
         float w_sum;
         CUBLAS_CHECK(cublasSgemv(cublas, CUBLAS_OP_N, n, n,
-                                 &one, d_W, n, d_ones, 1, &zero, d_wrow, 1));
+            &one, d_W, n, d_ones, 1, &zero, d_wrow, 1));
         CUBLAS_CHECK(cublasSdot(cublas, n, d_wrow, 1, d_ones, 1, &w_sum));
         kernel_grads[OFF_IDX(np)] = 0.5 * sigma_f * w_sum
-                                  * softplus_grad(k->raw_params[OFF_IDX(np)]);
+            * softplus_grad(k->raw_params[OFF_IDX(np)]);
         CUDA_CHECK(cudaFreeAsync(d_ones, stream));
         CUDA_CHECK(cudaFreeAsync(d_wrow, stream));
     }
@@ -315,34 +339,34 @@ static void matern32lin_mll_grad(const GPKernel *k, const float *d_X, int n, int
     CUDA_CHECK(cudaFreeAsync(d_temp, stream));
 }
 
-static void matern32lin_destroy(GPKernel *k) { free(k); }
+static void matern32lin_destroy(GPKernel* k) { free(k); }
 
-GPKernel *gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
-                                        float offset)
+GPKernel* gp_kernel_matern32_linear(int dim, float lengthscale, float outputscale,
+    float offset)
 {
     int n_params = dim + 2;
-    GPKernel *k = (GPKernel *)malloc(sizeof(GPKernel) + (size_t)n_params * sizeof(float));
-    k->n_params   = n_params;
-    k->raw_params = (float *)(k + 1);
+    GPKernel* k = (GPKernel*)malloc(sizeof(GPKernel) + (size_t)n_params * sizeof(float));
+    k->n_params = n_params;
+    k->raw_params = (float*)(k + 1);
     memcpy(k->tag, GP_KERNEL_TAG_MATERN32_LINEAR, 4);
     for (int i = 0; i < dim; i++)
         k->raw_params[i] = inv_softplus(lengthscale);
-    k->raw_params[SF_IDX(n_params)]  = inv_softplus(outputscale);
+    k->raw_params[SF_IDX(n_params)] = inv_softplus(outputscale);
     k->raw_params[OFF_IDX(n_params)] = inv_softplus(offset);
-    k->build_K          = matern32lin_build_K;
-    k->build_Ks         = matern32lin_build_Ks;
+    k->build_K = matern32lin_build_K;
+    k->build_Ks = matern32lin_build_Ks;
     k->build_kself_batch = matern32lin_build_kself_batch;
-    k->k_self           = matern32lin_k_self;
-    k->mll_grad         = matern32lin_mll_grad;
-    k->destroy          = matern32lin_destroy;
+    k->k_self = matern32lin_k_self;
+    k->mll_grad = matern32lin_mll_grad;
+    k->destroy = matern32lin_destroy;
     return k;
 }
 
-float gp_kernel_get_lengthscale(const GPKernel *k, int d) { return softplus(k->raw_params[d]); }
-float gp_kernel_get_outputscale(const GPKernel *k) { return softplus(k->raw_params[SF_IDX(k->n_params)]);  }
-float gp_kernel_get_offset     (const GPKernel *k) { return softplus(k->raw_params[OFF_IDX(k->n_params)]); }
-void gp_kernel_set_lengthscale(GPKernel *k, int d, float v) { k->raw_params[d] = inv_softplus(v); }
-void gp_kernel_set_outputscale(GPKernel *k, float v) { k->raw_params[SF_IDX(k->n_params)]  = inv_softplus(v); }
-void gp_kernel_set_offset     (GPKernel *k, float v) { k->raw_params[OFF_IDX(k->n_params)] = inv_softplus(v); }
+float gp_kernel_get_lengthscale(const GPKernel* k, int d) { return softplus(k->raw_params[d]); }
+float gp_kernel_get_outputscale(const GPKernel* k) { return softplus(k->raw_params[SF_IDX(k->n_params)]); }
+float gp_kernel_get_offset(const GPKernel* k) { return softplus(k->raw_params[OFF_IDX(k->n_params)]); }
+void gp_kernel_set_lengthscale(GPKernel* k, int d, float v) { k->raw_params[d] = inv_softplus(v); }
+void gp_kernel_set_outputscale(GPKernel* k, float v) { k->raw_params[SF_IDX(k->n_params)] = inv_softplus(v); }
+void gp_kernel_set_offset(GPKernel* k, float v) { k->raw_params[OFF_IDX(k->n_params)] = inv_softplus(v); }
 
 #endif // GP_CUDA_KERNEL_CU

--- a/src/gp_cuda_kernel.cu
+++ b/src/gp_cuda_kernel.cu
@@ -79,6 +79,11 @@ void gp_kernel_set_offset(GPKernel* k, float v);
 #define OFF_IDX(np) ((np)-1)
 
 #define GP_BLOCK 16
+
+#ifndef BLOCK_SIZE
+#define BLOCK_SIZE 256
+#endif
+
 inline int gp_grid(int n)
 {
     return (n + GP_BLOCK - 1) / GP_BLOCK;
@@ -183,7 +188,7 @@ __global__ void matern32lin_k_dk_dell_d(
 
 __global__ void matern32lin_k_fill(float* v, int n, float val)
 {
-    int i = blockIdx.x * 256 + threadIdx.x;
+    int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         v[i] = val;
 }
@@ -192,7 +197,7 @@ __global__ void matern32lin_k_kself_batch(
     const float* __restrict__ X, float* __restrict__ out,
     int m, int d, float sigma_f, float offset)
 {
-    int row = blockIdx.x * 256 + threadIdx.x;
+    int row = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (row >= m)
         return;
     float norm2 = 0.0;
@@ -269,7 +274,7 @@ static void matern32lin_build_kself_batch(const GPKernel* k, const float* d_X,
     int np = k->n_params;
     float sigma_f = softplus(k->raw_params[SF_IDX(np)]);
     float offset = softplus(k->raw_params[OFF_IDX(np)]);
-    matern32lin_k_kself_batch<<<(m + 255) / 256, 256, 0, stream>>>(d_X, d_out, m, d, sigma_f, offset);
+    matern32lin_k_kself_batch<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_X, d_out, m, d, sigma_f, offset);
     CUDA_CHECK(cudaGetLastError());
 }
 
@@ -321,7 +326,7 @@ static void matern32lin_mll_grad(const GPKernel* k, const float* d_X, int n, int
         float *d_ones, *d_wrow;
         CUDA_CHECK(cudaMallocAsync(&d_ones, (size_t)n * sizeof(float), stream));
         CUDA_CHECK(cudaMallocAsync(&d_wrow, (size_t)n * sizeof(float), stream));
-        matern32lin_k_fill<<<(n + 255) / 256, 256, 0, stream>>>(d_ones, n, 1.0);
+        matern32lin_k_fill<<<(n + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(d_ones, n, 1.0);
         CUDA_CHECK(cudaGetLastError());
         float w_sum;
         CUBLAS_CHECK(cublasSgemv(cublas, CUBLAS_OP_N, n, n,

--- a/src/protein.cu
+++ b/src/protein.cu
@@ -1,7 +1,4 @@
 // protein.cu -- Protein hyperparameter optimizer (CUDA).
-//
-// Depends on: gp_cuda.cu (GP, KDTree, CUDA_CHECK).
-// Includes: protein_util.h (Space, Pareto, CostModel, numeric helpers).
 
 #ifndef PROTEIN_CU
 #define PROTEIN_CU
@@ -25,27 +22,31 @@
 #define PROTEIN_THRESHOLD_FALLBACK 0.9f
 #define PROTEIN_RUNNING_BUF_CAP 30
 
+// clang-format off
 #include "protein_util.h"
 #include "gp_cuda.cu"
+// clang-format on
 
-// -- structs ------------------------------------------------------------------
+// clang-format off
+static inline void _curand_check(curandStatus_t s, const char* f, int l) {
+    if (s != CURAND_STATUS_SUCCESS) { fprintf(stderr, "cuRAND error %s:%d: %d\n", f, l, (int)s); abort(); }
+}
+#define CURAND_CHECK(call) _curand_check((call), __FILE__, __LINE__)
+// clang-format on
 
 typedef struct {
     int dim;
     int capacity;
-
-    float* d_bounds_min; // [dim]
-    float* d_bounds_max; // [dim]
-    float* d_scales; // [dim]
-
-    float* d_candidates; // [capacity * dim]
-    float* d_pred_y; // [capacity]
-    float* d_pred_c; // [capacity]
-    float* d_scores; // [capacity]
-    float* d_success_prob; // [capacity]
-    int* d_best_idx; // [1]
-
-    curandStatePhilox4_32_10_t* d_rng; // [capacity]
+    float *d_bounds_min;
+    float *d_bounds_max;
+    float *d_scales;
+    float *d_candidates;
+    float *d_pred_y;
+    float *d_pred_c;
+    float *d_scores;
+    float *d_success_prob;
+    int *d_best_idx;
+    curandStatePhilox4_32_10_t *d_rng;
 } ProteinAcq;
 
 typedef struct {
@@ -56,50 +57,46 @@ typedef struct {
 } ProteinAcqResult;
 
 typedef struct {
-    float* weights; // [dim] host
-    float* d_weights; // [dim] device
+    float *weights;
+    float *d_weights;
     float bias;
     int dim;
     int is_fitted;
 } ProteinClassifier;
 
 typedef struct {
-    float* params; // [cap * dim]
-    float* scores; // [cap]
-    float* costs; // [cap]
+    float *params;
+    float *scores;
+    float *costs;
     int n, cap;
 } ProteinObsList;
 
 typedef struct {
     ProteinObsList success;
     ProteinObsList failure;
-    int* top_idx; // [top_k] indices into success, sorted descending by score
+    int *top_idx;
     int n_top, top_k;
     int dim, cost_dim;
     float min_score, max_score;
     float log_c_min, log_c_max;
 } ProteinObs;
 
-// -- device kernels -----------------------------------------------------------
+typedef struct {
+    curandGenerator_t gen;
+    int dim;
+} Sobol;
 
-__global__ void protein_k_init_rng(curandStatePhilox4_32_10_t* states, int n,
-    unsigned long long seed)
-{
+__global__ void protein_k_init_rng(curandStatePhilox4_32_10_t *states, int n, unsigned long long seed) {
     int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i < n)
         curand_init(seed, i, 0, &states[i]);
 }
 
-__global__ void protein_k_sample(
-    float* __restrict__ candidates,
-    const float* __restrict__ centers,
-    const float* __restrict__ bounds_min,
-    const float* __restrict__ bounds_max,
-    const float* __restrict__ scales,
-    curandStatePhilox4_32_10_t* __restrict__ rng,
-    int n_candidates, int n_centers, int dim,
-    float global_scale, int cost_dim, float fixed_cost)
-{
+__global__ void protein_k_sample(float *__restrict__ candidates, const float *__restrict__ centers,
+                                 const float *__restrict__ bounds_min, const float *__restrict__ bounds_max,
+                                 const float *__restrict__ scales, curandStatePhilox4_32_10_t *__restrict__ rng,
+                                 int n_candidates, int n_centers, int dim, float global_scale, int cost_dim,
+                                 float fixed_cost) {
     int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i >= n_candidates)
         return;
@@ -109,8 +106,7 @@ __global__ void protein_k_sample(
 
     for (int d = 0; d < dim; d++) {
         float s = scales[d] * global_scale;
-        float val = s * (2.0f * curand_uniform(&state) - 1.0f)
-            + centers[center * dim + d];
+        float val = s * (2.0f * curand_uniform(&state) - 1.0f) + centers[center * dim + d];
         val = fmaxf(bounds_min[d], fminf(bounds_max[d], val));
         candidates[i * dim + d] = val;
     }
@@ -121,17 +117,10 @@ __global__ void protein_k_sample(
     rng[i] = state;
 }
 
-__global__ void protein_k_score(
-    const float* __restrict__ pred_y_norm,
-    const float* __restrict__ pred_c_norm,
-    const float* __restrict__ success_prob,
-    float* __restrict__ scores,
-    int m,
-    float min_score, float max_score,
-    float log_c_min, float log_c_max,
-    float max_cost, float target_cost,
-    int optimize_dir, int fixed_cost)
-{
+__global__ void protein_k_score(const float *__restrict__ pred_y_norm, const float *__restrict__ pred_c_norm,
+                                const float *__restrict__ success_prob, float *__restrict__ scores, int m,
+                                float min_score, float max_score, float log_c_min, float log_c_max, float max_cost,
+                                float target_cost, int optimize_dir, int fixed_cost) {
     int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i >= m)
         return;
@@ -154,9 +143,7 @@ __global__ void protein_k_score(
     scores[i] = s;
 }
 
-__global__ void protein_k_argmax(const float* __restrict__ scores, int n,
-    int* out_idx)
-{
+__global__ void protein_k_argmax(const float *__restrict__ scores, int n, int *out_idx) {
     __shared__ float s_val[BLOCK_SIZE];
     __shared__ int s_idx[BLOCK_SIZE];
 
@@ -186,12 +173,8 @@ __global__ void protein_k_argmax(const float* __restrict__ scores, int n,
         *out_idx = s_idx[0];
 }
 
-__global__ void protein_k_classifier_predict(
-    const float* __restrict__ X,
-    const float* __restrict__ weights,
-    float bias, float* __restrict__ probs,
-    int m, int dim)
-{
+__global__ void protein_k_classifier_predict(const float *__restrict__ X, const float *__restrict__ weights, float bias,
+                                             float *__restrict__ probs, int m, int dim) {
     int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
     if (i >= m)
         return;
@@ -201,19 +184,15 @@ __global__ void protein_k_classifier_predict(
     probs[i] = 1.0f / (1.0f + expf(-z));
 }
 
-// -- classifier ---------------------------------------------------------------
-
-ProteinClassifier* protein_classifier_create(int dim)
-{
-    ProteinClassifier* clf = (ProteinClassifier*)calloc(1, sizeof(ProteinClassifier));
+ProteinClassifier *protein_classifier_create(int dim) {
+    ProteinClassifier *clf = (ProteinClassifier *)calloc(1, sizeof(ProteinClassifier));
     clf->dim = dim;
-    clf->weights = (float*)calloc((size_t)dim, sizeof(float));
+    clf->weights = (float *)calloc((size_t)dim, sizeof(float));
     CUDA_CHECK(cudaMalloc(&clf->d_weights, (size_t)dim * sizeof(float)));
     return clf;
 }
 
-void protein_classifier_destroy(ProteinClassifier* clf)
-{
+void protein_classifier_destroy(ProteinClassifier *clf) {
     if (!clf)
         return;
     free(clf->weights);
@@ -221,10 +200,7 @@ void protein_classifier_destroy(ProteinClassifier* clf)
     free(clf);
 }
 
-void protein_classifier_fit(ProteinClassifier* clf,
-    const float* X, const int* y, int n,
-    float C_reg, int max_iter)
-{
+void protein_classifier_fit(ProteinClassifier *clf, const float *X, const int *y, int n, float C_reg, int max_iter) {
     int dim = clf->dim;
     clf->is_fitted = 0;
 
@@ -241,7 +217,7 @@ void protein_classifier_fit(ProteinClassifier* clf,
 
     memset(clf->weights, 0, (size_t)dim * sizeof(float));
     clf->bias = 0.0f;
-    float* grad = (float*)calloc((size_t)dim, sizeof(float));
+    float *grad = (float *)calloc((size_t)dim, sizeof(float));
 
     for (int iter = 0; iter < max_iter; iter++) {
         float lr = 0.1f / (1.0f + 0.01f * (float)iter);
@@ -271,98 +247,68 @@ void protein_classifier_fit(ProteinClassifier* clf,
     free(grad);
     clf->is_fitted = 1;
 
-    CUDA_CHECK(cudaMemcpy(clf->d_weights, clf->weights,
-        (size_t)dim * sizeof(float), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(clf->d_weights, clf->weights, (size_t)dim * sizeof(float), cudaMemcpyHostToDevice));
 }
 
-void protein_classifier_predict_d(const ProteinClassifier* clf,
-    const float* d_X, float* d_probs,
-    int m, cudaStream_t stream)
-{
+void protein_classifier_predict_d(const ProteinClassifier *clf, const float *d_X, float *d_probs, int m,
+                                  cudaStream_t stream) {
     protein_k_classifier_predict<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
         d_X, clf->d_weights, clf->bias, d_probs, m, clf->dim);
     CUDA_CHECK(cudaGetLastError());
 }
 
-// -- acquisition lifecycle ----------------------------------------------------
-
-ProteinAcq* protein_acq_create(int dim, int capacity,
-    const float* bounds_min, const float* bounds_max,
-    const float* scales, unsigned long long rng_seed)
-{
-    ProteinAcq* acq = (ProteinAcq*)calloc(1, sizeof(ProteinAcq));
+ProteinAcq *protein_acq_create(int dim, int capacity, const float *bounds_min, const float *bounds_max,
+                               const float *scales, unsigned long long rng_seed) {
+    ProteinAcq *acq = (ProteinAcq *)calloc(1, sizeof(ProteinAcq));
     acq->dim = dim;
     acq->capacity = capacity;
 
     CUDA_CHECK(cudaMalloc(&acq->d_bounds_min, (size_t)dim * sizeof(float)));
     CUDA_CHECK(cudaMalloc(&acq->d_bounds_max, (size_t)dim * sizeof(float)));
     CUDA_CHECK(cudaMalloc(&acq->d_scales, (size_t)dim * sizeof(float)));
-    CUDA_CHECK(cudaMemcpy(acq->d_bounds_min, bounds_min,
-        (size_t)dim * sizeof(float), cudaMemcpyHostToDevice));
-    CUDA_CHECK(cudaMemcpy(acq->d_bounds_max, bounds_max,
-        (size_t)dim * sizeof(float), cudaMemcpyHostToDevice));
-    CUDA_CHECK(cudaMemcpy(acq->d_scales, scales,
-        (size_t)dim * sizeof(float), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(acq->d_bounds_min, bounds_min, (size_t)dim * sizeof(float), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(acq->d_bounds_max, bounds_max, (size_t)dim * sizeof(float), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(acq->d_scales, scales, (size_t)dim * sizeof(float), cudaMemcpyHostToDevice));
 
-    CUDA_CHECK(cudaMalloc(&acq->d_candidates,
-        (size_t)capacity * dim * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&acq->d_candidates, (size_t)capacity * dim * sizeof(float)));
     CUDA_CHECK(cudaMalloc(&acq->d_pred_y, (size_t)capacity * sizeof(float)));
     CUDA_CHECK(cudaMalloc(&acq->d_pred_c, (size_t)capacity * sizeof(float)));
     CUDA_CHECK(cudaMalloc(&acq->d_scores, (size_t)capacity * sizeof(float)));
     CUDA_CHECK(cudaMalloc(&acq->d_success_prob, (size_t)capacity * sizeof(float)));
     CUDA_CHECK(cudaMalloc(&acq->d_best_idx, sizeof(int)));
-    CUDA_CHECK(cudaMalloc(&acq->d_rng,
-        (size_t)capacity * sizeof(curandStatePhilox4_32_10_t)));
+    CUDA_CHECK(cudaMalloc(&acq->d_rng, (size_t)capacity * sizeof(curandStatePhilox4_32_10_t)));
 
-    protein_k_init_rng<<<(capacity + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(
-        acq->d_rng, capacity, rng_seed);
+    protein_k_init_rng<<<(capacity + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(acq->d_rng, capacity, rng_seed);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaDeviceSynchronize());
 
     return acq;
 }
 
-void protein_acq_destroy(ProteinAcq* acq)
-{
+void protein_acq_destroy(ProteinAcq *acq) {
     if (!acq)
         return;
-    cudaFree(acq->d_bounds_min);
-    cudaFree(acq->d_bounds_max);
-    cudaFree(acq->d_scales);
-    cudaFree(acq->d_candidates);
-    cudaFree(acq->d_pred_y);
-    cudaFree(acq->d_pred_c);
-    cudaFree(acq->d_scores);
-    cudaFree(acq->d_success_prob);
-    cudaFree(acq->d_best_idx);
-    cudaFree(acq->d_rng);
+    void *ptrs[] = {acq->d_bounds_min, acq->d_bounds_max, acq->d_scales,       acq->d_candidates, acq->d_pred_y,
+                    acq->d_pred_c,     acq->d_scores,     acq->d_success_prob, acq->d_best_idx,   acq->d_rng};
+    for (int i = 0; i < 10; i++)
+        cudaFree(ptrs[i]);
     free(acq);
 }
 
-// -- sampling -----------------------------------------------------------------
-
-int protein_acq_sample(ProteinAcq* acq,
-    const float* centers, int n_centers, int n_total,
-    float global_scale,
-    int cost_dim, float fixed_cost_norm,
-    float dedup_threshold, cudaStream_t stream)
-{
+int protein_acq_sample(ProteinAcq *acq, const float *centers, int n_centers, int n_total, float global_scale,
+                       int cost_dim, float fixed_cost_norm, float dedup_threshold, cudaStream_t stream) {
     int dim = acq->dim;
     if (n_total > acq->capacity)
         n_total = acq->capacity;
 
-    float* d_centers;
-    CUDA_CHECK(cudaMallocAsync(&d_centers,
-        (size_t)n_centers * dim * sizeof(float), stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_centers, centers,
-        (size_t)n_centers * dim * sizeof(float),
-        cudaMemcpyHostToDevice, stream));
+    float *d_centers;
+    CUDA_CHECK(cudaMallocAsync(&d_centers, (size_t)n_centers * dim * sizeof(float), stream));
+    CUDA_CHECK(
+        cudaMemcpyAsync(d_centers, centers, (size_t)n_centers * dim * sizeof(float), cudaMemcpyHostToDevice, stream));
 
     protein_k_sample<<<(n_total + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
-        acq->d_candidates, d_centers,
-        acq->d_bounds_min, acq->d_bounds_max, acq->d_scales,
-        acq->d_rng, n_total, n_centers, dim,
-        global_scale, cost_dim, fixed_cost_norm);
+        acq->d_candidates, d_centers, acq->d_bounds_min, acq->d_bounds_max, acq->d_scales, acq->d_rng, n_total,
+        n_centers, dim, global_scale, cost_dim, fixed_cost_norm);
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaFreeAsync(d_centers, stream));
 
@@ -371,24 +317,20 @@ int protein_acq_sample(ProteinAcq* acq,
         return n_total;
     }
 
-    float* h_cands = (float*)malloc((size_t)n_total * dim * sizeof(float));
-    CUDA_CHECK(cudaMemcpyAsync(h_cands, acq->d_candidates,
-        (size_t)n_total * dim * sizeof(float),
-        cudaMemcpyDeviceToHost, stream));
+    float *h_cands = (float *)malloc((size_t)n_total * dim * sizeof(float));
+    CUDA_CHECK(cudaMemcpyAsync(h_cands, acq->d_candidates, (size_t)n_total * dim * sizeof(float),
+                               cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaStreamSynchronize(stream));
 
-    int* kept = (int*)malloc((size_t)n_total * sizeof(int));
-    int n_kept = gp_filter_near_duplicates(h_cands, n_total, dim,
-        dedup_threshold, kept);
+    int *kept = (int *)malloc((size_t)n_total * sizeof(int));
+    int n_kept = gp_filter_near_duplicates(h_cands, n_total, dim, dedup_threshold, kept);
 
     if (n_kept > 0 && n_kept < n_total) {
-        float* h_compact = (float*)malloc((size_t)n_kept * dim * sizeof(float));
+        float *h_compact = (float *)malloc((size_t)n_kept * dim * sizeof(float));
         for (int i = 0; i < n_kept; i++)
-            memcpy(&h_compact[(size_t)i * dim], &h_cands[(size_t)kept[i] * dim],
-                (size_t)dim * sizeof(float));
-        CUDA_CHECK(cudaMemcpyAsync(acq->d_candidates, h_compact,
-            (size_t)n_kept * dim * sizeof(float),
-            cudaMemcpyHostToDevice, stream));
+            memcpy(&h_compact[(size_t)i * dim], &h_cands[(size_t)kept[i] * dim], (size_t)dim * sizeof(float));
+        CUDA_CHECK(cudaMemcpyAsync(acq->d_candidates, h_compact, (size_t)n_kept * dim * sizeof(float),
+                                   cudaMemcpyHostToDevice, stream));
         CUDA_CHECK(cudaStreamSynchronize(stream));
         free(h_compact);
     }
@@ -398,94 +340,63 @@ int protein_acq_sample(ProteinAcq* acq,
     return n_kept;
 }
 
-// -- scoring ------------------------------------------------------------------
+ProteinAcqResult protein_acq_suggest(ProteinAcq *acq, int m, const GaussianProcess *gp_score,
+                                     const GaussianProcess *gp_cost, float min_score, float max_score, float log_c_min,
+                                     float log_c_max, float max_suggestion_cost, float target_cost_ratio,
+                                     int optimize_direction, int fixed_cost, const float *d_success_prob,
+                                     cudaStream_t stream) {
+    gp_predict_d(gp_score, acq->d_candidates, acq->d_pred_y, NULL, m, stream);
+    gp_predict_d(gp_cost, acq->d_candidates, acq->d_pred_c, NULL, m, stream);
 
-ProteinAcqResult protein_acq_score(
-    ProteinAcq* acq, int m,
-    float min_score, float max_score,
-    float log_c_min, float log_c_max,
-    float max_suggestion_cost, float target_cost_ratio,
-    int optimize_direction, int fixed_cost,
-    const float* d_success_prob, cudaStream_t stream)
-{
     protein_k_score<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
-        acq->d_pred_y, acq->d_pred_c, d_success_prob,
-        acq->d_scores, m,
-        min_score, max_score, log_c_min, log_c_max,
-        max_suggestion_cost, target_cost_ratio,
-        optimize_direction, fixed_cost);
+        acq->d_pred_y, acq->d_pred_c, d_success_prob, acq->d_scores, m, min_score, max_score, log_c_min, log_c_max,
+        max_suggestion_cost, target_cost_ratio, optimize_direction, fixed_cost);
     CUDA_CHECK(cudaGetLastError());
 
     protein_k_argmax<<<1, BLOCK_SIZE, 0, stream>>>(acq->d_scores, m, acq->d_best_idx);
     CUDA_CHECK(cudaGetLastError());
 
     int best;
-    CUDA_CHECK(cudaMemcpyAsync(&best, acq->d_best_idx, sizeof(int),
-        cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaMemcpyAsync(&best, acq->d_best_idx, sizeof(int), cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaStreamSynchronize(stream));
 
     float y_norm, c_norm, rating;
-    CUDA_CHECK(cudaMemcpy(&y_norm, &acq->d_pred_y[best], sizeof(float),
-        cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(&c_norm, &acq->d_pred_c[best], sizeof(float),
-        cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaMemcpy(&rating, &acq->d_scores[best], sizeof(float),
-        cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(&y_norm, &acq->d_pred_y[best], sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(&c_norm, &acq->d_pred_c[best], sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(&rating, &acq->d_scores[best], sizeof(float), cudaMemcpyDeviceToHost));
 
-    ProteinAcqResult result;
-    result.best_idx = best;
-    result.predicted_score = y_norm * (max_score - min_score) + min_score;
-    result.predicted_cost = expf(c_norm * (log_c_max - log_c_min) + log_c_min);
-    result.rating = rating;
-    return result;
+    return (ProteinAcqResult){
+        .best_idx = best,
+        .predicted_score = y_norm * (max_score - min_score) + min_score,
+        .predicted_cost = expf(c_norm * (log_c_max - log_c_min) + log_c_min),
+        .rating = rating,
+    };
 }
 
-ProteinAcqResult protein_acq_suggest(
-    ProteinAcq* acq, int m,
-    const GaussianProcess* gp_score, const GaussianProcess* gp_cost,
-    float min_score, float max_score,
-    float log_c_min, float log_c_max,
-    float max_suggestion_cost, float target_cost_ratio,
-    int optimize_direction, int fixed_cost,
-    const float* d_success_prob, cudaStream_t stream)
-{
-    gp_predict_d(gp_score, acq->d_candidates, acq->d_pred_y, NULL, m, stream);
-    gp_predict_d(gp_cost, acq->d_candidates, acq->d_pred_c, NULL, m, stream);
-    return protein_acq_score(acq, m, min_score, max_score, log_c_min, log_c_max,
-        max_suggestion_cost, target_cost_ratio,
-        optimize_direction, fixed_cost,
-        d_success_prob, stream);
-}
-
-// -- GP optimizer (Adam + noise prior) ----------------------------------------
-
-#define NOISE_PRIOR_MU (-4.60517f) // log(1e-2)
+#define NOISE_PRIOR_MU (-4.60517f)
 #define NOISE_PRIOR_SIGMA 0.5f
 
 typedef struct {
-    float *m, *v, *v_max; // [n] each
+    float *m, *v, *v_max;
     float lr, beta1, beta2, eps;
     int t, n;
 } Adam;
 
-Adam* adam_create(int n_kernel_params, float lr)
-{
+Adam *adam_create(int n_kernel_params, float lr) {
     int n = n_kernel_params + 1;
-    Adam* opt = (Adam*)calloc(1, sizeof(Adam));
+    Adam *opt = (Adam *)calloc(1, sizeof(Adam));
     opt->n = n;
     opt->lr = lr;
     opt->beta1 = 0.9f;
     opt->beta2 = 0.999f;
     opt->eps = 1e-8f;
-    opt->t = 0;
-    opt->m = (float*)calloc((size_t)n, sizeof(float));
-    opt->v = (float*)calloc((size_t)n, sizeof(float));
-    opt->v_max = (float*)calloc((size_t)n, sizeof(float));
+    opt->m = (float *)calloc((size_t)n, sizeof(float));
+    opt->v = (float *)calloc((size_t)n, sizeof(float));
+    opt->v_max = (float *)calloc((size_t)n, sizeof(float));
     return opt;
 }
 
-void adam_destroy(Adam* opt)
-{
+void adam_destroy(Adam *opt) {
     if (!opt)
         return;
     free(opt->m);
@@ -494,37 +405,30 @@ void adam_destroy(Adam* opt)
     free(opt);
 }
 
-void adam_reset(Adam* opt)
-{
+void adam_reset(Adam *opt) {
     memset(opt->m, 0, (size_t)opt->n * sizeof(float));
     memset(opt->v, 0, (size_t)opt->n * sizeof(float));
     memset(opt->v_max, 0, (size_t)opt->n * sizeof(float));
     opt->t = 0;
 }
 
-static float noise_log_prior_grad(float raw_noise)
-{
-    float sig = softplus_grad(raw_noise); // sigmoid(raw_noise)
-    float noise = softplus(raw_noise); // includes + SP_LB
+static float noise_log_prior_grad(float raw_noise) {
+    float sig = softplus_grad(raw_noise);
+    float noise = softplus(raw_noise);
     float log_noise = logf(noise);
-    float d_log_p = (-(log_noise - NOISE_PRIOR_MU)
-                            / (NOISE_PRIOR_SIGMA * NOISE_PRIOR_SIGMA)
-                        - 1.0f)
-        * sig / noise;
-    float d_log_jac = 1.0f - sig; // sigmoid(-raw_noise)
+    float d_log_p = (-(log_noise - NOISE_PRIOR_MU) / (NOISE_PRIOR_SIGMA * NOISE_PRIOR_SIGMA) - 1.0f) * sig / noise;
+    float d_log_jac = 1.0f - sig;
     return d_log_p + d_log_jac;
 }
 
-float protein_train_gp(GaussianProcess* gp, Adam* opt,
-    const float* X, const float* y, int n_data,
-    int training_iter, cudaStream_t stream)
-{
+float protein_train_gp(GaussianProcess *gp, Adam *opt, const float *X, const float *y, int n_data, int training_iter,
+                       cudaStream_t stream) {
     int rc = gp_fit(gp, X, y, n_data, stream);
     if (rc != 0)
         return 0.0f;
 
     int n_kp = gp->kernel->n_params;
-    float* kg = (float*)malloc((size_t)n_kp * sizeof(float));
+    float *kg = (float *)malloc((size_t)n_kp * sizeof(float));
     float loss = 0.0f;
 
     for (int iter = 0; iter < training_iter; iter++) {
@@ -541,10 +445,10 @@ float protein_train_gp(GaussianProcess* gp, Adam* opt,
 
         float noise_val = softplus(gp->raw_noise);
         float ln_noise = logf(noise_val);
-        float lp = -0.5f * powf((ln_noise - NOISE_PRIOR_MU) / NOISE_PRIOR_SIGMA, 2.0f)
-            - ln_noise - logf(NOISE_PRIOR_SIGMA); // log-prob
-        float lj = -log1pf(expf(-gp->raw_noise)); // log-Jacobian
-        loss = -mll - (lp + lj); // Change of variables posterior
+        float lp =
+            -0.5f * powf((ln_noise - NOISE_PRIOR_MU) / NOISE_PRIOR_SIGMA, 2.0f) - ln_noise - logf(NOISE_PRIOR_SIGMA);
+        float lj = -log1pf(expf(-gp->raw_noise));
+        loss = -mll - (lp + lj);
 
         opt->t++;
         float bc1 = 1.0f - powf(opt->beta1, (float)opt->t);
@@ -571,110 +475,61 @@ float protein_train_gp(GaussianProcess* gp, Adam* opt,
     return loss;
 }
 
-// -- data access --------------------------------------------------------------
-
-void protein_acq_get_candidate(const ProteinAcq* acq, int idx,
-    float* out, cudaStream_t stream)
-{
-    CUDA_CHECK(cudaMemcpyAsync(out, &acq->d_candidates[(size_t)idx * acq->dim],
-        (size_t)acq->dim * sizeof(float),
-        cudaMemcpyDeviceToHost, stream));
-    CUDA_CHECK(cudaStreamSynchronize(stream));
-}
-
-// -- Sobol quasi-random sequence (cuRAND) --------------------------------------
-
-#define CURAND_CHECK(call)                                                  \
-    do {                                                                    \
-        curandStatus_t _s = (call);                                         \
-        if (_s != CURAND_STATUS_SUCCESS) {                                  \
-            fprintf(stderr, "cuRAND error %s:%d: %d\n", __FILE__, __LINE__, \
-                (int)_s);                                                   \
-            abort();                                                        \
-        }                                                                   \
-    } while (0)
-
-typedef struct {
-    curandGenerator_t gen;
-    int dim;
-} Sobol;
-
-Sobol* sobol_create(int dim, unsigned long long seed)
-{
-    Sobol* sob = (Sobol*)calloc(1, sizeof(Sobol));
+Sobol *sobol_create(int dim, unsigned long long seed) {
+    Sobol *sob = (Sobol *)calloc(1, sizeof(Sobol));
     sob->dim = dim;
-    CURAND_CHECK(curandCreateGeneratorHost(&sob->gen,
-        CURAND_RNG_QUASI_SCRAMBLED_SOBOL32));
+    CURAND_CHECK(curandCreateGeneratorHost(&sob->gen, CURAND_RNG_QUASI_SCRAMBLED_SOBOL32));
     CURAND_CHECK(curandSetQuasiRandomGeneratorDimensions(sob->gen, dim));
     CURAND_CHECK(curandSetGeneratorOffset(sob->gen, seed));
     return sob;
 }
 
-void sobol_destroy(Sobol* sob)
-{
+void sobol_destroy(Sobol *sob) {
     if (!sob)
         return;
     curandDestroyGenerator(sob->gen);
     free(sob);
 }
 
-void sobol_next(Sobol* sob, float* out)
-{
-    CURAND_CHECK(curandGenerateUniform(sob->gen, out, sob->dim));
-}
-
-// -- observation store --------------------------------------------------------
-
-static void protein_obs_list_init(ProteinObsList* l, int dim, int cap)
-{
-    l->params = (float*)calloc((size_t)cap * dim, sizeof(float));
-    l->scores = (float*)calloc((size_t)cap, sizeof(float));
-    l->costs = (float*)calloc((size_t)cap, sizeof(float));
-    l->n = 0;
-    l->cap = cap;
-}
-
-static void protein_obs_list_free(ProteinObsList* l)
-{
-    free(l->params);
-    free(l->scores);
-    free(l->costs);
-}
-
-ProteinObs* protein_obs_create(int dim, int success_cap, int failure_cap,
-    int top_k, int cost_dim)
-{
-    ProteinObs* obs = (ProteinObs*)calloc(1, sizeof(ProteinObs));
+ProteinObs *protein_obs_create(int dim, int success_cap, int failure_cap, int top_k, int cost_dim) {
+    ProteinObs *obs = (ProteinObs *)calloc(1, sizeof(ProteinObs));
     obs->dim = dim;
     obs->cost_dim = cost_dim;
     obs->top_k = top_k;
-    obs->top_idx = (int*)malloc((size_t)top_k * sizeof(int));
+    obs->top_idx = (int *)malloc((size_t)top_k * sizeof(int));
     obs->min_score = FLT_MAX;
     obs->max_score = -FLT_MAX;
     obs->log_c_min = FLT_MAX;
     obs->log_c_max = -FLT_MAX;
-    protein_obs_list_init(&obs->success, dim, success_cap);
-    protein_obs_list_init(&obs->failure, dim, failure_cap);
+    obs->success.params = (float *)calloc((size_t)success_cap * dim, sizeof(float));
+    obs->success.scores = (float *)calloc((size_t)success_cap, sizeof(float));
+    obs->success.costs = (float *)calloc((size_t)success_cap, sizeof(float));
+    obs->success.cap = success_cap;
+    obs->failure.params = (float *)calloc((size_t)failure_cap * dim, sizeof(float));
+    obs->failure.scores = (float *)calloc((size_t)failure_cap, sizeof(float));
+    obs->failure.costs = (float *)calloc((size_t)failure_cap, sizeof(float));
+    obs->failure.cap = failure_cap;
     return obs;
 }
 
-void protein_obs_destroy(ProteinObs* obs)
-{
+void protein_obs_destroy(ProteinObs *obs) {
     if (!obs)
         return;
-    protein_obs_list_free(&obs->success);
-    protein_obs_list_free(&obs->failure);
+    free(obs->success.params);
+    free(obs->success.scores);
+    free(obs->success.costs);
+    free(obs->failure.params);
+    free(obs->failure.scores);
+    free(obs->failure.costs);
     free(obs->top_idx);
     free(obs);
 }
 
-void protein_obs_add(ProteinObs* obs, const float* params, float score,
-    float cost, int is_failure)
-{
+void protein_obs_add(ProteinObs *obs, const float *params, float score, float cost, int is_failure) {
     int dim = obs->dim;
 
     if (is_failure || !isfinite(score) || isnan(score)) {
-        ProteinObsList* f = &obs->failure;
+        ProteinObsList *f = &obs->failure;
         if (f->n < f->cap) {
             int i = f->n++;
             memcpy(&f->params[(size_t)i * dim], params, (size_t)dim * sizeof(float));
@@ -684,7 +539,7 @@ void protein_obs_add(ProteinObs* obs, const float* params, float score,
         return;
     }
 
-    ProteinObsList* s = &obs->success;
+    ProteinObsList *s = &obs->success;
 
     for (int i = 0; i < s->n; i++) {
         float dist2 = 0.0f;
@@ -728,19 +583,16 @@ void protein_obs_add(ProteinObs* obs, const float* params, float score,
     }
 }
 
-static void protein_obs_extract(const float* ext, int ext_dim, int dim,
-    int idx, float* out_params, float* out_score, float* out_cost)
-{
+static void protein_obs_extract(const float *ext, int ext_dim, int dim, int idx, float *out_params, float *out_score,
+                                float *out_cost) {
     memcpy(out_params, &ext[(size_t)idx * ext_dim], (size_t)dim * sizeof(float));
     *out_score = ext[(size_t)idx * ext_dim + dim];
     *out_cost = ext[(size_t)idx * ext_dim + dim + 1];
 }
 
-int protein_obs_sample_for_gp(ProteinObs* obs, int max_size,
-    float recent_ratio, float* out_params, float* out_scores,
-    float* out_costs)
-{
-    ProteinObsList* s = &obs->success;
+int protein_obs_sample_for_gp(ProteinObs *obs, int max_size, float recent_ratio, float *out_params, float *out_scores,
+                              float *out_costs) {
+    ProteinObsList *s = &obs->success;
     int dim = obs->dim;
     if (s->n == 0)
         return 0;
@@ -754,7 +606,7 @@ int protein_obs_sample_for_gp(ProteinObs* obs, int max_size,
             obs->max_score = s->scores[i];
     }
 
-    float* log_c_buf = (float*)malloc((size_t)s->n * sizeof(float));
+    float *log_c_buf = (float *)malloc((size_t)s->n * sizeof(float));
     for (int i = 0; i < s->n; i++)
         log_c_buf[i] = logf(fmaxf(s->costs[i], PROTEIN_EPSILON));
     obs->log_c_min = log_c_buf[0];
@@ -764,38 +616,35 @@ int protein_obs_sample_for_gp(ProteinObs* obs, int max_size,
     obs->log_c_max = protein_quantile(log_c_buf, s->n, PROTEIN_COST_QUANTILE);
     free(log_c_buf);
 
-    ProteinObsList* f = &obs->failure;
+    ProteinObsList *f = &obs->failure;
     int use_failures = (s->n < PROTEIN_MIN_OBS_NO_FAIL && f->n > 0);
     int combined_n = use_failures ? f->n + s->n : s->n;
     int ext_dim = dim + 2;
-    float* ext = (float*)malloc((size_t)combined_n * ext_dim * sizeof(float));
+    float *ext = (float *)malloc((size_t)combined_n * ext_dim * sizeof(float));
 
     int ci = 0;
     if (use_failures) {
         for (int i = 0; i < f->n; i++) {
-            memcpy(&ext[(size_t)ci * ext_dim], &f->params[(size_t)i * dim],
-                (size_t)dim * sizeof(float));
+            memcpy(&ext[(size_t)ci * ext_dim], &f->params[(size_t)i * dim], (size_t)dim * sizeof(float));
             ext[(size_t)ci * ext_dim + dim] = obs->min_score;
             ext[(size_t)ci * ext_dim + dim + 1] = f->costs[i];
             ci++;
         }
     }
     for (int i = 0; i < s->n; i++) {
-        memcpy(&ext[(size_t)ci * ext_dim], &s->params[(size_t)i * dim],
-            (size_t)dim * sizeof(float));
+        memcpy(&ext[(size_t)ci * ext_dim], &s->params[(size_t)i * dim], (size_t)dim * sizeof(float));
         ext[(size_t)ci * ext_dim + dim] = s->scores[i];
         ext[(size_t)ci * ext_dim + dim + 1] = s->costs[i];
         ci++;
     }
 
-    int* kept = (int*)malloc((size_t)combined_n * sizeof(int));
-    int n_kept = gp_filter_near_duplicates(ext, combined_n, ext_dim,
-        PROTEIN_EPSILON, kept);
+    int *kept = (int *)malloc((size_t)combined_n * sizeof(int));
+    int n_kept = gp_filter_near_duplicates(ext, combined_n, ext_dim, PROTEIN_EPSILON, kept);
 
     if (n_kept <= max_size) {
         for (int i = 0; i < n_kept; i++)
-            protein_obs_extract(ext, ext_dim, dim, kept[i],
-                &out_params[(size_t)i * dim], &out_scores[i], &out_costs[i]);
+            protein_obs_extract(ext, ext_dim, dim, kept[i], &out_params[(size_t)i * dim], &out_scores[i],
+                                &out_costs[i]);
         free(kept);
         free(ext);
         return n_kept;
@@ -805,7 +654,7 @@ int protein_obs_sample_for_gp(ProteinObs* obs, int max_size,
     int older_size = n_kept - recent_size;
     int num_sample = max_size - recent_size;
 
-    int* sample_idx = (int*)malloc((size_t)older_size * sizeof(int));
+    int *sample_idx = (int *)malloc((size_t)older_size * sizeof(int));
     for (int i = 0; i < older_size; i++)
         sample_idx[i] = i;
     for (int i = 0; i < num_sample && i < older_size; i++) {
@@ -817,15 +666,13 @@ int protein_obs_sample_for_gp(ProteinObs* obs, int max_size,
 
     int out_n = 0;
     for (int i = 0; i < num_sample && i < older_size; i++) {
-        protein_obs_extract(ext, ext_dim, dim, kept[sample_idx[i]],
-            &out_params[(size_t)out_n * dim], &out_scores[out_n],
-            &out_costs[out_n]);
+        protein_obs_extract(ext, ext_dim, dim, kept[sample_idx[i]], &out_params[(size_t)out_n * dim],
+                            &out_scores[out_n], &out_costs[out_n]);
         out_n++;
     }
     for (int i = n_kept - recent_size; i < n_kept; i++) {
-        protein_obs_extract(ext, ext_dim, dim, kept[i],
-            &out_params[(size_t)out_n * dim], &out_scores[out_n],
-            &out_costs[out_n]);
+        protein_obs_extract(ext, ext_dim, dim, kept[i], &out_params[(size_t)out_n * dim], &out_scores[out_n],
+                            &out_costs[out_n]);
         out_n++;
     }
 
@@ -834,8 +681,6 @@ int protein_obs_sample_for_gp(ProteinObs* obs, int max_size,
     free(ext);
     return out_n;
 }
-
-// -- sweep orchestrator -------------------------------------------------------
 
 typedef struct {
     float score_loss;
@@ -850,18 +695,17 @@ typedef struct {
 } ProteinSweepInfo;
 
 typedef struct {
-    Hyperparameters* hypers;
-    ProteinObs* obs;
-    ProteinAcq* acq;
+    Hyperparameters *hypers;
+    ProteinObs *obs;
+    ProteinAcq *acq;
     ProteinCostModel cost_model;
-    ProteinClassifier* clf;
-    Sobol* sobol;
-    GaussianProcess* gp_score;
-    GaussianProcess* gp_cost;
-    Adam* opt_score;
-    Adam* opt_cost;
+    ProteinClassifier *clf;
+    Sobol *sobol;
+    GaussianProcess *gp_score;
+    GaussianProcess *gp_cost;
+    Adam *opt_score;
+    Adam *opt_cost;
     cudaStream_t stream;
-
     int suggestion_idx;
     int num_random_samples;
     int suggestions_per_pareto;
@@ -876,39 +720,28 @@ typedef struct {
     float expansion_rate;
     float cost_random_suggestion;
     float upper_cost_threshold;
-
     float ratio_pool[PROTEIN_NUM_COST_RATIOS];
     int pool_remaining;
-
     float running_buf[PROTEIN_RUNNING_BUF_CAP];
     int running_pos;
     int running_len;
-
-    // Pre-allocated scratch for suggest()
-    float* gp_train_params; // [gp_max_obs * dim]
-    float* gp_train_y; // [gp_max_obs]
-    float* gp_train_c; // [gp_max_obs]
-    int* pareto_buf; // [obs_cap]
-    int* pruned_buf; // [obs_cap]
-    float* centers_buf; // [centers_cap * dim]
+    float *gp_train_params;
+    float *gp_train_y;
+    float *gp_train_c;
+    int *pareto_buf;
+    int *pruned_buf;
+    float *centers_buf;
     int obs_cap, centers_cap;
 } ProteinSweep;
 
-ProteinSweep* protein_sweep_create(
-    Hyperparameters* hypers,
-    int num_random_samples, int suggestions_per_pareto,
-    int gp_training_iter, float gp_learning_rate,
-    int optimizer_reset_frequency, int gp_max_obs,
-    int infer_batch_size, int use_success_prob,
-    int prune_pareto, int use_logit,
-    float global_search_scale, float max_suggestion_cost,
-    float expansion_rate, float cost_random_suggestion,
-    float early_stop_quantile,
-    int success_cap, int failure_cap, int top_k,
-    unsigned long long rng_seed)
-{
+ProteinSweep *protein_sweep_create(Hyperparameters *hypers, int num_random_samples, int suggestions_per_pareto,
+                                   int gp_training_iter, float gp_learning_rate, int optimizer_reset_frequency,
+                                   int gp_max_obs, int infer_batch_size, int use_success_prob, int prune_pareto,
+                                   int use_logit, float global_search_scale, float max_suggestion_cost,
+                                   float expansion_rate, float cost_random_suggestion, float early_stop_quantile,
+                                   int success_cap, int failure_cap, int top_k, unsigned long long rng_seed) {
     int dim = hypers->num;
-    ProteinSweep* sw = (ProteinSweep*)calloc(1, sizeof(ProteinSweep));
+    ProteinSweep *sw = (ProteinSweep *)calloc(1, sizeof(ProteinSweep));
     sw->hypers = hypers;
     sw->num_random_samples = num_random_samples;
     sw->suggestions_per_pareto = suggestions_per_pareto;
@@ -924,70 +757,53 @@ ProteinSweep* protein_sweep_create(
     sw->cost_random_suggestion = cost_random_suggestion;
     sw->upper_cost_threshold = -FLT_MAX;
 
-    static const float default_ratios[PROTEIN_NUM_COST_RATIOS] = {
-        0.16f, 0.32f, 0.48f, 0.64f, 0.8f, 1.0f
-    };
+    static const float default_ratios[PROTEIN_NUM_COST_RATIOS] = {0.16f, 0.32f, 0.48f, 0.64f, 0.8f, 1.0f};
     memcpy(sw->ratio_pool, default_ratios, sizeof(default_ratios));
 
-    sw->obs = protein_obs_create(dim, success_cap, failure_cap, top_k,
-        hypers->cost_idx);
+    sw->obs = protein_obs_create(dim, success_cap, failure_cap, top_k, hypers->cost_idx);
 
-    // ACQ capacity: Python generates n_centers * spp candidates then batches GP
-    // prediction. Here we must size the buffer to hold all candidates pre-dedup.
     int max_centers = success_cap + 3 * top_k;
     int acq_cap = max_centers * suggestions_per_pareto;
     if (acq_cap < infer_batch_size)
         acq_cap = infer_batch_size;
     if (acq_cap > PROTEIN_ACQ_MAX_CAP)
         acq_cap = PROTEIN_ACQ_MAX_CAP;
-    sw->acq = protein_acq_create(dim, acq_cap,
-        hypers->bounds_min, hypers->bounds_max, hypers->scales, rng_seed);
-    protein_cost_model_init(&sw->cost_model, early_stop_quantile, 30);
+    sw->acq = protein_acq_create(dim, acq_cap, hypers->bounds_min, hypers->bounds_max, hypers->scales, rng_seed);
+    sw->cost_model.quantile = early_stop_quantile;
+    sw->cost_model.min_samples = 30;
     sw->clf = protein_classifier_create(dim);
     sw->sobol = sobol_create(dim, rng_seed);
 
-    sw->gp_score = gp_create(dim, gp_max_obs,
-        gp_kernel_matern32_linear(dim, 1.0f, 1.0f, 1.0f), 0.01f);
-    sw->gp_cost = gp_create(dim, gp_max_obs,
-        gp_kernel_matern32_linear(dim, 1.0f, 1.0f, 1.0f), 0.01f);
+    sw->gp_score = gp_create(dim, gp_max_obs, gp_kernel_matern32_linear(dim, 1.0f, 1.0f, 1.0f), 0.01f);
+    sw->gp_cost = gp_create(dim, gp_max_obs, gp_kernel_matern32_linear(dim, 1.0f, 1.0f, 1.0f), 0.01f);
     sw->opt_score = adam_create(sw->gp_score->kernel->n_params, gp_learning_rate);
     sw->opt_cost = adam_create(sw->gp_cost->kernel->n_params, gp_learning_rate);
 
     sw->obs_cap = success_cap;
     sw->centers_cap = max_centers;
-    sw->gp_train_params = (float*)malloc((size_t)gp_max_obs * dim * sizeof(float));
-    sw->gp_train_y = (float*)malloc((size_t)gp_max_obs * sizeof(float));
-    sw->gp_train_c = (float*)malloc((size_t)gp_max_obs * sizeof(float));
-    sw->pareto_buf = (int*)malloc((size_t)success_cap * sizeof(int));
-    sw->pruned_buf = (int*)malloc((size_t)success_cap * sizeof(int));
-    sw->centers_buf = (float*)malloc((size_t)max_centers * dim * sizeof(float));
+    sw->gp_train_params = (float *)malloc((size_t)gp_max_obs * dim * sizeof(float));
+    sw->gp_train_y = (float *)malloc((size_t)gp_max_obs * sizeof(float));
+    sw->gp_train_c = (float *)malloc((size_t)gp_max_obs * sizeof(float));
+    sw->pareto_buf = (int *)malloc((size_t)success_cap * sizeof(int));
+    sw->pruned_buf = (int *)malloc((size_t)success_cap * sizeof(int));
+    sw->centers_buf = (float *)malloc((size_t)max_centers * dim * sizeof(float));
 
     CUDA_CHECK(cudaStreamCreate(&sw->stream));
     return sw;
 }
 
-void protein_sweep_destroy(ProteinSweep* sw)
-{
+void protein_sweep_destroy(ProteinSweep *sw) {
     if (!sw)
         return;
-    if (sw->hypers)
-        hyperparameters_destroy(sw->hypers);
-    if (sw->obs)
-        protein_obs_destroy(sw->obs);
-    if (sw->acq)
-        protein_acq_destroy(sw->acq);
-    if (sw->clf)
-        protein_classifier_destroy(sw->clf);
-    if (sw->sobol)
-        sobol_destroy(sw->sobol);
-    if (sw->gp_score)
-        gp_destroy(sw->gp_score);
-    if (sw->gp_cost)
-        gp_destroy(sw->gp_cost);
-    if (sw->opt_score)
-        adam_destroy(sw->opt_score);
-    if (sw->opt_cost)
-        adam_destroy(sw->opt_cost);
+    hyperparameters_destroy(sw->hypers);
+    protein_obs_destroy(sw->obs);
+    protein_acq_destroy(sw->acq);
+    protein_classifier_destroy(sw->clf);
+    sobol_destroy(sw->sobol);
+    gp_destroy(sw->gp_score);
+    gp_destroy(sw->gp_cost);
+    adam_destroy(sw->opt_score);
+    adam_destroy(sw->opt_cost);
     if (sw->stream)
         cudaStreamDestroy(sw->stream);
     free(sw->gp_train_params);
@@ -999,24 +815,20 @@ void protein_sweep_destroy(ProteinSweep* sw)
     free(sw);
 }
 
-void protein_sweep_observe(ProteinSweep* sw, const float* norm_params,
-    float score, float cost, int is_failure)
-{
+void protein_sweep_observe(ProteinSweep *sw, const float *norm_params, float score, float cost, int is_failure) {
     if (sw->use_logit)
         score = protein_logit_transform(score);
     protein_obs_add(sw->obs, norm_params, score, cost, is_failure);
 }
 
-void protein_sweep_add_running(ProteinSweep* sw, float val)
-{
+void protein_sweep_add_running(ProteinSweep *sw, float val) {
     sw->running_buf[sw->running_pos] = val;
     sw->running_pos = (sw->running_pos + 1) % PROTEIN_RUNNING_BUF_CAP;
     if (sw->running_len < PROTEIN_RUNNING_BUF_CAP)
         sw->running_len++;
 }
 
-float protein_sweep_running_mean(const ProteinSweep* sw)
-{
+float protein_sweep_running_mean(const ProteinSweep *sw) {
     if (sw->running_len == 0)
         return 0.0f;
     float sum = 0.0f;
@@ -1025,25 +837,21 @@ float protein_sweep_running_mean(const ProteinSweep* sw)
     return sum / (float)sw->running_len;
 }
 
-float protein_sweep_get_threshold(const ProteinSweep* sw, float cost)
-{
+float protein_sweep_get_threshold(const ProteinSweep *sw, float cost) {
     return protein_cost_model_threshold(&sw->cost_model, cost, 0.3f, 10.0f);
 }
 
-int protein_sweep_should_stop(const ProteinSweep* sw, float score, float cost)
-{
+int protein_sweep_should_stop(const ProteinSweep *sw, float score, float cost) {
     float threshold = protein_sweep_get_threshold(sw, cost);
     if (sw->use_logit)
         score = protein_logit_transform(score);
     return score < threshold;
 }
 
-static void protein_sobol_fallback(ProteinSweep* sw, float* out,
-    int is_fixed_cost, float fixed_cost_norm)
-{
+static void protein_sobol_fallback(ProteinSweep *sw, float *out, int is_fixed_cost, float fixed_cost_norm) {
     int dim = sw->hypers->num;
     int cost_dim = sw->hypers->cost_idx;
-    sobol_next(sw->sobol, out);
+    CURAND_CHECK(curandGenerateUniform(sw->sobol->gen, out, sw->sobol->dim));
     for (int d = 0; d < dim; d++)
         out[d] = 2.0f * out[d] - 1.0f;
     if (is_fixed_cost && cost_dim >= 0) {
@@ -1051,40 +859,28 @@ static void protein_sobol_fallback(ProteinSweep* sw, float* out,
     } else if (cost_dim >= 0) {
         float u1 = ((float)rand() + 1.0f) / ((float)RAND_MAX + 1.0f);
         float u2 = ((float)rand() + 1.0f) / ((float)RAND_MAX + 1.0f);
-        float noise = 0.1f * sqrtf(-2.0f * logf(u1))
-            * cosf(2.0f * (float)M_PI * u2);
-        out[cost_dim] = fmaxf(-1.0f,
-            fminf(1.0f, sw->cost_random_suggestion + noise));
+        float noise = 0.1f * sqrtf(-2.0f * logf(u1)) * cosf(2.0f * (float)M_PI * u2);
+        out[cost_dim] = fmaxf(-1.0f, fminf(1.0f, sw->cost_random_suggestion + noise));
     }
 }
 
-ProteinSweepInfo protein_sweep_suggest(ProteinSweep* sw,
-    float* out, float fixed_cost_norm)
-{
-    ProteinSweepInfo info;
-    memset(&info, 0, sizeof(info));
+ProteinSweepInfo protein_sweep_suggest(ProteinSweep *sw, float *out, float fixed_cost_norm) {
+    ProteinSweepInfo info = {0};
     sw->suggestion_idx++;
 
     int dim = sw->hypers->num;
     int cost_dim = sw->hypers->cost_idx;
     int is_fixed_cost = !isnan(fixed_cost_norm);
 
-    if (sw->suggestion_idx <= sw->num_random_samples) {
+    ProteinObsList *s = &sw->obs->success;
+    if (sw->suggestion_idx <= sw->num_random_samples || s->n == 0) {
         protein_sobol_fallback(sw, out, is_fixed_cost, fixed_cost_norm);
         info.is_random = 1;
         return info;
     }
 
-    ProteinObsList* s = &sw->obs->success;
-    if (s->n == 0) {
-        protein_sobol_fallback(sw, out, is_fixed_cost, fixed_cost_norm);
-        info.is_random = 1;
-        return info;
-    }
-
-    // Sample and normalise observations for GP training
-    int n_gp = protein_obs_sample_for_gp(sw->obs, sw->gp_max_obs, 0.5f,
-        sw->gp_train_params, sw->gp_train_y, sw->gp_train_c);
+    int n_gp =
+        protein_obs_sample_for_gp(sw->obs, sw->gp_max_obs, 0.5f, sw->gp_train_params, sw->gp_train_y, sw->gp_train_c);
 
     float min_score = sw->obs->min_score;
     float max_score = sw->obs->max_score;
@@ -1093,34 +889,29 @@ ProteinSweepInfo protein_sweep_suggest(ProteinSweep* sw,
     float score_range = fabsf(max_score - min_score) + PROTEIN_EPSILON;
     float cost_range = log_c_max - log_c_min + PROTEIN_EPSILON;
 
-    float* y_norm = sw->gp_train_y;
-    float* c_norm = sw->gp_train_c;
+    float *y_norm = sw->gp_train_y;
+    float *c_norm = sw->gp_train_c;
     for (int i = 0; i < n_gp; i++) {
         y_norm[i] = (y_norm[i] - min_score) / score_range;
         float lc = logf(fmaxf(c_norm[i], PROTEIN_EPSILON));
         c_norm[i] = (lc - log_c_min) / cost_range;
     }
 
-    float score_loss = protein_train_gp(sw->gp_score, sw->opt_score,
-        sw->gp_train_params, y_norm, n_gp, sw->gp_training_iter, sw->stream);
-    float cost_loss = protein_train_gp(sw->gp_cost, sw->opt_cost,
-        sw->gp_train_params, c_norm, n_gp, sw->gp_training_iter, sw->stream);
+    float score_loss = protein_train_gp(sw->gp_score, sw->opt_score, sw->gp_train_params, y_norm, n_gp,
+                                        sw->gp_training_iter, sw->stream);
+    float cost_loss = protein_train_gp(sw->gp_cost, sw->opt_cost, sw->gp_train_params, c_norm, n_gp,
+                                       sw->gp_training_iter, sw->stream);
 
-    if (sw->optimizer_reset_frequency > 0
-        && sw->suggestion_idx % sw->optimizer_reset_frequency == 0) {
+    if (sw->optimizer_reset_frequency > 0 && sw->suggestion_idx % sw->optimizer_reset_frequency == 0) {
         adam_reset(sw->opt_score);
         adam_reset(sw->opt_cost);
     }
 
-    // Pareto front
-    int n_pareto = protein_pareto_front(s->scores, s->costs, s->n,
-        sw->pareto_buf);
+    int n_pareto = protein_pareto_front(s->scores, s->costs, s->n, sw->pareto_buf);
 
     memcpy(sw->pruned_buf, sw->pareto_buf, (size_t)n_pareto * sizeof(int));
-    int n_pruned = protein_prune_pareto(s->scores, s->costs,
-        sw->pruned_buf, n_pareto, 0.5f, 0.98f);
+    int n_pruned = protein_prune_pareto(s->scores, s->costs, sw->pruned_buf, n_pareto, 0.5f, 0.98f);
 
-    // Upper cost threshold tracking
     if (n_pruned > 0) {
         float pruned_max_cost = s->costs[sw->pruned_buf[n_pruned - 1]];
         if (sw->upper_cost_threshold < 0)
@@ -1128,32 +919,24 @@ ProteinSweepInfo protein_sweep_suggest(ProteinSweep* sw,
         else if (sw->upper_cost_threshold < pruned_max_cost)
             sw->upper_cost_threshold *= PROTEIN_COST_GROWTH;
     }
-    protein_cost_model_fit(&sw->cost_model,
-        s->scores, s->costs, s->n, sw->upper_cost_threshold);
+    protein_cost_model_fit(&sw->cost_model, s->scores, s->costs, s->n, sw->upper_cost_threshold);
 
-    int* use_pareto = sw->prune_pareto ? sw->pruned_buf : sw->pareto_buf;
+    int *use_pareto = sw->prune_pareto ? sw->pruned_buf : sw->pareto_buf;
     int n_use = sw->prune_pareto ? n_pruned : n_pareto;
 
-    // Build search centers: pareto + top-k with reduced cost
     int n_top = sw->obs->n_top;
-    int n_centers = protein_build_search_centers(s->params, dim,
-        use_pareto, n_use, sw->obs->top_idx, n_top, cost_dim,
-        sw->centers_buf);
+    int n_centers = protein_build_search_centers(s->params, dim, use_pareto, n_use, sw->obs->top_idx, n_top, cost_dim,
+                                                 sw->centers_buf);
 
     float target_cost = 0.0f;
     if (!is_fixed_cost) {
-        target_cost = protein_sample_target_cost(
-            sw->ratio_pool, &sw->pool_remaining,
-            PROTEIN_NUM_COST_RATIOS, sw->expansion_rate);
+        target_cost = protein_sample_target_cost(sw->ratio_pool, &sw->pool_remaining, PROTEIN_NUM_COST_RATIOS,
+                                                 sw->expansion_rate);
     }
 
-    // Sample candidates around search centers
     int n_total = n_centers * sw->suggestions_per_pareto;
-    int n_cands = protein_acq_sample(sw->acq,
-        sw->centers_buf, n_centers, n_total,
-        sw->global_search_scale,
-        cost_dim, is_fixed_cost ? fixed_cost_norm : NAN,
-        PROTEIN_EPSILON, sw->stream);
+    int n_cands = protein_acq_sample(sw->acq, sw->centers_buf, n_centers, n_total, sw->global_search_scale, cost_dim,
+                                     is_fixed_cost ? fixed_cost_norm : NAN, PROTEIN_EPSILON, sw->stream);
 
     if (n_cands == 0) {
         protein_sobol_fallback(sw, out, is_fixed_cost, fixed_cost_norm);
@@ -1161,16 +944,14 @@ ProteinSweepInfo protein_sweep_suggest(ProteinSweep* sw,
         return info;
     }
 
-    // Optionally fit success classifier
-    float* d_success_prob = NULL;
+    float *d_success_prob = NULL;
     if (sw->use_success_prob && s->n > 9 && sw->obs->failure.n > 9) {
         int n_s = s->n, n_f = sw->obs->failure.n;
         int n_clf = n_s + n_f;
-        float* X = (float*)malloc((size_t)n_clf * dim * sizeof(float));
-        int* y = (int*)malloc((size_t)n_clf * sizeof(int));
+        float *X = (float *)malloc((size_t)n_clf * dim * sizeof(float));
+        int *y = (int *)malloc((size_t)n_clf * sizeof(int));
         memcpy(X, s->params, (size_t)n_s * dim * sizeof(float));
-        memcpy(X + (size_t)n_s * dim, sw->obs->failure.params,
-            (size_t)n_f * dim * sizeof(float));
+        memcpy(X + (size_t)n_s * dim, sw->obs->failure.params, (size_t)n_f * dim * sizeof(float));
         for (int i = 0; i < n_s; i++)
             y[i] = 1;
         for (int i = 0; i < n_f; i++)
@@ -1180,22 +961,19 @@ ProteinSweepInfo protein_sweep_suggest(ProteinSweep* sw,
         free(y);
 
         if (sw->clf->is_fitted) {
-            protein_classifier_predict_d(sw->clf,
-                sw->acq->d_candidates, sw->acq->d_success_prob,
-                n_cands, sw->stream);
+            protein_classifier_predict_d(sw->clf, sw->acq->d_candidates, sw->acq->d_success_prob, n_cands, sw->stream);
             d_success_prob = sw->acq->d_success_prob;
         }
     }
 
-    // GP predict + score + argmax
-    ProteinAcqResult acq_result = protein_acq_suggest(sw->acq, n_cands,
-        sw->gp_score, sw->gp_cost,
-        min_score, max_score, log_c_min, log_c_max,
-        sw->max_suggestion_cost, target_cost,
-        sw->hypers->optimize_direction, is_fixed_cost,
-        d_success_prob, sw->stream);
+    ProteinAcqResult acq_result =
+        protein_acq_suggest(sw->acq, n_cands, sw->gp_score, sw->gp_cost, min_score, max_score, log_c_min, log_c_max,
+                            sw->max_suggestion_cost, target_cost, sw->hypers->optimize_direction, is_fixed_cost,
+                            d_success_prob, sw->stream);
 
-    protein_acq_get_candidate(sw->acq, acq_result.best_idx, out, sw->stream);
+    CUDA_CHECK(cudaMemcpyAsync(out, &sw->acq->d_candidates[(size_t)acq_result.best_idx * sw->acq->dim],
+                               (size_t)sw->acq->dim * sizeof(float), cudaMemcpyDeviceToHost, sw->stream));
+    CUDA_CHECK(cudaStreamSynchronize(sw->stream));
 
     info.score_loss = score_loss;
     info.cost_loss = cost_loss;

--- a/src/protein.cu
+++ b/src/protein.cu
@@ -1,0 +1,1211 @@
+// protein.cu -- Protein hyperparameter optimizer (CUDA).
+//
+// Depends on: gp_cuda.cu (GP, KDTree, CUDA_CHECK).
+// Includes: protein_util.h (Space, Pareto, CostModel, numeric helpers).
+
+#ifndef PROTEIN_CU
+#define PROTEIN_CU
+
+#include <curand.h>
+#include <curand_kernel.h>
+#include <float.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#define PROTEIN_EPSILON 1e-6f
+#define PROTEIN_NUM_COST_RATIOS 6
+#define PROTEIN_ACQ_MAX_CAP 65536
+#define PROTEIN_COST_QUANTILE 0.97f
+#define PROTEIN_MIN_OBS_NO_FAIL 100
+#define PROTEIN_COST_GROWTH 1.01f
+#define PROTEIN_CLF_ITERS 100
+#define PROTEIN_THRESHOLD_COST_CAP 1.2f
+#define PROTEIN_THRESHOLD_FALLBACK 0.9f
+#define PROTEIN_RUNNING_BUF_CAP 30
+
+#include "protein_util.h"
+#include "gp_cuda.cu"
+
+// -- structs ------------------------------------------------------------------
+
+typedef struct {
+    int dim;
+    int capacity;
+
+    float* d_bounds_min; // [dim]
+    float* d_bounds_max; // [dim]
+    float* d_scales; // [dim]
+
+    float* d_candidates; // [capacity * dim]
+    float* d_pred_y; // [capacity]
+    float* d_pred_c; // [capacity]
+    float* d_scores; // [capacity]
+    float* d_success_prob; // [capacity]
+    int* d_best_idx; // [1]
+
+    curandStatePhilox4_32_10_t* d_rng; // [capacity]
+} ProteinAcq;
+
+typedef struct {
+    int best_idx;
+    float predicted_score;
+    float predicted_cost;
+    float rating;
+} ProteinAcqResult;
+
+typedef struct {
+    float* weights; // [dim] host
+    float* d_weights; // [dim] device
+    float bias;
+    int dim;
+    int is_fitted;
+} ProteinClassifier;
+
+typedef struct {
+    float* params; // [cap * dim]
+    float* scores; // [cap]
+    float* costs; // [cap]
+    int n, cap;
+} ProteinObsList;
+
+typedef struct {
+    ProteinObsList success;
+    ProteinObsList failure;
+    int* top_idx; // [top_k] indices into success, sorted descending by score
+    int n_top, top_k;
+    int dim, cost_dim;
+    float min_score, max_score;
+    float log_c_min, log_c_max;
+} ProteinObs;
+
+// -- device kernels -----------------------------------------------------------
+
+__global__ void protein_k_init_rng(curandStatePhilox4_32_10_t* states, int n,
+    unsigned long long seed)
+{
+    int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
+    if (i < n)
+        curand_init(seed, i, 0, &states[i]);
+}
+
+__global__ void protein_k_sample(
+    float* __restrict__ candidates,
+    const float* __restrict__ centers,
+    const float* __restrict__ bounds_min,
+    const float* __restrict__ bounds_max,
+    const float* __restrict__ scales,
+    curandStatePhilox4_32_10_t* __restrict__ rng,
+    int n_candidates, int n_centers, int dim,
+    float global_scale, int cost_dim, float fixed_cost)
+{
+    int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
+    if (i >= n_candidates)
+        return;
+
+    curandStatePhilox4_32_10_t state = rng[i];
+    int center = ((int)(curand_uniform(&state) * n_centers)) % n_centers;
+
+    for (int d = 0; d < dim; d++) {
+        float s = scales[d] * global_scale;
+        float val = s * (2.0f * curand_uniform(&state) - 1.0f)
+            + centers[center * dim + d];
+        val = fmaxf(bounds_min[d], fminf(bounds_max[d], val));
+        candidates[i * dim + d] = val;
+    }
+
+    if (cost_dim >= 0 && !isnan(fixed_cost))
+        candidates[i * dim + cost_dim] = fixed_cost;
+
+    rng[i] = state;
+}
+
+__global__ void protein_k_score(
+    const float* __restrict__ pred_y_norm,
+    const float* __restrict__ pred_c_norm,
+    const float* __restrict__ success_prob,
+    float* __restrict__ scores,
+    int m,
+    float min_score, float max_score,
+    float log_c_min, float log_c_max,
+    float max_cost, float target_cost,
+    int optimize_dir, int fixed_cost)
+{
+    int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
+    if (i >= m)
+        return;
+
+    float y_norm = pred_y_norm[i];
+    float c_norm = pred_c_norm[i];
+    float s = (float)optimize_dir * y_norm;
+
+    if (!fixed_cost) {
+        float log_c = c_norm * (log_c_max - log_c_min) + log_c_min;
+        float c = expf(log_c);
+        float mask = (c < max_cost) ? 1.0f : 0.0f;
+        float w = 1.0f - fabsf(target_cost - c_norm);
+        s *= mask * w;
+    }
+
+    if (success_prob)
+        s *= success_prob[i];
+
+    scores[i] = s;
+}
+
+__global__ void protein_k_argmax(const float* __restrict__ scores, int n,
+    int* out_idx)
+{
+    __shared__ float s_val[BLOCK_SIZE];
+    __shared__ int s_idx[BLOCK_SIZE];
+
+    int tid = threadIdx.x;
+    float best = -FLT_MAX;
+    int best_i = 0;
+
+    for (int i = tid; i < n; i += BLOCK_SIZE) {
+        if (scores[i] > best) {
+            best = scores[i];
+            best_i = i;
+        }
+    }
+    s_val[tid] = best;
+    s_idx[tid] = best_i;
+    __syncthreads();
+
+    for (int s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s && s_val[tid + s] > s_val[tid]) {
+            s_val[tid] = s_val[tid + s];
+            s_idx[tid] = s_idx[tid + s];
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0)
+        *out_idx = s_idx[0];
+}
+
+__global__ void protein_k_classifier_predict(
+    const float* __restrict__ X,
+    const float* __restrict__ weights,
+    float bias, float* __restrict__ probs,
+    int m, int dim)
+{
+    int i = blockIdx.x * BLOCK_SIZE + threadIdx.x;
+    if (i >= m)
+        return;
+    float z = bias;
+    for (int d = 0; d < dim; d++)
+        z += X[i * dim + d] * weights[d];
+    probs[i] = 1.0f / (1.0f + expf(-z));
+}
+
+// -- classifier ---------------------------------------------------------------
+
+ProteinClassifier* protein_classifier_create(int dim)
+{
+    ProteinClassifier* clf = (ProteinClassifier*)calloc(1, sizeof(ProteinClassifier));
+    clf->dim = dim;
+    clf->weights = (float*)calloc((size_t)dim, sizeof(float));
+    CUDA_CHECK(cudaMalloc(&clf->d_weights, (size_t)dim * sizeof(float)));
+    return clf;
+}
+
+void protein_classifier_destroy(ProteinClassifier* clf)
+{
+    if (!clf)
+        return;
+    free(clf->weights);
+    cudaFree(clf->d_weights);
+    free(clf);
+}
+
+void protein_classifier_fit(ProteinClassifier* clf,
+    const float* X, const int* y, int n,
+    float C_reg, int max_iter)
+{
+    int dim = clf->dim;
+    clf->is_fitted = 0;
+
+    int n_pos = 0;
+    for (int i = 0; i < n; i++)
+        n_pos += y[i];
+    int n_neg = n - n_pos;
+    if (n_pos == 0 || n_neg == 0)
+        return;
+
+    float w_pos = (float)n / (2.0f * (float)n_pos);
+    float w_neg = (float)n / (2.0f * (float)n_neg);
+    float lambda = 1.0f / C_reg;
+
+    memset(clf->weights, 0, (size_t)dim * sizeof(float));
+    clf->bias = 0.0f;
+    float* grad = (float*)calloc((size_t)dim, sizeof(float));
+
+    for (int iter = 0; iter < max_iter; iter++) {
+        float lr = 0.1f / (1.0f + 0.01f * (float)iter);
+        memset(grad, 0, (size_t)dim * sizeof(float));
+        float grad_b = 0.0f;
+
+        for (int i = 0; i < n; i++) {
+            float z = clf->bias;
+            for (int d = 0; d < dim; d++)
+                z += X[(size_t)i * dim + d] * clf->weights[d];
+            float sig = 1.0f / (1.0f + expf(-z));
+            float sw = y[i] ? w_pos : w_neg;
+            float err = sw * (sig - (float)y[i]) / (float)n;
+            for (int d = 0; d < dim; d++)
+                grad[d] += err * X[(size_t)i * dim + d];
+            grad_b += err;
+        }
+
+        for (int d = 0; d < dim; d++)
+            grad[d] += lambda * clf->weights[d];
+
+        for (int d = 0; d < dim; d++)
+            clf->weights[d] -= lr * grad[d];
+        clf->bias -= lr * grad_b;
+    }
+
+    free(grad);
+    clf->is_fitted = 1;
+
+    CUDA_CHECK(cudaMemcpy(clf->d_weights, clf->weights,
+        (size_t)dim * sizeof(float), cudaMemcpyHostToDevice));
+}
+
+void protein_classifier_predict_d(const ProteinClassifier* clf,
+    const float* d_X, float* d_probs,
+    int m, cudaStream_t stream)
+{
+    protein_k_classifier_predict<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
+        d_X, clf->d_weights, clf->bias, d_probs, m, clf->dim);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+// -- acquisition lifecycle ----------------------------------------------------
+
+ProteinAcq* protein_acq_create(int dim, int capacity,
+    const float* bounds_min, const float* bounds_max,
+    const float* scales, unsigned long long rng_seed)
+{
+    ProteinAcq* acq = (ProteinAcq*)calloc(1, sizeof(ProteinAcq));
+    acq->dim = dim;
+    acq->capacity = capacity;
+
+    CUDA_CHECK(cudaMalloc(&acq->d_bounds_min, (size_t)dim * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&acq->d_bounds_max, (size_t)dim * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&acq->d_scales, (size_t)dim * sizeof(float)));
+    CUDA_CHECK(cudaMemcpy(acq->d_bounds_min, bounds_min,
+        (size_t)dim * sizeof(float), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(acq->d_bounds_max, bounds_max,
+        (size_t)dim * sizeof(float), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(acq->d_scales, scales,
+        (size_t)dim * sizeof(float), cudaMemcpyHostToDevice));
+
+    CUDA_CHECK(cudaMalloc(&acq->d_candidates,
+        (size_t)capacity * dim * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&acq->d_pred_y, (size_t)capacity * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&acq->d_pred_c, (size_t)capacity * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&acq->d_scores, (size_t)capacity * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&acq->d_success_prob, (size_t)capacity * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&acq->d_best_idx, sizeof(int)));
+    CUDA_CHECK(cudaMalloc(&acq->d_rng,
+        (size_t)capacity * sizeof(curandStatePhilox4_32_10_t)));
+
+    protein_k_init_rng<<<(capacity + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(
+        acq->d_rng, capacity, rng_seed);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    return acq;
+}
+
+void protein_acq_destroy(ProteinAcq* acq)
+{
+    if (!acq)
+        return;
+    cudaFree(acq->d_bounds_min);
+    cudaFree(acq->d_bounds_max);
+    cudaFree(acq->d_scales);
+    cudaFree(acq->d_candidates);
+    cudaFree(acq->d_pred_y);
+    cudaFree(acq->d_pred_c);
+    cudaFree(acq->d_scores);
+    cudaFree(acq->d_success_prob);
+    cudaFree(acq->d_best_idx);
+    cudaFree(acq->d_rng);
+    free(acq);
+}
+
+// -- sampling -----------------------------------------------------------------
+
+int protein_acq_sample(ProteinAcq* acq,
+    const float* centers, int n_centers, int n_total,
+    float global_scale,
+    int cost_dim, float fixed_cost_norm,
+    float dedup_threshold, cudaStream_t stream)
+{
+    int dim = acq->dim;
+    if (n_total > acq->capacity)
+        n_total = acq->capacity;
+
+    float* d_centers;
+    CUDA_CHECK(cudaMallocAsync(&d_centers,
+        (size_t)n_centers * dim * sizeof(float), stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_centers, centers,
+        (size_t)n_centers * dim * sizeof(float),
+        cudaMemcpyHostToDevice, stream));
+
+    protein_k_sample<<<(n_total + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
+        acq->d_candidates, d_centers,
+        acq->d_bounds_min, acq->d_bounds_max, acq->d_scales,
+        acq->d_rng, n_total, n_centers, dim,
+        global_scale, cost_dim, fixed_cost_norm);
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaFreeAsync(d_centers, stream));
+
+    if (dedup_threshold <= 0.0f) {
+        CUDA_CHECK(cudaStreamSynchronize(stream));
+        return n_total;
+    }
+
+    float* h_cands = (float*)malloc((size_t)n_total * dim * sizeof(float));
+    CUDA_CHECK(cudaMemcpyAsync(h_cands, acq->d_candidates,
+        (size_t)n_total * dim * sizeof(float),
+        cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    int* kept = (int*)malloc((size_t)n_total * sizeof(int));
+    int n_kept = gp_filter_near_duplicates(h_cands, n_total, dim,
+        dedup_threshold, kept);
+
+    if (n_kept > 0 && n_kept < n_total) {
+        float* h_compact = (float*)malloc((size_t)n_kept * dim * sizeof(float));
+        for (int i = 0; i < n_kept; i++)
+            memcpy(&h_compact[(size_t)i * dim], &h_cands[(size_t)kept[i] * dim],
+                (size_t)dim * sizeof(float));
+        CUDA_CHECK(cudaMemcpyAsync(acq->d_candidates, h_compact,
+            (size_t)n_kept * dim * sizeof(float),
+            cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
+        free(h_compact);
+    }
+
+    free(h_cands);
+    free(kept);
+    return n_kept;
+}
+
+// -- scoring ------------------------------------------------------------------
+
+ProteinAcqResult protein_acq_score(
+    ProteinAcq* acq, int m,
+    float min_score, float max_score,
+    float log_c_min, float log_c_max,
+    float max_suggestion_cost, float target_cost_ratio,
+    int optimize_direction, int fixed_cost,
+    const float* d_success_prob, cudaStream_t stream)
+{
+    protein_k_score<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
+        acq->d_pred_y, acq->d_pred_c, d_success_prob,
+        acq->d_scores, m,
+        min_score, max_score, log_c_min, log_c_max,
+        max_suggestion_cost, target_cost_ratio,
+        optimize_direction, fixed_cost);
+    CUDA_CHECK(cudaGetLastError());
+
+    protein_k_argmax<<<1, BLOCK_SIZE, 0, stream>>>(acq->d_scores, m, acq->d_best_idx);
+    CUDA_CHECK(cudaGetLastError());
+
+    int best;
+    CUDA_CHECK(cudaMemcpyAsync(&best, acq->d_best_idx, sizeof(int),
+        cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    float y_norm, c_norm, rating;
+    CUDA_CHECK(cudaMemcpy(&y_norm, &acq->d_pred_y[best], sizeof(float),
+        cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(&c_norm, &acq->d_pred_c[best], sizeof(float),
+        cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(&rating, &acq->d_scores[best], sizeof(float),
+        cudaMemcpyDeviceToHost));
+
+    ProteinAcqResult result;
+    result.best_idx = best;
+    result.predicted_score = y_norm * (max_score - min_score) + min_score;
+    result.predicted_cost = expf(c_norm * (log_c_max - log_c_min) + log_c_min);
+    result.rating = rating;
+    return result;
+}
+
+ProteinAcqResult protein_acq_suggest(
+    ProteinAcq* acq, int m,
+    const GaussianProcess* gp_score, const GaussianProcess* gp_cost,
+    float min_score, float max_score,
+    float log_c_min, float log_c_max,
+    float max_suggestion_cost, float target_cost_ratio,
+    int optimize_direction, int fixed_cost,
+    const float* d_success_prob, cudaStream_t stream)
+{
+    gp_predict_d(gp_score, acq->d_candidates, acq->d_pred_y, NULL, m, stream);
+    gp_predict_d(gp_cost, acq->d_candidates, acq->d_pred_c, NULL, m, stream);
+    return protein_acq_score(acq, m, min_score, max_score, log_c_min, log_c_max,
+        max_suggestion_cost, target_cost_ratio,
+        optimize_direction, fixed_cost,
+        d_success_prob, stream);
+}
+
+// -- GP optimizer (Adam + noise prior) ----------------------------------------
+
+#define NOISE_PRIOR_MU (-4.60517f) // log(1e-2)
+#define NOISE_PRIOR_SIGMA 0.5f
+
+typedef struct {
+    float *m, *v, *v_max; // [n] each
+    float lr, beta1, beta2, eps;
+    int t, n;
+} Adam;
+
+Adam* adam_create(int n_kernel_params, float lr)
+{
+    int n = n_kernel_params + 1;
+    Adam* opt = (Adam*)calloc(1, sizeof(Adam));
+    opt->n = n;
+    opt->lr = lr;
+    opt->beta1 = 0.9f;
+    opt->beta2 = 0.999f;
+    opt->eps = 1e-8f;
+    opt->t = 0;
+    opt->m = (float*)calloc((size_t)n, sizeof(float));
+    opt->v = (float*)calloc((size_t)n, sizeof(float));
+    opt->v_max = (float*)calloc((size_t)n, sizeof(float));
+    return opt;
+}
+
+void adam_destroy(Adam* opt)
+{
+    if (!opt)
+        return;
+    free(opt->m);
+    free(opt->v);
+    free(opt->v_max);
+    free(opt);
+}
+
+void adam_reset(Adam* opt)
+{
+    memset(opt->m, 0, (size_t)opt->n * sizeof(float));
+    memset(opt->v, 0, (size_t)opt->n * sizeof(float));
+    memset(opt->v_max, 0, (size_t)opt->n * sizeof(float));
+    opt->t = 0;
+}
+
+static float noise_log_prior_grad(float raw_noise)
+{
+    float sig = softplus_grad(raw_noise); // sigmoid(raw_noise)
+    float noise = softplus(raw_noise); // includes + SP_LB
+    float log_noise = logf(noise);
+    float d_log_p = (-(log_noise - NOISE_PRIOR_MU)
+                            / (NOISE_PRIOR_SIGMA * NOISE_PRIOR_SIGMA)
+                        - 1.0f)
+        * sig / noise;
+    float d_log_jac = 1.0f - sig; // sigmoid(-raw_noise)
+    return d_log_p + d_log_jac;
+}
+
+float protein_train_gp(GaussianProcess* gp, Adam* opt,
+    const float* X, const float* y, int n_data,
+    int training_iter, cudaStream_t stream)
+{
+    int rc = gp_fit(gp, X, y, n_data, stream);
+    if (rc != 0)
+        return 0.0f;
+
+    int n_kp = gp->kernel->n_params;
+    float* kg = (float*)malloc((size_t)n_kp * sizeof(float));
+    float loss = 0.0f;
+
+    for (int iter = 0; iter < training_iter; iter++) {
+        rc = gp_recompute(gp, stream);
+        if (rc != 0)
+            break;
+
+        float mll = gp_marginal_log_likelihood(gp);
+        float d_noise;
+        gp_mll_grad(gp, &d_noise, kg, stream);
+        cudaStreamSynchronize(stream);
+
+        float np_grad = noise_log_prior_grad(gp->raw_noise);
+
+        float noise_val = softplus(gp->raw_noise);
+        float ln_noise = logf(noise_val);
+        float lp = -0.5f * powf((ln_noise - NOISE_PRIOR_MU) / NOISE_PRIOR_SIGMA, 2.0f)
+            - ln_noise - logf(NOISE_PRIOR_SIGMA); // log-prob
+        float lj = -log1pf(expf(-gp->raw_noise)); // log-Jacobian
+        loss = -mll - (lp + lj); // Change of variables posterior
+
+        opt->t++;
+        float bc1 = 1.0f - powf(opt->beta1, (float)opt->t);
+        float bc2 = 1.0f - powf(opt->beta2, (float)opt->t);
+
+        for (int i = 0; i < opt->n; i++) {
+            float g = (i < n_kp) ? -kg[i] : -d_noise - np_grad;
+            opt->m[i] = opt->beta1 * opt->m[i] + (1.0f - opt->beta1) * g;
+            opt->v[i] = opt->beta2 * opt->v[i] + (1.0f - opt->beta2) * g * g;
+            float m_hat = opt->m[i] / bc1;
+            float v_hat = opt->v[i] / bc2;
+            if (v_hat > opt->v_max[i])
+                opt->v_max[i] = v_hat;
+            float step = opt->lr * m_hat / (sqrtf(opt->v_max[i]) + opt->eps);
+            if (i < n_kp)
+                gp->kernel->raw_params[i] -= step;
+            else
+                gp->raw_noise -= step;
+        }
+    }
+
+    gp_recompute(gp, stream);
+    free(kg);
+    return loss;
+}
+
+// -- data access --------------------------------------------------------------
+
+void protein_acq_get_candidate(const ProteinAcq* acq, int idx,
+    float* out, cudaStream_t stream)
+{
+    CUDA_CHECK(cudaMemcpyAsync(out, &acq->d_candidates[(size_t)idx * acq->dim],
+        (size_t)acq->dim * sizeof(float),
+        cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+}
+
+// -- Sobol quasi-random sequence (cuRAND) --------------------------------------
+
+#define CURAND_CHECK(call)                                                  \
+    do {                                                                    \
+        curandStatus_t _s = (call);                                         \
+        if (_s != CURAND_STATUS_SUCCESS) {                                  \
+            fprintf(stderr, "cuRAND error %s:%d: %d\n", __FILE__, __LINE__, \
+                (int)_s);                                                   \
+            abort();                                                        \
+        }                                                                   \
+    } while (0)
+
+typedef struct {
+    curandGenerator_t gen;
+    int dim;
+} Sobol;
+
+Sobol* sobol_create(int dim, unsigned long long seed)
+{
+    Sobol* sob = (Sobol*)calloc(1, sizeof(Sobol));
+    sob->dim = dim;
+    CURAND_CHECK(curandCreateGeneratorHost(&sob->gen,
+        CURAND_RNG_QUASI_SCRAMBLED_SOBOL32));
+    CURAND_CHECK(curandSetQuasiRandomGeneratorDimensions(sob->gen, dim));
+    CURAND_CHECK(curandSetGeneratorOffset(sob->gen, seed));
+    return sob;
+}
+
+void sobol_destroy(Sobol* sob)
+{
+    if (!sob)
+        return;
+    curandDestroyGenerator(sob->gen);
+    free(sob);
+}
+
+void sobol_next(Sobol* sob, float* out)
+{
+    CURAND_CHECK(curandGenerateUniform(sob->gen, out, sob->dim));
+}
+
+// -- observation store --------------------------------------------------------
+
+static void protein_obs_list_init(ProteinObsList* l, int dim, int cap)
+{
+    l->params = (float*)calloc((size_t)cap * dim, sizeof(float));
+    l->scores = (float*)calloc((size_t)cap, sizeof(float));
+    l->costs = (float*)calloc((size_t)cap, sizeof(float));
+    l->n = 0;
+    l->cap = cap;
+}
+
+static void protein_obs_list_free(ProteinObsList* l)
+{
+    free(l->params);
+    free(l->scores);
+    free(l->costs);
+}
+
+ProteinObs* protein_obs_create(int dim, int success_cap, int failure_cap,
+    int top_k, int cost_dim)
+{
+    ProteinObs* obs = (ProteinObs*)calloc(1, sizeof(ProteinObs));
+    obs->dim = dim;
+    obs->cost_dim = cost_dim;
+    obs->top_k = top_k;
+    obs->top_idx = (int*)malloc((size_t)top_k * sizeof(int));
+    obs->min_score = FLT_MAX;
+    obs->max_score = -FLT_MAX;
+    obs->log_c_min = FLT_MAX;
+    obs->log_c_max = -FLT_MAX;
+    protein_obs_list_init(&obs->success, dim, success_cap);
+    protein_obs_list_init(&obs->failure, dim, failure_cap);
+    return obs;
+}
+
+void protein_obs_destroy(ProteinObs* obs)
+{
+    if (!obs)
+        return;
+    protein_obs_list_free(&obs->success);
+    protein_obs_list_free(&obs->failure);
+    free(obs->top_idx);
+    free(obs);
+}
+
+void protein_obs_add(ProteinObs* obs, const float* params, float score,
+    float cost, int is_failure)
+{
+    int dim = obs->dim;
+
+    if (is_failure || !isfinite(score) || isnan(score)) {
+        ProteinObsList* f = &obs->failure;
+        if (f->n < f->cap) {
+            int i = f->n++;
+            memcpy(&f->params[(size_t)i * dim], params, (size_t)dim * sizeof(float));
+            f->scores[i] = score;
+            f->costs[i] = cost;
+        }
+        return;
+    }
+
+    ProteinObsList* s = &obs->success;
+
+    for (int i = 0; i < s->n; i++) {
+        float dist2 = 0.0f;
+        for (int d = 0; d < dim; d++) {
+            float diff = params[d] - s->params[(size_t)i * dim + d];
+            dist2 += diff * diff;
+        }
+        if (sqrtf(dist2) < PROTEIN_EPSILON) {
+            memcpy(&s->params[(size_t)i * dim], params, (size_t)dim * sizeof(float));
+            s->scores[i] = score;
+            s->costs[i] = cost;
+            return;
+        }
+    }
+
+    if (obs->cost_dim >= 0 && params[obs->cost_dim] <= -1.0f)
+        return;
+
+    if (s->n >= s->cap)
+        return;
+
+    int idx = s->n++;
+    memcpy(&s->params[(size_t)idx * dim], params, (size_t)dim * sizeof(float));
+    s->scores[idx] = score;
+    s->costs[idx] = cost;
+
+    if (obs->n_top < obs->top_k)
+        obs->top_idx[obs->n_top++] = idx;
+    else if (score > s->scores[obs->top_idx[obs->n_top - 1]])
+        obs->top_idx[obs->n_top - 1] = idx;
+    else
+        return;
+
+    for (int j = obs->n_top - 1; j > 0; j--) {
+        if (s->scores[obs->top_idx[j]] > s->scores[obs->top_idx[j - 1]]) {
+            int tmp = obs->top_idx[j];
+            obs->top_idx[j] = obs->top_idx[j - 1];
+            obs->top_idx[j - 1] = tmp;
+        } else
+            break;
+    }
+}
+
+static void protein_obs_extract(const float* ext, int ext_dim, int dim,
+    int idx, float* out_params, float* out_score, float* out_cost)
+{
+    memcpy(out_params, &ext[(size_t)idx * ext_dim], (size_t)dim * sizeof(float));
+    *out_score = ext[(size_t)idx * ext_dim + dim];
+    *out_cost = ext[(size_t)idx * ext_dim + dim + 1];
+}
+
+int protein_obs_sample_for_gp(ProteinObs* obs, int max_size,
+    float recent_ratio, float* out_params, float* out_scores,
+    float* out_costs)
+{
+    ProteinObsList* s = &obs->success;
+    int dim = obs->dim;
+    if (s->n == 0)
+        return 0;
+
+    obs->min_score = s->scores[0];
+    obs->max_score = s->scores[0];
+    for (int i = 1; i < s->n; i++) {
+        if (s->scores[i] < obs->min_score)
+            obs->min_score = s->scores[i];
+        if (s->scores[i] > obs->max_score)
+            obs->max_score = s->scores[i];
+    }
+
+    float* log_c_buf = (float*)malloc((size_t)s->n * sizeof(float));
+    for (int i = 0; i < s->n; i++)
+        log_c_buf[i] = logf(fmaxf(s->costs[i], PROTEIN_EPSILON));
+    obs->log_c_min = log_c_buf[0];
+    for (int i = 1; i < s->n; i++)
+        if (log_c_buf[i] < obs->log_c_min)
+            obs->log_c_min = log_c_buf[i];
+    obs->log_c_max = protein_quantile(log_c_buf, s->n, PROTEIN_COST_QUANTILE);
+    free(log_c_buf);
+
+    ProteinObsList* f = &obs->failure;
+    int use_failures = (s->n < PROTEIN_MIN_OBS_NO_FAIL && f->n > 0);
+    int combined_n = use_failures ? f->n + s->n : s->n;
+    int ext_dim = dim + 2;
+    float* ext = (float*)malloc((size_t)combined_n * ext_dim * sizeof(float));
+
+    int ci = 0;
+    if (use_failures) {
+        for (int i = 0; i < f->n; i++) {
+            memcpy(&ext[(size_t)ci * ext_dim], &f->params[(size_t)i * dim],
+                (size_t)dim * sizeof(float));
+            ext[(size_t)ci * ext_dim + dim] = obs->min_score;
+            ext[(size_t)ci * ext_dim + dim + 1] = f->costs[i];
+            ci++;
+        }
+    }
+    for (int i = 0; i < s->n; i++) {
+        memcpy(&ext[(size_t)ci * ext_dim], &s->params[(size_t)i * dim],
+            (size_t)dim * sizeof(float));
+        ext[(size_t)ci * ext_dim + dim] = s->scores[i];
+        ext[(size_t)ci * ext_dim + dim + 1] = s->costs[i];
+        ci++;
+    }
+
+    int* kept = (int*)malloc((size_t)combined_n * sizeof(int));
+    int n_kept = gp_filter_near_duplicates(ext, combined_n, ext_dim,
+        PROTEIN_EPSILON, kept);
+
+    if (n_kept <= max_size) {
+        for (int i = 0; i < n_kept; i++)
+            protein_obs_extract(ext, ext_dim, dim, kept[i],
+                &out_params[(size_t)i * dim], &out_scores[i], &out_costs[i]);
+        free(kept);
+        free(ext);
+        return n_kept;
+    }
+
+    int recent_size = (int)(recent_ratio * (float)max_size);
+    int older_size = n_kept - recent_size;
+    int num_sample = max_size - recent_size;
+
+    int* sample_idx = (int*)malloc((size_t)older_size * sizeof(int));
+    for (int i = 0; i < older_size; i++)
+        sample_idx[i] = i;
+    for (int i = 0; i < num_sample && i < older_size; i++) {
+        int j = i + rand() % (older_size - i);
+        int tmp = sample_idx[i];
+        sample_idx[i] = sample_idx[j];
+        sample_idx[j] = tmp;
+    }
+
+    int out_n = 0;
+    for (int i = 0; i < num_sample && i < older_size; i++) {
+        protein_obs_extract(ext, ext_dim, dim, kept[sample_idx[i]],
+            &out_params[(size_t)out_n * dim], &out_scores[out_n],
+            &out_costs[out_n]);
+        out_n++;
+    }
+    for (int i = n_kept - recent_size; i < n_kept; i++) {
+        protein_obs_extract(ext, ext_dim, dim, kept[i],
+            &out_params[(size_t)out_n * dim], &out_scores[out_n],
+            &out_costs[out_n]);
+        out_n++;
+    }
+
+    free(sample_idx);
+    free(kept);
+    free(ext);
+    return out_n;
+}
+
+// -- sweep orchestrator -------------------------------------------------------
+
+typedef struct {
+    float score_loss;
+    float cost_loss;
+    float predicted_score;
+    float predicted_cost;
+    float rating;
+    int n_pareto;
+    int n_gp_obs;
+    int n_candidates;
+    int is_random;
+} ProteinSweepInfo;
+
+typedef struct {
+    Hyperparameters* hypers;
+    ProteinObs* obs;
+    ProteinAcq* acq;
+    ProteinCostModel cost_model;
+    ProteinClassifier* clf;
+    Sobol* sobol;
+    GaussianProcess* gp_score;
+    GaussianProcess* gp_cost;
+    Adam* opt_score;
+    Adam* opt_cost;
+    cudaStream_t stream;
+
+    int suggestion_idx;
+    int num_random_samples;
+    int suggestions_per_pareto;
+    int gp_training_iter;
+    int optimizer_reset_frequency;
+    int gp_max_obs;
+    int use_success_prob;
+    int prune_pareto;
+    int use_logit;
+    float global_search_scale;
+    float max_suggestion_cost;
+    float expansion_rate;
+    float cost_random_suggestion;
+    float upper_cost_threshold;
+
+    float ratio_pool[PROTEIN_NUM_COST_RATIOS];
+    int pool_remaining;
+
+    float running_buf[PROTEIN_RUNNING_BUF_CAP];
+    int running_pos;
+    int running_len;
+
+    // Pre-allocated scratch for suggest()
+    float* gp_train_params; // [gp_max_obs * dim]
+    float* gp_train_y; // [gp_max_obs]
+    float* gp_train_c; // [gp_max_obs]
+    int* pareto_buf; // [obs_cap]
+    int* pruned_buf; // [obs_cap]
+    float* centers_buf; // [centers_cap * dim]
+    int obs_cap, centers_cap;
+} ProteinSweep;
+
+ProteinSweep* protein_sweep_create(
+    Hyperparameters* hypers,
+    int num_random_samples, int suggestions_per_pareto,
+    int gp_training_iter, float gp_learning_rate,
+    int optimizer_reset_frequency, int gp_max_obs,
+    int infer_batch_size, int use_success_prob,
+    int prune_pareto, int use_logit,
+    float global_search_scale, float max_suggestion_cost,
+    float expansion_rate, float cost_random_suggestion,
+    float early_stop_quantile,
+    int success_cap, int failure_cap, int top_k,
+    unsigned long long rng_seed)
+{
+    int dim = hypers->num;
+    ProteinSweep* sw = (ProteinSweep*)calloc(1, sizeof(ProteinSweep));
+    sw->hypers = hypers;
+    sw->num_random_samples = num_random_samples;
+    sw->suggestions_per_pareto = suggestions_per_pareto;
+    sw->gp_training_iter = gp_training_iter;
+    sw->optimizer_reset_frequency = optimizer_reset_frequency;
+    sw->gp_max_obs = gp_max_obs;
+    sw->use_success_prob = use_success_prob;
+    sw->prune_pareto = prune_pareto;
+    sw->use_logit = use_logit;
+    sw->global_search_scale = global_search_scale;
+    sw->max_suggestion_cost = max_suggestion_cost;
+    sw->expansion_rate = expansion_rate;
+    sw->cost_random_suggestion = cost_random_suggestion;
+    sw->upper_cost_threshold = -FLT_MAX;
+
+    static const float default_ratios[PROTEIN_NUM_COST_RATIOS] = {
+        0.16f, 0.32f, 0.48f, 0.64f, 0.8f, 1.0f
+    };
+    memcpy(sw->ratio_pool, default_ratios, sizeof(default_ratios));
+
+    sw->obs = protein_obs_create(dim, success_cap, failure_cap, top_k,
+        hypers->cost_idx);
+
+    // ACQ capacity: Python generates n_centers * spp candidates then batches GP
+    // prediction. Here we must size the buffer to hold all candidates pre-dedup.
+    int max_centers = success_cap + 3 * top_k;
+    int acq_cap = max_centers * suggestions_per_pareto;
+    if (acq_cap < infer_batch_size)
+        acq_cap = infer_batch_size;
+    if (acq_cap > PROTEIN_ACQ_MAX_CAP)
+        acq_cap = PROTEIN_ACQ_MAX_CAP;
+    sw->acq = protein_acq_create(dim, acq_cap,
+        hypers->bounds_min, hypers->bounds_max, hypers->scales, rng_seed);
+    protein_cost_model_init(&sw->cost_model, early_stop_quantile, 30);
+    sw->clf = protein_classifier_create(dim);
+    sw->sobol = sobol_create(dim, rng_seed);
+
+    sw->gp_score = gp_create(dim, gp_max_obs,
+        gp_kernel_matern32_linear(dim, 1.0f, 1.0f, 1.0f), 0.01f);
+    sw->gp_cost = gp_create(dim, gp_max_obs,
+        gp_kernel_matern32_linear(dim, 1.0f, 1.0f, 1.0f), 0.01f);
+    sw->opt_score = adam_create(sw->gp_score->kernel->n_params, gp_learning_rate);
+    sw->opt_cost = adam_create(sw->gp_cost->kernel->n_params, gp_learning_rate);
+
+    sw->obs_cap = success_cap;
+    sw->centers_cap = max_centers;
+    sw->gp_train_params = (float*)malloc((size_t)gp_max_obs * dim * sizeof(float));
+    sw->gp_train_y = (float*)malloc((size_t)gp_max_obs * sizeof(float));
+    sw->gp_train_c = (float*)malloc((size_t)gp_max_obs * sizeof(float));
+    sw->pareto_buf = (int*)malloc((size_t)success_cap * sizeof(int));
+    sw->pruned_buf = (int*)malloc((size_t)success_cap * sizeof(int));
+    sw->centers_buf = (float*)malloc((size_t)max_centers * dim * sizeof(float));
+
+    CUDA_CHECK(cudaStreamCreate(&sw->stream));
+    return sw;
+}
+
+void protein_sweep_destroy(ProteinSweep* sw)
+{
+    if (!sw)
+        return;
+    if (sw->hypers)
+        hyperparameters_destroy(sw->hypers);
+    if (sw->obs)
+        protein_obs_destroy(sw->obs);
+    if (sw->acq)
+        protein_acq_destroy(sw->acq);
+    if (sw->clf)
+        protein_classifier_destroy(sw->clf);
+    if (sw->sobol)
+        sobol_destroy(sw->sobol);
+    if (sw->gp_score)
+        gp_destroy(sw->gp_score);
+    if (sw->gp_cost)
+        gp_destroy(sw->gp_cost);
+    if (sw->opt_score)
+        adam_destroy(sw->opt_score);
+    if (sw->opt_cost)
+        adam_destroy(sw->opt_cost);
+    if (sw->stream)
+        cudaStreamDestroy(sw->stream);
+    free(sw->gp_train_params);
+    free(sw->gp_train_y);
+    free(sw->gp_train_c);
+    free(sw->pareto_buf);
+    free(sw->pruned_buf);
+    free(sw->centers_buf);
+    free(sw);
+}
+
+void protein_sweep_observe(ProteinSweep* sw, const float* norm_params,
+    float score, float cost, int is_failure)
+{
+    if (sw->use_logit)
+        score = protein_logit_transform(score);
+    protein_obs_add(sw->obs, norm_params, score, cost, is_failure);
+}
+
+void protein_sweep_add_running(ProteinSweep* sw, float val)
+{
+    sw->running_buf[sw->running_pos] = val;
+    sw->running_pos = (sw->running_pos + 1) % PROTEIN_RUNNING_BUF_CAP;
+    if (sw->running_len < PROTEIN_RUNNING_BUF_CAP)
+        sw->running_len++;
+}
+
+float protein_sweep_running_mean(const ProteinSweep* sw)
+{
+    if (sw->running_len == 0)
+        return 0.0f;
+    float sum = 0.0f;
+    for (int i = 0; i < sw->running_len; i++)
+        sum += sw->running_buf[i];
+    return sum / (float)sw->running_len;
+}
+
+float protein_sweep_get_threshold(const ProteinSweep* sw, float cost)
+{
+    return protein_cost_model_threshold(&sw->cost_model, cost, 0.3f, 10.0f);
+}
+
+int protein_sweep_should_stop(const ProteinSweep* sw, float score, float cost)
+{
+    float threshold = protein_sweep_get_threshold(sw, cost);
+    if (sw->use_logit)
+        score = protein_logit_transform(score);
+    return score < threshold;
+}
+
+static void protein_sobol_fallback(ProteinSweep* sw, float* out,
+    int is_fixed_cost, float fixed_cost_norm)
+{
+    int dim = sw->hypers->num;
+    int cost_dim = sw->hypers->cost_idx;
+    sobol_next(sw->sobol, out);
+    for (int d = 0; d < dim; d++)
+        out[d] = 2.0f * out[d] - 1.0f;
+    if (is_fixed_cost && cost_dim >= 0) {
+        out[cost_dim] = fixed_cost_norm;
+    } else if (cost_dim >= 0) {
+        float u1 = ((float)rand() + 1.0f) / ((float)RAND_MAX + 1.0f);
+        float u2 = ((float)rand() + 1.0f) / ((float)RAND_MAX + 1.0f);
+        float noise = 0.1f * sqrtf(-2.0f * logf(u1))
+            * cosf(2.0f * (float)M_PI * u2);
+        out[cost_dim] = fmaxf(-1.0f,
+            fminf(1.0f, sw->cost_random_suggestion + noise));
+    }
+}
+
+ProteinSweepInfo protein_sweep_suggest(ProteinSweep* sw,
+    float* out, float fixed_cost_norm)
+{
+    ProteinSweepInfo info;
+    memset(&info, 0, sizeof(info));
+    sw->suggestion_idx++;
+
+    int dim = sw->hypers->num;
+    int cost_dim = sw->hypers->cost_idx;
+    int is_fixed_cost = !isnan(fixed_cost_norm);
+
+    if (sw->suggestion_idx <= sw->num_random_samples) {
+        protein_sobol_fallback(sw, out, is_fixed_cost, fixed_cost_norm);
+        info.is_random = 1;
+        return info;
+    }
+
+    ProteinObsList* s = &sw->obs->success;
+    if (s->n == 0) {
+        protein_sobol_fallback(sw, out, is_fixed_cost, fixed_cost_norm);
+        info.is_random = 1;
+        return info;
+    }
+
+    // Sample and normalise observations for GP training
+    int n_gp = protein_obs_sample_for_gp(sw->obs, sw->gp_max_obs, 0.5f,
+        sw->gp_train_params, sw->gp_train_y, sw->gp_train_c);
+
+    float min_score = sw->obs->min_score;
+    float max_score = sw->obs->max_score;
+    float log_c_min = sw->obs->log_c_min;
+    float log_c_max = sw->obs->log_c_max;
+    float score_range = fabsf(max_score - min_score) + PROTEIN_EPSILON;
+    float cost_range = log_c_max - log_c_min + PROTEIN_EPSILON;
+
+    float* y_norm = sw->gp_train_y;
+    float* c_norm = sw->gp_train_c;
+    for (int i = 0; i < n_gp; i++) {
+        y_norm[i] = (y_norm[i] - min_score) / score_range;
+        float lc = logf(fmaxf(c_norm[i], PROTEIN_EPSILON));
+        c_norm[i] = (lc - log_c_min) / cost_range;
+    }
+
+    float score_loss = protein_train_gp(sw->gp_score, sw->opt_score,
+        sw->gp_train_params, y_norm, n_gp, sw->gp_training_iter, sw->stream);
+    float cost_loss = protein_train_gp(sw->gp_cost, sw->opt_cost,
+        sw->gp_train_params, c_norm, n_gp, sw->gp_training_iter, sw->stream);
+
+    if (sw->optimizer_reset_frequency > 0
+        && sw->suggestion_idx % sw->optimizer_reset_frequency == 0) {
+        adam_reset(sw->opt_score);
+        adam_reset(sw->opt_cost);
+    }
+
+    // Pareto front
+    int n_pareto = protein_pareto_front(s->scores, s->costs, s->n,
+        sw->pareto_buf);
+
+    memcpy(sw->pruned_buf, sw->pareto_buf, (size_t)n_pareto * sizeof(int));
+    int n_pruned = protein_prune_pareto(s->scores, s->costs,
+        sw->pruned_buf, n_pareto, 0.5f, 0.98f);
+
+    // Upper cost threshold tracking
+    if (n_pruned > 0) {
+        float pruned_max_cost = s->costs[sw->pruned_buf[n_pruned - 1]];
+        if (sw->upper_cost_threshold < 0)
+            sw->upper_cost_threshold = pruned_max_cost;
+        else if (sw->upper_cost_threshold < pruned_max_cost)
+            sw->upper_cost_threshold *= PROTEIN_COST_GROWTH;
+    }
+    protein_cost_model_fit(&sw->cost_model,
+        s->scores, s->costs, s->n, sw->upper_cost_threshold);
+
+    int* use_pareto = sw->prune_pareto ? sw->pruned_buf : sw->pareto_buf;
+    int n_use = sw->prune_pareto ? n_pruned : n_pareto;
+
+    // Build search centers: pareto + top-k with reduced cost
+    int n_top = sw->obs->n_top;
+    int n_centers = protein_build_search_centers(s->params, dim,
+        use_pareto, n_use, sw->obs->top_idx, n_top, cost_dim,
+        sw->centers_buf);
+
+    float target_cost = 0.0f;
+    if (!is_fixed_cost) {
+        target_cost = protein_sample_target_cost(
+            sw->ratio_pool, &sw->pool_remaining,
+            PROTEIN_NUM_COST_RATIOS, sw->expansion_rate);
+    }
+
+    // Sample candidates around search centers
+    int n_total = n_centers * sw->suggestions_per_pareto;
+    int n_cands = protein_acq_sample(sw->acq,
+        sw->centers_buf, n_centers, n_total,
+        sw->global_search_scale,
+        cost_dim, is_fixed_cost ? fixed_cost_norm : NAN,
+        PROTEIN_EPSILON, sw->stream);
+
+    if (n_cands == 0) {
+        protein_sobol_fallback(sw, out, is_fixed_cost, fixed_cost_norm);
+        info.is_random = 1;
+        return info;
+    }
+
+    // Optionally fit success classifier
+    float* d_success_prob = NULL;
+    if (sw->use_success_prob && s->n > 9 && sw->obs->failure.n > 9) {
+        int n_s = s->n, n_f = sw->obs->failure.n;
+        int n_clf = n_s + n_f;
+        float* X = (float*)malloc((size_t)n_clf * dim * sizeof(float));
+        int* y = (int*)malloc((size_t)n_clf * sizeof(int));
+        memcpy(X, s->params, (size_t)n_s * dim * sizeof(float));
+        memcpy(X + (size_t)n_s * dim, sw->obs->failure.params,
+            (size_t)n_f * dim * sizeof(float));
+        for (int i = 0; i < n_s; i++)
+            y[i] = 1;
+        for (int i = 0; i < n_f; i++)
+            y[n_s + i] = 0;
+        protein_classifier_fit(sw->clf, X, y, n_clf, 1.0f, PROTEIN_CLF_ITERS);
+        free(X);
+        free(y);
+
+        if (sw->clf->is_fitted) {
+            protein_classifier_predict_d(sw->clf,
+                sw->acq->d_candidates, sw->acq->d_success_prob,
+                n_cands, sw->stream);
+            d_success_prob = sw->acq->d_success_prob;
+        }
+    }
+
+    // GP predict + score + argmax
+    ProteinAcqResult acq_result = protein_acq_suggest(sw->acq, n_cands,
+        sw->gp_score, sw->gp_cost,
+        min_score, max_score, log_c_min, log_c_max,
+        sw->max_suggestion_cost, target_cost,
+        sw->hypers->optimize_direction, is_fixed_cost,
+        d_success_prob, sw->stream);
+
+    protein_acq_get_candidate(sw->acq, acq_result.best_idx, out, sw->stream);
+
+    info.score_loss = score_loss;
+    info.cost_loss = cost_loss;
+    info.predicted_score = acq_result.predicted_score;
+    info.predicted_cost = acq_result.predicted_cost;
+    info.rating = acq_result.rating;
+    info.n_pareto = n_use;
+    info.n_gp_obs = n_gp;
+    info.n_candidates = n_cands;
+    return info;
+}
+
+#endif // PROTEIN_CU

--- a/src/protein_util.h
+++ b/src/protein_util.h
@@ -1,7 +1,4 @@
-// protein_util.h -- Pure-C utilities for the Protein optimizer:
-//                   search space, Pareto front, cost model, numeric helpers.
-//
-// Included by protein.cu.  No CUDA dependency.
+// protein_util.h -- Pure-C utilities for the Protein optimizer.
 
 #ifndef PROTEIN_UTIL_H
 #define PROTEIN_UTIL_H
@@ -10,8 +7,6 @@
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
-
-// -- search space (Space types) -----------------------------------------------
 
 enum SpaceType {
     SPACE_LINEAR,
@@ -27,33 +22,28 @@ typedef struct {
     int is_integer;
 } Space;
 
-static float space_normalize(const Space* s, float value)
-{
+static float space_normalize(const Space *s, float value) {
     float zero_one;
     switch (s->type) {
     case SPACE_LINEAR:
         zero_one = (value - s->min) / (s->max - s->min);
         break;
     case SPACE_LOG:
-        zero_one = (log10f(value) - log10f(s->min))
-            / (log10f(s->max) - log10f(s->min));
+        zero_one = (log10f(value) - log10f(s->min)) / (log10f(s->max) - log10f(s->min));
         break;
     case SPACE_POW2:
-        zero_one = (log2f(value) - log2f(s->min))
-            / (log2f(s->max) - log2f(s->min));
+        zero_one = (log2f(value) - log2f(s->min)) / (log2f(s->max) - log2f(s->min));
         break;
     case SPACE_LOGIT: {
         float clamped = fmaxf(s->min, fminf(value, s->max));
-        zero_one = (log10f(1.0f - clamped) - log10f(1.0f - s->min))
-            / (log10f(1.0f - s->max) - log10f(1.0f - s->min));
+        zero_one = (log10f(1.0f - clamped) - log10f(1.0f - s->min)) / (log10f(1.0f - s->max) - log10f(1.0f - s->min));
         break;
     }
     }
     return 2.0f * zero_one - 1.0f;
 }
 
-static float space_unnormalize(const Space* s, float norm)
-{
+static float space_unnormalize(const Space *s, float norm) {
     float zero_one = (norm + 1.0f) * 0.5f;
     float val;
     switch (s->type) {
@@ -63,22 +53,19 @@ static float space_unnormalize(const Space* s, float norm)
             val = roundf(val);
         break;
     case SPACE_LOG: {
-        float log_val = zero_one * (log10f(s->max) - log10f(s->min))
-            + log10f(s->min);
+        float log_val = zero_one * (log10f(s->max) - log10f(s->min)) + log10f(s->min);
         val = powf(10.0f, log_val);
         if (s->is_integer)
             val = roundf(val);
         break;
     }
     case SPACE_POW2: {
-        float log_val = zero_one * (log2f(s->max) - log2f(s->min))
-            + log2f(s->min);
+        float log_val = zero_one * (log2f(s->max) - log2f(s->min)) + log2f(s->min);
         val = powf(2.0f, roundf(log_val));
         break;
     }
     case SPACE_LOGIT: {
-        float log_val = zero_one * (log10f(1.0f - s->max) - log10f(1.0f - s->min))
-            + log10f(1.0f - s->min);
+        float log_val = zero_one * (log10f(1.0f - s->max) - log10f(1.0f - s->min)) + log10f(1.0f - s->min);
         val = 1.0f - powf(10.0f, log_val);
         break;
     }
@@ -86,9 +73,7 @@ static float space_unnormalize(const Space* s, float norm)
     return val;
 }
 
-static void space_init(Space* s, SpaceType type, float min, float max,
-    float scale, int is_integer)
-{
+static void space_init(Space *s, SpaceType type, float min, float max, float scale, int is_integer) {
     s->type = type;
     s->min = min;
     s->max = max;
@@ -98,29 +83,25 @@ static void space_init(Space* s, SpaceType type, float min, float max,
     s->norm_max = space_normalize(s, max);
 }
 
-// -- Hyperparameters ----------------------------------------------------------
-
 typedef struct {
-    Space* spaces; // [num]
-    float* bounds_min; // [num] normalised
-    float* bounds_max; // [num] normalised
-    float* scales; // [num]
+    Space *spaces;
+    float *bounds_min;
+    float *bounds_max;
+    float *scales;
     int num;
-    int cost_idx; // index of cost parameter (-1 if none)
-    int optimize_direction; // 1 = maximise, -1 = minimise
+    int cost_idx;
+    int optimize_direction;
 } Hyperparameters;
 
-Hyperparameters* hyperparameters_create(const Space* spaces, int num,
-    int cost_idx, int optimize_direction)
-{
-    Hyperparameters* h = (Hyperparameters*)calloc(1, sizeof(Hyperparameters));
+Hyperparameters *hyperparameters_create(const Space *spaces, int num, int cost_idx, int optimize_direction) {
+    Hyperparameters *h = (Hyperparameters *)calloc(1, sizeof(Hyperparameters));
     h->num = num;
     h->cost_idx = cost_idx;
     h->optimize_direction = optimize_direction;
-    h->spaces = (Space*)malloc((size_t)num * sizeof(Space));
-    h->bounds_min = (float*)malloc((size_t)num * sizeof(float));
-    h->bounds_max = (float*)malloc((size_t)num * sizeof(float));
-    h->scales = (float*)malloc((size_t)num * sizeof(float));
+    h->spaces = (Space *)malloc((size_t)num * sizeof(Space));
+    h->bounds_min = (float *)malloc((size_t)num * sizeof(float));
+    h->bounds_max = (float *)malloc((size_t)num * sizeof(float));
+    h->scales = (float *)malloc((size_t)num * sizeof(float));
     memcpy(h->spaces, spaces, (size_t)num * sizeof(Space));
     for (int i = 0; i < num; i++) {
         h->bounds_min[i] = h->spaces[i].norm_min;
@@ -130,8 +111,7 @@ Hyperparameters* hyperparameters_create(const Space* spaces, int num,
     return h;
 }
 
-void hyperparameters_destroy(Hyperparameters* h)
-{
+void hyperparameters_destroy(Hyperparameters *h) {
     if (!h)
         return;
     free(h->spaces);
@@ -141,17 +121,13 @@ void hyperparameters_destroy(Hyperparameters* h)
     free(h);
 }
 
-// -- numeric helpers ----------------------------------------------------------
-
-static int protein_float_cmp(const void* a, const void* b)
-{
-    float fa = *(const float*)a, fb = *(const float*)b;
+static int protein_float_cmp(const void *a, const void *b) {
+    float fa = *(const float *)a, fb = *(const float *)b;
     return (fa > fb) - (fa < fb);
 }
 
-static float protein_quantile(const float* data, int n, float q)
-{
-    float* sorted = (float*)malloc((size_t)n * sizeof(float));
+static float protein_quantile(const float *data, int n, float q) {
+    float *sorted = (float *)malloc((size_t)n * sizeof(float));
     memcpy(sorted, data, (size_t)n * sizeof(float));
     qsort(sorted, n, sizeof(float), protein_float_cmp);
     float idx = q * (float)(n - 1);
@@ -165,15 +141,14 @@ static float protein_quantile(const float* data, int n, float q)
 }
 
 typedef struct {
-    const float* x;
-    const float* y;
+    const float *x;
+    const float *y;
     int n;
     float q;
 } PinballData;
 
-static float pinball_loss(float a, float b, const void* data)
-{
-    const PinballData* pd = (const PinballData*)data;
+static float pinball_loss(float a, float b, const void *data) {
+    const PinballData *pd = (const PinballData *)data;
     float loss = 0.0f;
     for (int i = 0; i < pd->n; i++) {
         float r = pd->y[i] - (a + b * pd->x[i]);
@@ -182,13 +157,14 @@ static float pinball_loss(float a, float b, const void* data)
     return loss;
 }
 
-static void nelder_mead_2d(float (*f)(float, float, const void*),
-    const void* data,
-    float* out_a, float* out_b,
-    float a0, float b0, int max_iter, float tol)
-{
-    float sx[3] = { a0, a0 + 0.05f, a0 - 0.05f };
-    float sy[3] = { b0, b0 - 0.05f, b0 + 0.05f };
+// clang-format off
+#define SWAP_F(a, b) do { float _t = (a); (a) = (b); (b) = _t; } while (0)
+// clang-format on
+
+static void nelder_mead_2d(float (*f)(float, float, const void *), const void *data, float *out_a, float *out_b,
+                           float a0, float b0, int max_iter, float tol) {
+    float sx[3] = {a0, a0 + 0.05f, a0 - 0.05f};
+    float sy[3] = {b0, b0 - 0.05f, b0 + 0.05f};
     float sv[3];
     for (int i = 0; i < 3; i++)
         sv[i] = f(sx[i], sy[i], data);
@@ -197,16 +173,9 @@ static void nelder_mead_2d(float (*f)(float, float, const void*),
         for (int i = 0; i < 2; i++)
             for (int j = i + 1; j < 3; j++)
                 if (sv[j] < sv[i]) {
-                    float t;
-                    t = sx[i];
-                    sx[i] = sx[j];
-                    sx[j] = t;
-                    t = sy[i];
-                    sy[i] = sy[j];
-                    sy[j] = t;
-                    t = sv[i];
-                    sv[i] = sv[j];
-                    sv[j] = t;
+                    SWAP_F(sx[i], sx[j]);
+                    SWAP_F(sy[i], sy[j]);
+                    SWAP_F(sv[i], sv[j]);
                 }
 
         if (fabsf(sv[2] - sv[0]) < tol)
@@ -263,9 +232,9 @@ static void nelder_mead_2d(float (*f)(float, float, const void*),
     *out_b = sy[0];
 }
 
-static void polyfit_1d(const float* x, const float* y, int n,
-    float* intercept, float* slope)
-{
+#undef SWAP_F
+
+static void polyfit_1d(const float *x, const float *y, int n, float *intercept, float *slope) {
     float sx = 0, sy = 0, sxx = 0, sxy = 0;
     for (int i = 0; i < n; i++) {
         sx += x[i];
@@ -283,8 +252,6 @@ static void polyfit_1d(const float* x, const float* y, int n,
     *intercept = (sy - *slope * sx) / (float)n;
 }
 
-// -- cost model ---------------------------------------------------------------
-
 typedef struct {
     float A, B;
     float max_score;
@@ -294,17 +261,8 @@ typedef struct {
     int is_fitted;
 } ProteinCostModel;
 
-void protein_cost_model_init(ProteinCostModel* m, float quantile, int min_samples)
-{
-    memset(m, 0, sizeof(*m));
-    m->quantile = quantile;
-    m->min_samples = min_samples;
-}
-
-void protein_cost_model_fit(ProteinCostModel* m,
-    const float* scores, const float* costs, int n,
-    float upper_cost_threshold)
-{
+void protein_cost_model_fit(ProteinCostModel *m, const float *scores, const float *costs, int n,
+                            float upper_cost_threshold) {
     m->is_fitted = 0;
     if (n == 0)
         return;
@@ -324,8 +282,8 @@ void protein_cost_model_fit(ProteinCostModel* m,
     if (n_valid < m->min_samples)
         return;
 
-    float* x = (float*)malloc((size_t)n_valid * sizeof(float));
-    float* y = (float*)malloc((size_t)n_valid * sizeof(float));
+    float *x = (float *)malloc((size_t)n_valid * sizeof(float));
+    float *y = (float *)malloc((size_t)n_valid * sizeof(float));
     int j = 0;
     for (int i = 0; i < n; i++) {
         if (costs[i] > PROTEIN_EPSILON && isfinite(scores[i])) {
@@ -338,21 +296,17 @@ void protein_cost_model_fit(ProteinCostModel* m,
     float a_init, b_init;
     polyfit_1d(x, y, n_valid, &a_init, &b_init);
 
-    PinballData pd = { x, y, n_valid, m->quantile };
-    nelder_mead_2d(pinball_loss, &pd, &m->A, &m->B,
-        a_init, b_init, 500, 1e-7f);
+    PinballData pd = {x, y, n_valid, m->quantile};
+    nelder_mead_2d(pinball_loss, &pd, &m->A, &m->B, a_init, b_init, 500, 1e-7f);
 
     free(x);
     free(y);
     m->is_fitted = 1;
 }
 
-float protein_cost_model_threshold(const ProteinCostModel* m, float cost,
-    float min_cost_frac, float abs_min_cost)
-{
+float protein_cost_model_threshold(const ProteinCostModel *m, float cost, float min_cost_frac, float abs_min_cost) {
     if (!m->is_fitted)
         return -FLT_MAX;
-
     float min_allowed = m->upper_cost_threshold * min_cost_frac + abs_min_cost;
     if (cost < min_allowed)
         return -FLT_MAX;
@@ -361,24 +315,19 @@ float protein_cost_model_threshold(const ProteinCostModel* m, float cost,
     return m->A + m->B * logf(cost);
 }
 
-// -- Pareto utilities ---------------------------------------------------------
+static const float *g_protein_pareto_costs;
 
-static const float* g_protein_pareto_costs;
-
-static int protein_pareto_cmp(const void* a, const void* b)
-{
-    float ca = g_protein_pareto_costs[*(const int*)a];
-    float cb = g_protein_pareto_costs[*(const int*)b];
+static int protein_pareto_cmp(const void *a, const void *b) {
+    float ca = g_protein_pareto_costs[*(const int *)a];
+    float cb = g_protein_pareto_costs[*(const int *)b];
     return (ca > cb) - (ca < cb);
 }
 
-int protein_pareto_front(const float* scores, const float* costs, int n,
-    int* out_indices)
-{
+int protein_pareto_front(const float *scores, const float *costs, int n, int *out_indices) {
     if (n == 0)
         return 0;
 
-    int* sorted = (int*)malloc((size_t)n * sizeof(int));
+    int *sorted = (int *)malloc((size_t)n * sizeof(int));
     for (int i = 0; i < n; i++)
         sorted[i] = i;
     g_protein_pareto_costs = costs;
@@ -398,10 +347,8 @@ int protein_pareto_front(const float* scores, const float* costs, int n,
     return count;
 }
 
-int protein_prune_pareto(const float* scores, const float* costs,
-    int* indices, int n,
-    float eff_threshold, float stop_fraction)
-{
+int protein_prune_pareto(const float *scores, const float *costs, int *indices, int n, float eff_threshold,
+                         float stop_fraction) {
     if (n < 2)
         return n;
 
@@ -440,47 +387,36 @@ int protein_prune_pareto(const float* scores, const float* costs,
     return pruned;
 }
 
-int protein_build_search_centers(const float* obs_params, int dim,
-    const int* pareto_indices, int n_pareto,
-    const int* top_indices, int n_top,
-    int cost_dim, float* out_centers)
-{
+int protein_build_search_centers(const float *obs_params, int dim, const int *pareto_indices, int n_pareto,
+                                 const int *top_indices, int n_top, int cost_dim, float *out_centers) {
     int count = 0;
     for (int i = 0; i < n_pareto; i++) {
-        memcpy(&out_centers[(size_t)count * dim],
-            &obs_params[(size_t)pareto_indices[i] * dim],
-            (size_t)dim * sizeof(float));
+        memcpy(&out_centers[(size_t)count * dim], &obs_params[(size_t)pareto_indices[i] * dim],
+               (size_t)dim * sizeof(float));
         count++;
     }
     if (cost_dim >= 0) {
-        for (int i = 0; i < n_top; i++) {
-            const float* src = &obs_params[(size_t)top_indices[i] * dim];
-            float orig = src[cost_dim];
-            memcpy(&out_centers[(size_t)count * dim], src, (size_t)dim * sizeof(float));
-            out_centers[(size_t)count * dim + cost_dim] = orig - (orig + 1.0f) / 2.0f;
-            count++;
-        }
-        for (int i = 0; i < n_top; i++) {
-            const float* src = &obs_params[(size_t)top_indices[i] * dim];
-            float orig = src[cost_dim];
-            memcpy(&out_centers[(size_t)count * dim], src, (size_t)dim * sizeof(float));
-            out_centers[(size_t)count * dim + cost_dim] = orig - (orig + 1.0f) / 3.0f;
-            count++;
+        float divisors[] = {2.0f, 3.0f};
+        for (int r = 0; r < 2; r++) {
+            for (int i = 0; i < n_top; i++) {
+                const float *src = &obs_params[(size_t)top_indices[i] * dim];
+                float orig = src[cost_dim];
+                memcpy(&out_centers[(size_t)count * dim], src, (size_t)dim * sizeof(float));
+                out_centers[(size_t)count * dim + cost_dim] = orig - (orig + 1.0f) / divisors[r];
+                count++;
+            }
         }
     } else {
         for (int i = 0; i < n_top; i++) {
-            memcpy(&out_centers[(size_t)count * dim],
-                &obs_params[(size_t)top_indices[i] * dim],
-                (size_t)dim * sizeof(float));
+            memcpy(&out_centers[(size_t)count * dim], &obs_params[(size_t)top_indices[i] * dim],
+                   (size_t)dim * sizeof(float));
             count++;
         }
     }
     return count;
 }
 
-float protein_sample_target_cost(float* ratio_pool, int* pool_remaining,
-    int pool_total, float expansion_rate)
-{
+float protein_sample_target_cost(float *ratio_pool, int *pool_remaining, int pool_total, float expansion_rate) {
     if (*pool_remaining <= 0) {
         for (int i = pool_total - 1; i > 0; i--) {
             int j = rand() % (i + 1);
@@ -500,8 +436,7 @@ float protein_sample_target_cost(float* ratio_pool, int* pool_remaining,
     return (1.0f + expansion_rate) * ratio;
 }
 
-static float protein_logit_transform(float value)
-{
+static float protein_logit_transform(float value) {
     float epsilon = 1e-9f;
     value = fmaxf(epsilon, fminf(1.0f - epsilon, value));
     float logit = logf(value / (1.0f - value));

--- a/src/protein_util.h
+++ b/src/protein_util.h
@@ -1,0 +1,511 @@
+// protein_util.h -- Pure-C utilities for the Protein optimizer:
+//                   search space, Pareto front, cost model, numeric helpers.
+//
+// Included by protein.cu.  No CUDA dependency.
+
+#ifndef PROTEIN_UTIL_H
+#define PROTEIN_UTIL_H
+
+#include <float.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+// -- search space (Space types) -----------------------------------------------
+
+enum SpaceType {
+    SPACE_LINEAR,
+    SPACE_LOG,
+    SPACE_POW2,
+    SPACE_LOGIT,
+};
+
+typedef struct {
+    SpaceType type;
+    float min, max, scale;
+    float norm_min, norm_max;
+    int is_integer;
+} Space;
+
+static float space_normalize(const Space* s, float value)
+{
+    float zero_one;
+    switch (s->type) {
+    case SPACE_LINEAR:
+        zero_one = (value - s->min) / (s->max - s->min);
+        break;
+    case SPACE_LOG:
+        zero_one = (log10f(value) - log10f(s->min))
+            / (log10f(s->max) - log10f(s->min));
+        break;
+    case SPACE_POW2:
+        zero_one = (log2f(value) - log2f(s->min))
+            / (log2f(s->max) - log2f(s->min));
+        break;
+    case SPACE_LOGIT: {
+        float clamped = fmaxf(s->min, fminf(value, s->max));
+        zero_one = (log10f(1.0f - clamped) - log10f(1.0f - s->min))
+            / (log10f(1.0f - s->max) - log10f(1.0f - s->min));
+        break;
+    }
+    }
+    return 2.0f * zero_one - 1.0f;
+}
+
+static float space_unnormalize(const Space* s, float norm)
+{
+    float zero_one = (norm + 1.0f) * 0.5f;
+    float val;
+    switch (s->type) {
+    case SPACE_LINEAR:
+        val = zero_one * (s->max - s->min) + s->min;
+        if (s->is_integer)
+            val = roundf(val);
+        break;
+    case SPACE_LOG: {
+        float log_val = zero_one * (log10f(s->max) - log10f(s->min))
+            + log10f(s->min);
+        val = powf(10.0f, log_val);
+        if (s->is_integer)
+            val = roundf(val);
+        break;
+    }
+    case SPACE_POW2: {
+        float log_val = zero_one * (log2f(s->max) - log2f(s->min))
+            + log2f(s->min);
+        val = powf(2.0f, roundf(log_val));
+        break;
+    }
+    case SPACE_LOGIT: {
+        float log_val = zero_one * (log10f(1.0f - s->max) - log10f(1.0f - s->min))
+            + log10f(1.0f - s->min);
+        val = 1.0f - powf(10.0f, log_val);
+        break;
+    }
+    }
+    return val;
+}
+
+static void space_init(Space* s, SpaceType type, float min, float max,
+    float scale, int is_integer)
+{
+    s->type = type;
+    s->min = min;
+    s->max = max;
+    s->scale = scale;
+    s->is_integer = is_integer;
+    s->norm_min = space_normalize(s, min);
+    s->norm_max = space_normalize(s, max);
+}
+
+// -- Hyperparameters ----------------------------------------------------------
+
+typedef struct {
+    Space* spaces; // [num]
+    float* bounds_min; // [num] normalised
+    float* bounds_max; // [num] normalised
+    float* scales; // [num]
+    int num;
+    int cost_idx; // index of cost parameter (-1 if none)
+    int optimize_direction; // 1 = maximise, -1 = minimise
+} Hyperparameters;
+
+Hyperparameters* hyperparameters_create(const Space* spaces, int num,
+    int cost_idx, int optimize_direction)
+{
+    Hyperparameters* h = (Hyperparameters*)calloc(1, sizeof(Hyperparameters));
+    h->num = num;
+    h->cost_idx = cost_idx;
+    h->optimize_direction = optimize_direction;
+    h->spaces = (Space*)malloc((size_t)num * sizeof(Space));
+    h->bounds_min = (float*)malloc((size_t)num * sizeof(float));
+    h->bounds_max = (float*)malloc((size_t)num * sizeof(float));
+    h->scales = (float*)malloc((size_t)num * sizeof(float));
+    memcpy(h->spaces, spaces, (size_t)num * sizeof(Space));
+    for (int i = 0; i < num; i++) {
+        h->bounds_min[i] = h->spaces[i].norm_min;
+        h->bounds_max[i] = h->spaces[i].norm_max;
+        h->scales[i] = h->spaces[i].scale;
+    }
+    return h;
+}
+
+void hyperparameters_destroy(Hyperparameters* h)
+{
+    if (!h)
+        return;
+    free(h->spaces);
+    free(h->bounds_min);
+    free(h->bounds_max);
+    free(h->scales);
+    free(h);
+}
+
+// -- numeric helpers ----------------------------------------------------------
+
+static int protein_float_cmp(const void* a, const void* b)
+{
+    float fa = *(const float*)a, fb = *(const float*)b;
+    return (fa > fb) - (fa < fb);
+}
+
+static float protein_quantile(const float* data, int n, float q)
+{
+    float* sorted = (float*)malloc((size_t)n * sizeof(float));
+    memcpy(sorted, data, (size_t)n * sizeof(float));
+    qsort(sorted, n, sizeof(float), protein_float_cmp);
+    float idx = q * (float)(n - 1);
+    int lo = (int)idx, hi = lo + 1;
+    if (hi >= n)
+        hi = n - 1;
+    float frac = idx - (float)lo;
+    float val = sorted[lo] * (1.0f - frac) + sorted[hi] * frac;
+    free(sorted);
+    return val;
+}
+
+typedef struct {
+    const float* x;
+    const float* y;
+    int n;
+    float q;
+} PinballData;
+
+static float pinball_loss(float a, float b, const void* data)
+{
+    const PinballData* pd = (const PinballData*)data;
+    float loss = 0.0f;
+    for (int i = 0; i < pd->n; i++) {
+        float r = pd->y[i] - (a + b * pd->x[i]);
+        loss += (r > 0.0f) ? pd->q * r : (pd->q - 1.0f) * r;
+    }
+    return loss;
+}
+
+static void nelder_mead_2d(float (*f)(float, float, const void*),
+    const void* data,
+    float* out_a, float* out_b,
+    float a0, float b0, int max_iter, float tol)
+{
+    float sx[3] = { a0, a0 + 0.05f, a0 - 0.05f };
+    float sy[3] = { b0, b0 - 0.05f, b0 + 0.05f };
+    float sv[3];
+    for (int i = 0; i < 3; i++)
+        sv[i] = f(sx[i], sy[i], data);
+
+    for (int iter = 0; iter < max_iter; iter++) {
+        for (int i = 0; i < 2; i++)
+            for (int j = i + 1; j < 3; j++)
+                if (sv[j] < sv[i]) {
+                    float t;
+                    t = sx[i];
+                    sx[i] = sx[j];
+                    sx[j] = t;
+                    t = sy[i];
+                    sy[i] = sy[j];
+                    sy[j] = t;
+                    t = sv[i];
+                    sv[i] = sv[j];
+                    sv[j] = t;
+                }
+
+        if (fabsf(sv[2] - sv[0]) < tol)
+            break;
+
+        float cx = (sx[0] + sx[1]) * 0.5f;
+        float cy = (sy[0] + sy[1]) * 0.5f;
+
+        float rx = cx + (cx - sx[2]), ry = cy + (cy - sy[2]);
+        float rv = f(rx, ry, data);
+        if (rv < sv[1] && rv >= sv[0]) {
+            sx[2] = rx;
+            sy[2] = ry;
+            sv[2] = rv;
+            continue;
+        }
+        if (rv < sv[0]) {
+            float ex = cx + 2.0f * (rx - cx), ey = cy + 2.0f * (ry - cy);
+            float ev = f(ex, ey, data);
+            if (ev < rv) {
+                sx[2] = ex;
+                sy[2] = ey;
+                sv[2] = ev;
+            } else {
+                sx[2] = rx;
+                sy[2] = ry;
+                sv[2] = rv;
+            }
+            continue;
+        }
+        float ccx, ccy;
+        if (rv < sv[2]) {
+            ccx = cx + 0.5f * (rx - cx);
+            ccy = cy + 0.5f * (ry - cy);
+        } else {
+            ccx = cx + 0.5f * (sx[2] - cx);
+            ccy = cy + 0.5f * (sy[2] - cy);
+        }
+        float ccv = f(ccx, ccy, data);
+        if (ccv < sv[2]) {
+            sx[2] = ccx;
+            sy[2] = ccy;
+            sv[2] = ccv;
+            continue;
+        }
+
+        for (int i = 1; i < 3; i++) {
+            sx[i] = sx[0] + 0.5f * (sx[i] - sx[0]);
+            sy[i] = sy[0] + 0.5f * (sy[i] - sy[0]);
+            sv[i] = f(sx[i], sy[i], data);
+        }
+    }
+    *out_a = sx[0];
+    *out_b = sy[0];
+}
+
+static void polyfit_1d(const float* x, const float* y, int n,
+    float* intercept, float* slope)
+{
+    float sx = 0, sy = 0, sxx = 0, sxy = 0;
+    for (int i = 0; i < n; i++) {
+        sx += x[i];
+        sy += y[i];
+        sxx += x[i] * x[i];
+        sxy += x[i] * y[i];
+    }
+    float det = (float)n * sxx - sx * sx;
+    if (fabsf(det) < 1e-10f) {
+        *intercept = sy / fmaxf((float)n, 1.0f);
+        *slope = 0.0f;
+        return;
+    }
+    *slope = ((float)n * sxy - sx * sy) / det;
+    *intercept = (sy - *slope * sx) / (float)n;
+}
+
+// -- cost model ---------------------------------------------------------------
+
+typedef struct {
+    float A, B;
+    float max_score;
+    float upper_cost_threshold;
+    float quantile;
+    int min_samples;
+    int is_fitted;
+} ProteinCostModel;
+
+void protein_cost_model_init(ProteinCostModel* m, float quantile, int min_samples)
+{
+    memset(m, 0, sizeof(*m));
+    m->quantile = quantile;
+    m->min_samples = min_samples;
+}
+
+void protein_cost_model_fit(ProteinCostModel* m,
+    const float* scores, const float* costs, int n,
+    float upper_cost_threshold)
+{
+    m->is_fitted = 0;
+    if (n == 0)
+        return;
+
+    float s_max = scores[0];
+    for (int i = 1; i < n; i++)
+        if (scores[i] > s_max)
+            s_max = scores[i];
+    m->max_score = s_max;
+    m->upper_cost_threshold = upper_cost_threshold;
+
+    int n_valid = 0;
+    for (int i = 0; i < n; i++)
+        if (costs[i] > PROTEIN_EPSILON && isfinite(scores[i]))
+            n_valid++;
+
+    if (n_valid < m->min_samples)
+        return;
+
+    float* x = (float*)malloc((size_t)n_valid * sizeof(float));
+    float* y = (float*)malloc((size_t)n_valid * sizeof(float));
+    int j = 0;
+    for (int i = 0; i < n; i++) {
+        if (costs[i] > PROTEIN_EPSILON && isfinite(scores[i])) {
+            x[j] = logf(costs[i]);
+            y[j] = scores[i];
+            j++;
+        }
+    }
+
+    float a_init, b_init;
+    polyfit_1d(x, y, n_valid, &a_init, &b_init);
+
+    PinballData pd = { x, y, n_valid, m->quantile };
+    nelder_mead_2d(pinball_loss, &pd, &m->A, &m->B,
+        a_init, b_init, 500, 1e-7f);
+
+    free(x);
+    free(y);
+    m->is_fitted = 1;
+}
+
+float protein_cost_model_threshold(const ProteinCostModel* m, float cost,
+    float min_cost_frac, float abs_min_cost)
+{
+    if (!m->is_fitted)
+        return -FLT_MAX;
+
+    float min_allowed = m->upper_cost_threshold * min_cost_frac + abs_min_cost;
+    if (cost < min_allowed)
+        return -FLT_MAX;
+    if (cost > PROTEIN_THRESHOLD_COST_CAP * m->upper_cost_threshold)
+        return PROTEIN_THRESHOLD_FALLBACK * m->max_score;
+    return m->A + m->B * logf(cost);
+}
+
+// -- Pareto utilities ---------------------------------------------------------
+
+static const float* g_protein_pareto_costs;
+
+static int protein_pareto_cmp(const void* a, const void* b)
+{
+    float ca = g_protein_pareto_costs[*(const int*)a];
+    float cb = g_protein_pareto_costs[*(const int*)b];
+    return (ca > cb) - (ca < cb);
+}
+
+int protein_pareto_front(const float* scores, const float* costs, int n,
+    int* out_indices)
+{
+    if (n == 0)
+        return 0;
+
+    int* sorted = (int*)malloc((size_t)n * sizeof(int));
+    for (int i = 0; i < n; i++)
+        sorted[i] = i;
+    g_protein_pareto_costs = costs;
+    qsort(sorted, n, sizeof(int), protein_pareto_cmp);
+
+    int count = 0;
+    float max_score = -FLT_MAX;
+    for (int i = 0; i < n; i++) {
+        int idx = sorted[i];
+        if (scores[idx] > max_score + PROTEIN_EPSILON) {
+            out_indices[count++] = idx;
+            max_score = scores[idx];
+        }
+    }
+
+    free(sorted);
+    return count;
+}
+
+int protein_prune_pareto(const float* scores, const float* costs,
+    int* indices, int n,
+    float eff_threshold, float stop_fraction)
+{
+    if (n < 2)
+        return n;
+
+    float s_min = scores[indices[0]], s_max = s_min;
+    float c_min = costs[indices[0]], c_max = c_min;
+    for (int i = 1; i < n; i++) {
+        float s = scores[indices[i]], c = costs[indices[i]];
+        if (s < s_min)
+            s_min = s;
+        if (s > s_max)
+            s_max = s;
+        if (c < c_min)
+            c_min = c;
+        if (c > c_max)
+            c_max = c;
+    }
+    float s_range = fmaxf(s_max - s_min, PROTEIN_EPSILON);
+    float c_range = fmaxf(c_max - c_min, PROTEIN_EPSILON);
+    float max_pareto_s = scores[indices[n - 1]];
+
+    int pruned = n;
+    for (int i = pruned - 1; i > 1; i--) {
+        if (scores[indices[i - 1]] < stop_fraction * max_pareto_s)
+            break;
+        float ng = (scores[indices[i]] - scores[indices[i - 1]]) / s_range;
+        float nc = (costs[indices[i]] - costs[indices[i - 1]]) / c_range;
+        float eff = ng / (nc + PROTEIN_EPSILON);
+        if (eff < eff_threshold) {
+            for (int j = i; j < pruned - 1; j++)
+                indices[j] = indices[j + 1];
+            pruned--;
+        } else {
+            break;
+        }
+    }
+    return pruned;
+}
+
+int protein_build_search_centers(const float* obs_params, int dim,
+    const int* pareto_indices, int n_pareto,
+    const int* top_indices, int n_top,
+    int cost_dim, float* out_centers)
+{
+    int count = 0;
+    for (int i = 0; i < n_pareto; i++) {
+        memcpy(&out_centers[(size_t)count * dim],
+            &obs_params[(size_t)pareto_indices[i] * dim],
+            (size_t)dim * sizeof(float));
+        count++;
+    }
+    if (cost_dim >= 0) {
+        for (int i = 0; i < n_top; i++) {
+            const float* src = &obs_params[(size_t)top_indices[i] * dim];
+            float orig = src[cost_dim];
+            memcpy(&out_centers[(size_t)count * dim], src, (size_t)dim * sizeof(float));
+            out_centers[(size_t)count * dim + cost_dim] = orig - (orig + 1.0f) / 2.0f;
+            count++;
+        }
+        for (int i = 0; i < n_top; i++) {
+            const float* src = &obs_params[(size_t)top_indices[i] * dim];
+            float orig = src[cost_dim];
+            memcpy(&out_centers[(size_t)count * dim], src, (size_t)dim * sizeof(float));
+            out_centers[(size_t)count * dim + cost_dim] = orig - (orig + 1.0f) / 3.0f;
+            count++;
+        }
+    } else {
+        for (int i = 0; i < n_top; i++) {
+            memcpy(&out_centers[(size_t)count * dim],
+                &obs_params[(size_t)top_indices[i] * dim],
+                (size_t)dim * sizeof(float));
+            count++;
+        }
+    }
+    return count;
+}
+
+float protein_sample_target_cost(float* ratio_pool, int* pool_remaining,
+    int pool_total, float expansion_rate)
+{
+    if (*pool_remaining <= 0) {
+        for (int i = pool_total - 1; i > 0; i--) {
+            int j = rand() % (i + 1);
+            float tmp = ratio_pool[i];
+            ratio_pool[i] = ratio_pool[j];
+            ratio_pool[j] = tmp;
+        }
+        *pool_remaining = pool_total;
+    }
+    float ratio = ratio_pool[--(*pool_remaining)];
+
+    float u1 = ((float)rand() + 1.0f) / ((float)RAND_MAX + 1.0f);
+    float u2 = ((float)rand() + 1.0f) / ((float)RAND_MAX + 1.0f);
+    float noise = 0.1f * sqrtf(-2.0f * logf(u1)) * cosf(2.0f * (float)M_PI * u2);
+
+    ratio = fmaxf(0.0f, fminf(1.0f, ratio + noise));
+    return (1.0f + expansion_rate) * ratio;
+}
+
+static float protein_logit_transform(float value)
+{
+    float epsilon = 1e-9f;
+    value = fmaxf(epsilon, fminf(1.0f - epsilon, value));
+    float logit = logf(value / (1.0f - value));
+    return fmaxf(-5.0f, fminf(100.0f, logit));
+}
+
+#endif // PROTEIN_UTIL_H

--- a/tests/test_custom_gp_numerics.py
+++ b/tests/test_custom_gp_numerics.py
@@ -1,0 +1,137 @@
+"""
+Custom CUDA GP vs GPyTorch
+
+Hyperparameters are fixed identically, just comparing the raw numerical results and timings for training and prediction.
+"""
+
+import time, sys, math
+import numpy as np
+
+def make_data(n, dim=1, seed=42):
+    rng = np.random.RandomState(seed)
+    X = rng.uniform(-5, 5, size=(n, dim))
+    y = np.sin(X[:, 0]) + 0.1 * rng.randn(n)
+    return X.astype(np.float64), y.astype(np.float64)
+
+def make_test(m=200, dim=1):
+    xs = np.linspace(-6, 6, m).reshape(-1, 1)
+    if dim > 1:
+        xs = np.hstack([xs, np.zeros((m, dim - 1))])
+    return xs.astype(np.float64)
+
+def bench_custom(X, y, Xs, hp):
+    from pufferlib.gp_torch import GaussianProcess
+    import torch  # ensure CUDA context is warm before timing
+
+    # Warm-up: a tiny fit so the first CUDA call overhead isn't charged
+    # to the benchmark (driver init, JIT, etc.)
+    _gp = GaussianProcess(dim=X.shape[1], capacity=1,
+                          lengthscale=hp["lengthscale"],
+                          outputscale=hp["outputscale"],
+                          noise=hp["noise"])
+
+    t0 = time.perf_counter()
+    gp = GaussianProcess(dim=X.shape[1], capacity=len(X),
+                          lengthscale=hp["lengthscale"],
+                          outputscale=hp["outputscale"],
+                          noise=hp["noise"])
+    
+    print(gp)
+    gp.fit(X, y)
+    t_train = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    means, vars_ = gp.predict(Xs)
+    t_pred = time.perf_counter() - t0
+
+    return means.numpy(), vars_.numpy(), gp.log_marginal_likelihood, t_train, t_pred
+
+def bench_gpytorch(X, y, Xs, hp):
+    import torch, gpytorch
+
+    class ExactGP(gpytorch.models.ExactGP):
+        def __init__(self, tx, ty, lik):
+            super().__init__(tx, ty, lik)
+            from gpytorch.kernels import (MaternKernel, PolynomialKernel,
+                                          AdditiveKernel, ScaleKernel)
+            self.mean_module  = gpytorch.means.ZeroMean()
+            matern = MaternKernel(nu=1.5, ard_num_dims=tx.shape[-1])
+            linear = PolynomialKernel(power=1)
+            self.covar_module = ScaleKernel(AdditiveKernel(linear, matern))
+        def forward(self, x):
+            return gpytorch.distributions.MultivariateNormal(
+                self.mean_module(x), self.covar_module(x))
+
+    Xt  = torch.from_numpy(X).double()
+    yt  = torch.from_numpy(y).double()
+    Xst = torch.from_numpy(Xs).double()
+
+    t0 = time.perf_counter()
+    lik   = gpytorch.likelihoods.GaussianLikelihood()
+    model = ExactGP(Xt, yt, lik)
+    model.double()
+    model.covar_module.base_kernel.kernels[1].lengthscale  = hp["lengthscale"]
+    model.covar_module.outputscale                         = hp["outputscale"]
+    lik.noise                                              = hp["noise"]
+    model.covar_module.base_kernel.kernels[0].raw_offset.data.fill_(
+        math.log(math.expm1(hp["offset"])))
+    t_train = time.perf_counter() - t0
+
+    # Force exact Cholesky (default CG cutoff is 800)
+    chol_size = max(len(yt) + 1, 801)
+    model.eval(); lik.eval()
+    t0 = time.perf_counter()
+    with torch.no_grad(), \
+         gpytorch.settings.fast_pred_var(), \
+         gpytorch.settings.max_cholesky_size(chol_size):
+        latent = model(Xst)
+        means  = latent.mean.numpy()
+        vars_  = latent.variance.numpy()
+    t_pred = time.perf_counter() - t0
+
+    model.train(); lik.train()
+    with torch.no_grad(), gpytorch.settings.max_cholesky_size(chol_size):
+        mll = gpytorch.mlls.ExactMarginalLogLikelihood(lik, model)
+        mll = mll(model(Xt), yt).item()
+
+    return means, vars_, mll, t_train, t_pred
+
+def run(n, dim=1):
+    hp   = dict(lengthscale=1.0, outputscale=1.0, noise=0.01, offset=math.log(2))
+    X, y = make_data(n, dim)
+    Xs   = make_test(200, dim)
+
+    rows = {}
+
+    try:
+        rows["CUDA"] = bench_custom(X, y, Xs, hp)
+    except ImportError:
+        pass
+
+    rows["GPyTorch"] = bench_gpytorch(X, y, Xs, hp)
+
+    ref_means = rows["GPyTorch"][0]
+    ref_vars  = rows["GPyTorch"][1]
+
+    print(f"\n{'='*84}")
+    print(f"  n={n}  dim={dim}")
+    print(f"{'='*84}")
+    print(f"  {'':22s} {'train':>8s} {'predict':>8s} {'total':>8s}"
+          f" {'MLL':>12s} {'|err_mean|':>10s} {'|err_var|':>10s}")
+
+    for label, (m_, v_, mll, tt, tp) in rows.items():
+        me = np.max(np.abs(m_ - ref_means))
+        ve = np.max(np.abs(v_ - ref_vars))
+        print(f"  {label:22s} {tt:7.4f}s {tp:7.4f}s {tt+tp:7.4f}s"
+              f" {mll:12.4f} {me:9.2e} {ve:9.2e}")
+
+    print(f"  {'':22s} (GPyTorch: exact Cholesky forced for n>800, errors vs GPyTorch)")
+
+if __name__ == "__main__":
+    sizes = [100, 200, 1000, 2000]
+    dims  = [1, 5]
+    if len(sys.argv) > 1:
+        sizes = [int(s) for s in sys.argv[1:]]
+    for n in sizes:
+        for d in dims:
+            run(n, dim=d)

--- a/tests/test_custom_gp_optim.py
+++ b/tests/test_custom_gp_optim.py
@@ -1,0 +1,171 @@
+"""
+mini-batch hyperparameter optimization: custom CUDA GP vs GPyTorch
+
+Runs Adam on the same batches from the same starting point
+"""
+
+import math, sys
+import numpy as np
+import torch
+import gpytorch
+from gpytorch.kernels import MaternKernel, PolynomialKernel, AdditiveKernel, ScaleKernel
+
+sys.path.insert(0, ".")
+from pufferlib.gp_torch import GaussianProcess
+
+N     = 300
+BATCH = 40
+STEPS = 60
+LR    = 0.05
+SEED  = 42
+
+
+def make_data(n, seed):
+    rng = np.random.RandomState(seed)
+    X   = rng.uniform(-5, 5, (n, 1)).astype(np.float64)
+    y   = (np.sin(X[:, 0]) + 0.1 * rng.randn(n)).astype(np.float64)
+    return X, y
+
+
+class ExactGP(gpytorch.models.ExactGP):
+    def __init__(self, tx, ty, lik):
+        super().__init__(tx, ty, lik)
+        self.mean_module  = gpytorch.means.ZeroMean()
+        matern = MaternKernel(nu=1.5, ard_num_dims=1)
+        linear = PolynomialKernel(power=1)
+        self.covar_module = ScaleKernel(AdditiveKernel(linear, matern))
+
+    def forward(self, x):
+        return gpytorch.distributions.MultivariateNormal(
+            self.mean_module(x), self.covar_module(x))
+
+
+def main():
+    X, y   = make_data(N, SEED)
+    Xt, yt = torch.from_numpy(X).double(), torch.from_numpy(y).double()
+
+    rng     = np.random.RandomState(SEED + 1)
+    batches = [rng.choice(N, BATCH, replace=False) for _ in range(STEPS)]
+
+    # shared initial constrained hyperparameters
+    ell0, sf0, noise0, off0 = 1.0, 1.0, 0.01, 1.0
+
+    # -- our model ---------------------------------------------------------
+    gp = GaussianProcess(dim=1, capacity=BATCH,
+            lengthscale=ell0, outputscale=sf0, noise=noise0, offset=off0,
+            use_cuda=False)
+    opt_ours = torch.optim.Adam(gp.parameters(), lr=LR)
+    gp.train()
+
+    # -- GPyTorch model ----------------------------------------------------
+    lik = gpytorch.likelihoods.GaussianLikelihood()
+    gpyt = ExactGP(Xt, yt, lik)
+    gpyt.double()
+    # Match initial constrained hyperparameters
+    gpyt.covar_module.base_kernel.kernels[1].lengthscale = ell0
+    gpyt.covar_module.outputscale                         = sf0
+    lik.noise                                            = noise0
+    gpyt.covar_module.base_kernel.kernels[0].raw_offset.data.fill_(
+        math.log(math.expm1(off0)))
+
+    mll_fn  = gpytorch.mlls.ExactMarginalLogLikelihood(lik, gpyt)
+    opt_gpyt = torch.optim.Adam(gpyt.parameters(), lr=LR)
+    gpyt.train(); lik.train()
+
+    # -- step-by-step comparison -------------------------------------------
+    print(f"\n{'step':>4}  {'MLL (ours)':>11}  {'MLL (gpyt)':>11}  {'|dMLL|':>8}"
+          f"  {'ell_ours':>9}  {'ell_gpyt':>9}  {'noise_ours':>11}  {'noise_gpyt':>11}")
+    print("-" * 102)
+
+    for step, idx in enumerate(batches):
+        X_b, y_b = Xt[idx], yt[idx]
+
+        # ours: fit loads batch + Cholesky; mll(recompute=False) skips a second one
+        gp.fit(X_b.numpy(), y_b.numpy())
+        opt_ours.zero_grad()
+        loss_ours = -gp.mll(recompute=False)
+        loss_ours.backward()
+        mll_ours = -loss_ours.item()
+        opt_ours.step()
+
+        # gpytorch: update stored training data to the batch, then compute MLL
+        gpyt.set_train_data(inputs=X_b, targets=y_b, strict=False)
+        opt_gpyt.zero_grad()
+        with gpytorch.settings.max_cholesky_size(BATCH + 1):
+            loss_gpyt = -mll_fn(gpyt(X_b), y_b)
+        loss_gpyt.backward()
+        mll_gpyt = -loss_gpyt.item()
+        opt_gpyt.step()
+
+        if step % 10 == 0 or step == STEPS - 1:
+            ell_ours = float(gp.lengthscale[0])
+            ell_g    = gpyt.covar_module.base_kernel.kernels[1].lengthscale.flatten()[0].item()
+            print(f"{step:>4}  {mll_ours:>11.5f}  {mll_gpyt:>11.5f}  "
+                  f"{abs(mll_ours - mll_gpyt):>8.2e}"
+                  f"  {ell_ours:>9.4f}  {ell_g:>9.4f}"
+                  f"  {gp.noise:>11.6f}  {lik.noise.item():>11.6f}")
+
+    # -- final hyperparameter comparison -----------------------------------
+    ell_ours = float(gp.lengthscale[0])
+    ell_gpyt  = gpyt.covar_module.base_kernel.kernels[1].lengthscale.flatten()[0].item()
+    ours_vals = [ell_ours, gp.outputscale, gp.noise, gp.offset]
+    gpyt_vals  = [
+        ell_gpyt,
+        gpyt.covar_module.outputscale.item(),
+        lik.noise.item(),
+        gpyt.covar_module.base_kernel.kernels[0].offset.item(),
+    ]
+    print()
+    print("Final hyperparameters:")
+    for label, ov, gv in zip(["lengthscale", "outputscale", "noise", "offset"],
+                              ours_vals, gpyt_vals):
+        print(f"  {label:12s}  ours={ov:.6f}  gpyt={gv:.6f}  |d|={abs(ov - gv):.2e}")
+
+    # -- gradient agreement at a fixed point (sanity check) ----------------
+    print()
+    print("Gradient agreement check (fresh models, same batch, same params):")
+    idx0 = batches[0]
+    X_b0, y_b0 = Xt[idx0], yt[idx0]
+
+    # fresh ours
+    gp2 = GaussianProcess(dim=1, capacity=BATCH,
+             lengthscale=ell0, outputscale=sf0, noise=noise0, offset=off0,
+             use_cuda=False)
+    gp2.train()
+    gp2.fit(X_b0.numpy(), y_b0.numpy())
+    (-gp2.mll(recompute=False)).backward()
+    # raw_lengthscale is (1,); flatten all param grads into a list
+    grads_ours = []
+    for p in gp2.parameters():
+        grads_ours.extend(p.grad.detach().flatten().tolist())
+
+    # fresh gpytorch
+    lik2 = gpytorch.likelihoods.GaussianLikelihood()
+    gpyt2 = ExactGP(Xt, yt, lik2)
+    gpyt2.double()
+    gpyt2.covar_module.base_kernel.kernels[1].lengthscale = ell0
+    gpyt2.covar_module.outputscale                         = sf0
+    lik2.noise                                            = noise0
+    gpyt2.covar_module.base_kernel.kernels[0].raw_offset.data.fill_(
+        math.log(math.expm1(off0)))
+    gpyt2.train(); lik2.train()
+    mll_fn2 = gpytorch.mlls.ExactMarginalLogLikelihood(lik2, gpyt2)
+    gpyt2.set_train_data(inputs=X_b0, targets=y_b0, strict=False)
+    with gpytorch.settings.max_cholesky_size(BATCH + 1):
+        (-mll_fn2(gpyt2(X_b0), y_b0)).backward()
+
+    # collect gpytorch gradients in the same param order as ours
+    gpyt_grads = [
+        gpyt2.covar_module.base_kernel.kernels[1].raw_lengthscale.grad.flatten()[0].item(),
+        gpyt2.covar_module.raw_outputscale.grad.item(),
+        lik2.noise_covar.raw_noise.grad.item(),
+        gpyt2.covar_module.base_kernel.kernels[0].raw_offset.grad.item(),
+    ]
+
+    labels = ["raw_ell_0", "raw_outputscale", "raw_noise", "raw_offset"]
+    for label, og, gg in zip(labels, grads_ours, gpyt_grads):
+        print(f"  {label:16s}  ours={og:+.6f}  gpyt={gg:+.6f}  |d|={abs(og - gg):.2e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_protein.cu
+++ b/tests/test_protein.cu
@@ -1,0 +1,408 @@
+// test_protein.cu -- Standalone tests for protein.cu
+//
+// Build: nvcc -o test_protein tests/test_protein.cu -I src/ -lcublas -lcusolver -lcurand
+
+#include <cuda_runtime.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+
+#include "gp_cuda.cu"
+#include "protein.cu"
+
+#define T_PASS(...)  do { printf("  PASS: "); printf(__VA_ARGS__); printf("\n"); } while(0)
+#define T_FAIL(name, ...) do { printf("  FAIL: %s -- ", name); printf(__VA_ARGS__); printf("\n"); return 1; } while(0)
+
+// -- test: Pareto front -------------------------------------------------------
+
+static int test_pareto()
+{
+    printf("[test_pareto]\n");
+
+    float scores[] = {1.0f, 3.0f, 2.0f, 4.0f, 2.5f};
+    float costs[]  = {10.0f, 30.0f, 20.0f, 50.0f, 40.0f};
+    int idx[5];
+    // Sorted by cost: (10,1) (20,2) (30,3) (40,2.5) (50,4)
+    // Pareto: 1 < 2 < 3 > 2.5 < 4  →  indices 0,2,1,3  (original positions)
+    int n = protein_pareto_front(scores, costs, 5, idx);
+    if (n != 4) T_FAIL("count", "expected 4, got %d", n);
+    // Verify monotonic scores along the front
+    for (int i = 1; i < n; i++)
+        if (scores[idx[i]] <= scores[idx[i-1]])
+            T_FAIL("monotonic", "scores not strictly increasing on front");
+    T_PASS("pareto_front");
+
+    // All dominated except best
+    float scores2[] = {5.0f, 1.0f, 2.0f, 3.0f};
+    float costs2[]  = {10.0f, 20.0f, 30.0f, 40.0f};
+    n = protein_pareto_front(scores2, costs2, 4, idx);
+    if (n != 1) T_FAIL("single", "expected 1 pareto point, got %d", n);
+    T_PASS("pareto_single_dominant");
+
+    return 0;
+}
+
+// -- test: Pareto pruning -----------------------------------------------------
+
+static int test_prune()
+{
+    printf("[test_prune]\n");
+
+    // Create a front with an inefficient tail:
+    // (10, 1.0) (20, 2.0) (30, 2.5) (100, 2.51)  ← last one is inefficient
+    float scores[] = {1.0f, 2.0f, 2.5f, 2.51f};
+    float costs[]  = {10.0f, 20.0f, 30.0f, 100.0f};
+    int idx[] = {0, 1, 2, 3};
+    int n = protein_prune_pareto(scores, costs, idx, 4, 0.5f, 0.98f);
+    if (n >= 4) T_FAIL("prune", "expected pruning, got n=%d", n);
+    T_PASS("prune_removes_tail");
+
+    // Front where all steps are efficient → no pruning
+    float scores3[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    float costs3[]  = {10.0f, 20.0f, 30.0f, 40.0f};
+    int idx3[] = {0, 1, 2, 3};
+    n = protein_prune_pareto(scores3, costs3, idx3, 4, 0.5f, 0.98f);
+    if (n != 4) T_FAIL("no_prune", "expected 4, got %d", n);
+    T_PASS("prune_keeps_efficient");
+
+    return 0;
+}
+
+// -- test: build search centers -----------------------------------------------
+
+static int test_search_centers()
+{
+    printf("[test_search_centers]\n");
+
+    // 3 observations, dim=2, cost_dim=1
+    float params[] = {0.1f, 0.5f,   0.3f, 0.7f,   0.5f, -0.2f};
+    int pareto[] = {0, 1};
+    int top[]    = {2};
+    float centers[12]; // max: 2 pareto + 2*1 top = 4 rows
+    int nc = protein_build_search_centers(params, 2, pareto, 2, top, 1, 1, centers);
+    // 2 pareto + 2 cost-shifted top = 4
+    if (nc != 4) T_FAIL("count", "expected 4 centers, got %d", nc);
+
+    // Verify pareto centers are unchanged
+    if (fabsf(centers[0] - 0.1f) > 1e-5f) T_FAIL("pareto0", "wrong value");
+    if (fabsf(centers[2] - 0.3f) > 1e-5f) T_FAIL("pareto1", "wrong value");
+
+    // Verify cost-shifted top obs have lower cost than original (-0.2)
+    float shifted1 = centers[4*1 + 1]; // 3rd row, cost dim
+    float shifted2 = centers[4*1 + 3]; // 4th row, cost dim (wait, layout is row-major dim=2)
+    // row 2 (idx=2): centers[4], centers[5]  → cost = centers[5]
+    // row 3 (idx=3): centers[6], centers[7]  → cost = centers[7]
+    shifted1 = centers[5];
+    shifted2 = centers[7];
+    if (shifted1 >= -0.2f) T_FAIL("shift1", "expected < -0.2, got %.3f", shifted1);
+    if (shifted2 >= -0.2f) T_FAIL("shift2", "expected < -0.2, got %.3f", shifted2);
+    // Half-shift moves further toward -1 than third-shift
+    if (shifted1 >= shifted2) T_FAIL("shift_order", "half-shift should be more negative than third-shift");
+    T_PASS("search_centers");
+
+    return 0;
+}
+
+// -- test: cost model ---------------------------------------------------------
+
+static int test_cost_model()
+{
+    printf("[test_cost_model]\n");
+
+    int n = 50;
+    float scores[50], costs[50];
+    srand(42);
+    for (int i = 0; i < n; i++) {
+        costs[i]  = 10.0f + 90.0f * (float)i / (float)n;
+        scores[i] = 0.5f + 0.3f * logf(costs[i]);
+    }
+
+    ProteinCostModel model;
+    protein_cost_model_init(&model, 0.3f, 10);
+    protein_cost_model_fit(&model, scores, costs, n, 100.0f);
+    if (!model.is_fitted) T_FAIL("fit", "model not fitted");
+
+    float t50 = protein_cost_model_threshold(&model, 50.0f, 0.3f, 10.0f);
+    float expected = 0.5f + 0.3f * logf(50.0f);
+    if (fabsf(t50 - expected) > 0.5f) T_FAIL("thresh", "threshold %.3f far from expected %.3f", t50, expected);
+
+    // Below min cost → -FLT_MAX
+    float t_low = protein_cost_model_threshold(&model, 1.0f, 0.3f, 10.0f);
+    if (t_low > -1e30f) T_FAIL("low_cost", "expected -inf for low cost");
+
+    // Above upper threshold → 0.9 * max_score
+    float t_high = protein_cost_model_threshold(&model, 200.0f, 0.3f, 10.0f);
+    if (fabsf(t_high - 0.9f * model.max_score) > 0.01f)
+        T_FAIL("high_cost", "expected 0.9*max_score, got %.3f", t_high);
+
+    T_PASS("cost_model");
+    return 0;
+}
+
+// -- test: classifier ---------------------------------------------------------
+
+static int test_classifier()
+{
+    printf("[test_classifier]\n");
+
+    int dim = 2, n = 40;
+    float *X = (float *)malloc((size_t)n * dim * sizeof(float));
+    int   *y = (int *)malloc((size_t)n * sizeof(int));
+
+    srand(123);
+    for (int i = 0; i < n; i++) {
+        X[i * 2]     = (float)rand() / (float)RAND_MAX * 2.0f - 1.0f;
+        X[i * 2 + 1] = (float)rand() / (float)RAND_MAX * 2.0f - 1.0f;
+        y[i] = (X[i * 2] + X[i * 2 + 1] > 0.0f) ? 1 : 0;
+    }
+
+    ProteinClassifier *clf = protein_classifier_create(dim);
+    protein_classifier_fit(clf, X, y, n, 1.0f, 200);
+    if (!clf->is_fitted) T_FAIL("fit", "classifier not fitted");
+
+    // Predict on device
+    float *d_X, *d_probs;
+    cudaMalloc(&d_X, (size_t)n * dim * sizeof(float));
+    cudaMalloc(&d_probs, (size_t)n * sizeof(float));
+    cudaMemcpy(d_X, X, (size_t)n * dim * sizeof(float), cudaMemcpyHostToDevice);
+    protein_classifier_predict_d(clf, d_X, d_probs, n, 0);
+
+    float *h_probs = (float *)malloc((size_t)n * sizeof(float));
+    cudaMemcpy(h_probs, d_probs, (size_t)n * sizeof(float), cudaMemcpyDeviceToHost);
+
+    // Check: positive examples should generally have p > 0.5
+    int correct = 0;
+    for (int i = 0; i < n; i++) {
+        int pred = h_probs[i] > 0.5f ? 1 : 0;
+        if (pred == y[i]) correct++;
+    }
+    float accuracy = (float)correct / (float)n;
+    if (accuracy < 0.7f)
+        T_FAIL("accuracy", "%.0f%% accuracy on linearly separable data", accuracy * 100);
+
+    cudaFree(d_X); cudaFree(d_probs);
+    free(X); free(y); free(h_probs);
+    protein_classifier_destroy(clf);
+    T_PASS("classifier (accuracy=%.0f%%)", accuracy * 100);
+    return 0;
+}
+
+// -- test: sampling -----------------------------------------------------------
+
+static int test_sampling()
+{
+    printf("[test_sampling]\n");
+
+    int dim = 3, cap = 512;
+    float bmin[] = {-1.0f, -1.0f, -1.0f};
+    float bmax[] = { 1.0f,  1.0f,  1.0f};
+    float scl[]  = { 0.5f,  0.5f,  0.5f};
+    ProteinAcq *acq = protein_acq_create(dim, cap, bmin, bmax, scl, 42ULL);
+
+    float centers[] = {0.0f, 0.0f, 0.0f};
+    int m = protein_acq_sample(acq, centers, 1, cap,
+                                1.0f, -1, NAN, 0.0f, 0);
+    if (m != cap) T_FAIL("count", "expected %d, got %d", cap, m);
+
+    float *h_cands = (float *)malloc((size_t)m * dim * sizeof(float));
+    cudaMemcpy(h_cands, acq->d_candidates, (size_t)m * dim * sizeof(float),
+               cudaMemcpyDeviceToHost);
+
+    for (int i = 0; i < m; i++)
+        for (int d = 0; d < dim; d++) {
+            float v = h_cands[i * dim + d];
+            if (v < bmin[d] - 1e-5f || v > bmax[d] + 1e-5f)
+                T_FAIL("bounds", "candidate[%d][%d]=%.3f out of bounds", i, d, v);
+        }
+
+    free(h_cands);
+    protein_acq_destroy(acq);
+    T_PASS("sampling_bounds");
+    return 0;
+}
+
+// -- test: scoring kernel -----------------------------------------------------
+
+static int test_scoring()
+{
+    printf("[test_scoring]\n");
+
+    int dim = 2, cap = 64;
+    float bmin[] = {-1.0f, -1.0f}, bmax[] = {1.0f, 1.0f}, scl[] = {0.5f, 0.5f};
+    ProteinAcq *acq = protein_acq_create(dim, cap, bmin, bmax, scl, 99ULL);
+
+    // Manually fill prediction buffers with known values
+    int m = 4;
+    float h_pred_y[] = {0.2f, 0.8f, 0.5f, 0.1f};
+    float h_pred_c[] = {0.3f, 0.5f, 0.7f, 0.9f};
+    cudaMemcpy(acq->d_pred_y, h_pred_y, (size_t)m * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(acq->d_pred_c, h_pred_c, (size_t)m * sizeof(float), cudaMemcpyHostToDevice);
+
+    // Fixed cost mode → pure score maximization
+    ProteinAcqResult r = protein_acq_score(acq, m,
+        0.0f, 10.0f, 0.0f, 5.0f,
+        3600.0f, 0.5f,
+        1, 1, NULL, 0);
+    if (r.best_idx != 1)
+        T_FAIL("fixed_cost", "expected best_idx=1 (highest y_norm), got %d", r.best_idx);
+    T_PASS("scoring_fixed_cost");
+
+    // Cost-weighted mode
+    // target_cost=0.5, candidate 1 has c_norm=0.5 (exact match) and highest score
+    r = protein_acq_score(acq, m,
+        0.0f, 10.0f, 0.0f, 5.0f,
+        3600.0f, 0.5f,
+        1, 0, NULL, 0);
+    if (r.best_idx != 1)
+        T_FAIL("cost_weighted", "expected best_idx=1, got %d", r.best_idx);
+    T_PASS("scoring_cost_weighted");
+
+    // With success_prob that zeros out candidate 1
+    float h_sprob[] = {1.0f, 0.0f, 1.0f, 1.0f};
+    float *d_sprob;
+    cudaMalloc(&d_sprob, (size_t)m * sizeof(float));
+    cudaMemcpy(d_sprob, h_sprob, (size_t)m * sizeof(float), cudaMemcpyHostToDevice);
+    r = protein_acq_score(acq, m,
+        0.0f, 10.0f, 0.0f, 5.0f,
+        3600.0f, 0.5f,
+        1, 1, d_sprob, 0);
+    if (r.best_idx == 1)
+        T_FAIL("success_prob", "candidate 1 should be zeroed out");
+    cudaFree(d_sprob);
+    T_PASS("scoring_success_prob");
+
+    protein_acq_destroy(acq);
+    return 0;
+}
+
+// -- test: full GP pipeline ---------------------------------------------------
+
+static int test_full_pipeline()
+{
+    printf("[test_full_pipeline]\n");
+
+    int dim = 2, n_obs = 40, cap = 256;
+
+    // Generate observations: score = x0 + 0.5*x1, cost = exp(2 + x0)
+    float *obs_params = (float *)malloc((size_t)n_obs * dim * sizeof(float));
+    float *obs_scores = (float *)malloc((size_t)n_obs * sizeof(float));
+    float *obs_costs  = (float *)malloc((size_t)n_obs * sizeof(float));
+    float *gp_y_train = (float *)malloc((size_t)n_obs * sizeof(float));
+    float *gp_c_train = (float *)malloc((size_t)n_obs * sizeof(float));
+
+    srand(7);
+    float min_s = FLT_MAX, max_s = -FLT_MAX;
+    float log_c_min = FLT_MAX, log_c_max = -FLT_MAX;
+
+    for (int i = 0; i < n_obs; i++) {
+        float x0 = 2.0f * (float)rand() / (float)RAND_MAX - 1.0f;
+        float x1 = 2.0f * (float)rand() / (float)RAND_MAX - 1.0f;
+        obs_params[i * 2]     = x0;
+        obs_params[i * 2 + 1] = x1;
+        obs_scores[i] = x0 + 0.5f * x1;
+        obs_costs[i]  = expf(2.0f + x0);
+
+        if (obs_scores[i] < min_s) min_s = obs_scores[i];
+        if (obs_scores[i] > max_s) max_s = obs_scores[i];
+        float lc = logf(obs_costs[i]);
+        if (lc < log_c_min) log_c_min = lc;
+        if (lc > log_c_max) log_c_max = lc;
+    }
+
+    // Normalize for GP training
+    for (int i = 0; i < n_obs; i++) {
+        gp_y_train[i] = (obs_scores[i] - min_s) / (max_s - min_s + PROTEIN_EPSILON);
+        float lc = logf(obs_costs[i]);
+        gp_c_train[i] = (lc - log_c_min) / (log_c_max - log_c_min + PROTEIN_EPSILON);
+    }
+
+    // Create and fit GPs
+    GPKernel *k_score = gp_kernel_matern32_linear(dim, 1.0f, 1.0f, 1.0f);
+    GPKernel *k_cost  = gp_kernel_matern32_linear(dim, 1.0f, 1.0f, 1.0f);
+    GaussianProcess *gp_score = gp_create(dim, n_obs + 10, k_score, 1e-2f);
+    GaussianProcess *gp_cost  = gp_create(dim, n_obs + 10, k_cost,  1e-2f);
+
+    int rc = gp_fit(gp_score, obs_params, gp_y_train, n_obs, 0);
+    if (rc != 0) T_FAIL("gp_score_fit", "rc=%d", rc);
+    rc = gp_fit(gp_cost, obs_params, gp_c_train, n_obs, 0);
+    if (rc != 0) T_FAIL("gp_cost_fit", "rc=%d", rc);
+
+    // Pareto front
+    int *pareto_idx = (int *)malloc((size_t)n_obs * sizeof(int));
+    int n_pareto = protein_pareto_front(obs_scores, obs_costs, n_obs, pareto_idx);
+    if (n_pareto == 0) T_FAIL("pareto", "empty pareto front");
+    printf("  pareto points: %d\n", n_pareto);
+
+    // Build search centers (no top obs for simplicity)
+    float *centers = (float *)malloc((size_t)n_pareto * dim * sizeof(float));
+    int nc = protein_build_search_centers(obs_params, dim,
+                                           pareto_idx, n_pareto,
+                                           NULL, 0, -1, centers);
+
+    // Sample + predict + score
+    float bmin[] = {-1.0f, -1.0f}, bmax[] = {1.0f, 1.0f}, scl[] = {0.5f, 0.5f};
+    ProteinAcq *acq = protein_acq_create(dim, cap, bmin, bmax, scl, 1234ULL);
+
+    int m = protein_acq_sample(acq, centers, nc, nc * 64,
+                                1.0f, -1, NAN, PROTEIN_EPSILON, 0);
+    if (m == 0) T_FAIL("sample", "no candidates after dedup");
+    printf("  candidates after dedup: %d\n", m);
+
+    float target = 0.5f;
+    ProteinAcqResult result = protein_acq_suggest(
+        acq, m, gp_score, gp_cost,
+        min_s, max_s, log_c_min, log_c_max,
+        3600.0f, target, 1, 0, NULL, 0);
+
+    printf("  best_idx=%d  score=%.3f  cost=%.3f  rating=%.4f\n",
+           result.best_idx, result.predicted_score,
+           result.predicted_cost, result.rating);
+
+    float best_params[2];
+    protein_acq_get_candidate(acq, result.best_idx, best_params, 0);
+    printf("  best params: [%.3f, %.3f]\n", best_params[0], best_params[1]);
+
+    if (result.predicted_score < min_s || result.predicted_score > max_s * 1.5f)
+        T_FAIL("score_range", "predicted score %.3f out of reasonable range", result.predicted_score);
+
+    // Cost model
+    ProteinCostModel cm;
+    protein_cost_model_init(&cm, 0.3f, 10);
+    protein_cost_model_fit(&cm, obs_scores, obs_costs, n_obs, obs_costs[0]);
+    printf("  cost_model: fitted=%d A=%.3f B=%.3f\n", cm.is_fitted, cm.A, cm.B);
+
+    // Cleanup
+    protein_acq_destroy(acq);
+    gp_destroy(gp_score);
+    gp_destroy(gp_cost);
+    free(obs_params); free(obs_scores); free(obs_costs);
+    free(gp_y_train); free(gp_c_train);
+    free(pareto_idx); free(centers);
+
+    T_PASS("full_pipeline");
+    return 0;
+}
+
+// -- main ---------------------------------------------------------------------
+
+int main()
+{
+    srand((unsigned)time(NULL));
+    printf("=== Protein CUDA tests ===\n\n");
+
+    int failures = 0;
+    failures += test_pareto();
+    failures += test_prune();
+    failures += test_search_centers();
+    failures += test_cost_model();
+    failures += test_classifier();
+    failures += test_sampling();
+    failures += test_scoring();
+    failures += test_full_pipeline();
+
+    printf("\n=== %s: %d test(s) failed ===\n",
+           failures ? "FAILED" : "ALL PASSED", failures);
+    return failures;
+}

--- a/tests/test_protein.cu
+++ b/tests/test_protein.cu
@@ -15,6 +15,41 @@
 #define T_PASS(...)  do { printf("  PASS: "); printf(__VA_ARGS__); printf("\n"); } while(0)
 #define T_FAIL(name, ...) do { printf("  FAIL: %s -- ", name); printf(__VA_ARGS__); printf("\n"); return 1; } while(0)
 
+// Helpers inlined from protein.cu / protein_util.h (removed from production code)
+static void test_cost_model_init(ProteinCostModel *m, float quantile, int min_samples) {
+    memset(m, 0, sizeof(*m));
+    m->quantile = quantile;
+    m->min_samples = min_samples;
+}
+static void test_acq_get_candidate(const ProteinAcq *acq, int idx, float *out, cudaStream_t stream) {
+    CUDA_CHECK(cudaMemcpyAsync(out, &acq->d_candidates[(size_t)idx * acq->dim],
+        (size_t)acq->dim * sizeof(float), cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+}
+static ProteinAcqResult test_acq_score(ProteinAcq *acq, int m, float min_score, float max_score,
+    float log_c_min, float log_c_max, float max_suggestion_cost, float target_cost_ratio,
+    int optimize_direction, int fixed_cost, const float *d_success_prob, cudaStream_t stream) {
+    protein_k_score<<<(m + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE, 0, stream>>>(
+        acq->d_pred_y, acq->d_pred_c, d_success_prob, acq->d_scores, m, min_score, max_score,
+        log_c_min, log_c_max, max_suggestion_cost, target_cost_ratio, optimize_direction, fixed_cost);
+    CUDA_CHECK(cudaGetLastError());
+    protein_k_argmax<<<1, BLOCK_SIZE, 0, stream>>>(acq->d_scores, m, acq->d_best_idx);
+    CUDA_CHECK(cudaGetLastError());
+    int best;
+    CUDA_CHECK(cudaMemcpyAsync(&best, acq->d_best_idx, sizeof(int), cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+    float y_norm, c_norm, rating;
+    CUDA_CHECK(cudaMemcpy(&y_norm, &acq->d_pred_y[best], sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(&c_norm, &acq->d_pred_c[best], sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(&rating, &acq->d_scores[best], sizeof(float), cudaMemcpyDeviceToHost));
+    return (ProteinAcqResult){
+        .best_idx = best,
+        .predicted_score = y_norm * (max_score - min_score) + min_score,
+        .predicted_cost = expf(c_norm * (log_c_max - log_c_min) + log_c_min),
+        .rating = rating,
+    };
+}
+
 // -- test: Pareto front -------------------------------------------------------
 
 static int test_pareto()
@@ -120,7 +155,7 @@ static int test_cost_model()
     }
 
     ProteinCostModel model;
-    protein_cost_model_init(&model, 0.3f, 10);
+    test_cost_model_init(&model, 0.3f, 10);
     protein_cost_model_fit(&model, scores, costs, n, 100.0f);
     if (!model.is_fitted) T_FAIL("fit", "model not fitted");
 
@@ -241,7 +276,7 @@ static int test_scoring()
     cudaMemcpy(acq->d_pred_c, h_pred_c, (size_t)m * sizeof(float), cudaMemcpyHostToDevice);
 
     // Fixed cost mode → pure score maximization
-    ProteinAcqResult r = protein_acq_score(acq, m,
+    ProteinAcqResult r = test_acq_score(acq, m,
         0.0f, 10.0f, 0.0f, 5.0f,
         3600.0f, 0.5f,
         1, 1, NULL, 0);
@@ -251,7 +286,7 @@ static int test_scoring()
 
     // Cost-weighted mode
     // target_cost=0.5, candidate 1 has c_norm=0.5 (exact match) and highest score
-    r = protein_acq_score(acq, m,
+    r = test_acq_score(acq, m,
         0.0f, 10.0f, 0.0f, 5.0f,
         3600.0f, 0.5f,
         1, 0, NULL, 0);
@@ -264,7 +299,7 @@ static int test_scoring()
     float *d_sprob;
     cudaMalloc(&d_sprob, (size_t)m * sizeof(float));
     cudaMemcpy(d_sprob, h_sprob, (size_t)m * sizeof(float), cudaMemcpyHostToDevice);
-    r = protein_acq_score(acq, m,
+    r = test_acq_score(acq, m,
         0.0f, 10.0f, 0.0f, 5.0f,
         3600.0f, 0.5f,
         1, 1, d_sprob, 0);
@@ -361,7 +396,7 @@ static int test_full_pipeline()
            result.predicted_cost, result.rating);
 
     float best_params[2];
-    protein_acq_get_candidate(acq, result.best_idx, best_params, 0);
+    test_acq_get_candidate(acq, result.best_idx, best_params, 0);
     printf("  best params: [%.3f, %.3f]\n", best_params[0], best_params[1]);
 
     if (result.predicted_score < min_s || result.predicted_score > max_s * 1.5f)
@@ -369,7 +404,7 @@ static int test_full_pipeline()
 
     // Cost model
     ProteinCostModel cm;
-    protein_cost_model_init(&cm, 0.3f, 10);
+    test_cost_model_init(&cm, 0.3f, 10);
     protein_cost_model_fit(&cm, obs_scores, obs_costs, n_obs, obs_costs[0]);
     printf("  cost_model: fitted=%d A=%.3f B=%.3f\n", cm.is_fitted, cm.A, cm.B);
 

--- a/tests/test_protein_sweep.cu
+++ b/tests/test_protein_sweep.cu
@@ -1,0 +1,459 @@
+// test_protein_sweep.cu -- End-to-end sweep test for protein.cu
+// Replicates tests/test_sweep.py.
+//
+// Build:
+//   nvcc -o test_protein_sweep tests/test_protein_sweep.cu -I src/ -lcublas -lcusolver -lcurand
+
+#include <cuda_runtime.h>
+#include <float.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "gp_cuda.cu"
+#include "protein.cu"
+
+// -- default search space (21 dims, matches Python ordering) ------------------
+
+#define DIM 21
+#define COST_IDX 0 // train/total_timesteps
+#define LR_IDX 2 // train/learning_rate
+
+static Hyperparameters* build_default_search_space(void)
+{
+    Space spaces[DIM];
+    //  0: train/total_timesteps  Log    3e7..1e11  scale=1/(log2(1e11)-log2(3e7))
+    float ts_scale = 1.0f / (log2f(1e11f) - log2f(3e7f));
+    space_init(&spaces[0], SPACE_LOG, 3e7f, 1e11f, ts_scale, 0);
+    //  1: train/horizon          Pow2   8..1024    scale=0.5
+    space_init(&spaces[1], SPACE_POW2, 8.0f, 1024.0f, 0.5f, 1);
+    //  2: train/learning_rate    Log    1e-5..0.1  scale=0.5
+    space_init(&spaces[2], SPACE_LOG, 1e-5f, 0.1f, 0.5f, 0);
+    //  3: train/ent_coef         Log    1e-5..0.2  scale=0.5
+    space_init(&spaces[3], SPACE_LOG, 1e-5f, 0.2f, 0.5f, 0);
+    //  4: train/gamma            Logit  0.8..0.9999  scale=0.5
+    space_init(&spaces[4], SPACE_LOGIT, 0.8f, 0.9999f, 0.5f, 0);
+    //  5: train/gae_lambda       Logit  0.2..0.995   scale=0.5
+    space_init(&spaces[5], SPACE_LOGIT, 0.2f, 0.995f, 0.5f, 0);
+    //  6: train/vtrace_rho_clip  Linear 0.1..5.0   scale=0.5
+    space_init(&spaces[6], SPACE_LINEAR, 0.1f, 5.0f, 0.5f, 0);
+    //  7: train/vtrace_c_clip    Linear 0.1..5.0   scale=0.5
+    space_init(&spaces[7], SPACE_LINEAR, 0.1f, 5.0f, 0.5f, 0);
+    //  8: train/replay_ratio     Linear 0.25..4.0  scale=0.5
+    space_init(&spaces[8], SPACE_LINEAR, 0.25f, 4.0f, 0.5f, 0);
+    //  9: train/clip_coef        Linear 0.01..1.0  scale=0.5
+    space_init(&spaces[9], SPACE_LINEAR, 0.01f, 1.0f, 0.5f, 0);
+    // 10: train/vf_clip_coef     Linear 0.01..5.0  scale=0.5
+    space_init(&spaces[10], SPACE_LINEAR, 0.01f, 5.0f, 0.5f, 0);
+    // 11: train/vf_coef          Linear 0.1..5.0   scale=0.5
+    space_init(&spaces[11], SPACE_LINEAR, 0.1f, 5.0f, 0.5f, 0);
+    // 12: train/max_grad_norm    Linear 0.1..5.0   scale=0.5
+    space_init(&spaces[12], SPACE_LINEAR, 0.1f, 5.0f, 0.5f, 0);
+    // 13: train/beta1            Logit  0.5..0.999   scale=0.5
+    space_init(&spaces[13], SPACE_LOGIT, 0.5f, 0.999f, 0.5f, 0);
+    // 14: train/beta2            Logit  0.9..0.99999 scale=0.5
+    space_init(&spaces[14], SPACE_LOGIT, 0.9f, 0.99999f, 0.5f, 0);
+    // 15: train/eps              Log    1e-14..1e-4  scale=0.5
+    space_init(&spaces[15], SPACE_LOG, 1e-14f, 1e-4f, 0.5f, 0);
+    // 16: train/prio_alpha       Linear 0.0..1.0   scale=0.5
+    space_init(&spaces[16], SPACE_LINEAR, 0.0f, 1.0f, 0.5f, 0);
+    // 17: train/prio_beta0       Linear 0.0..1.0   scale=0.5
+    space_init(&spaces[17], SPACE_LINEAR, 0.0f, 1.0f, 0.5f, 0);
+    // 18: policy/hidden_size     Pow2   32..1024   scale=0.5
+    space_init(&spaces[18], SPACE_POW2, 32.0f, 1024.0f, 0.5f, 1);
+    // 19: policy/num_layers      Linear 1..8       scale=0.5
+    space_init(&spaces[19], SPACE_LINEAR, 1.0f, 8.0f, 0.5f, 0);
+    // 20: vec/num_buffers        Linear 1..8       scale=0.5
+    space_init(&spaces[20], SPACE_LINEAR, 1.0f, 8.0f, 0.5f, 0);
+
+    return hyperparameters_create(spaces, DIM, COST_IDX, 1);
+}
+
+static void synthetic_linear(float learning_rate, float total_timesteps,
+    float* out_score, float* out_cost)
+{
+    float basic = expf(-powf(log10f(learning_rate) + 3.0f, 2.0f));
+    *out_cost = total_timesteps / 5e7f;
+    *out_score = basic * (*out_cost);
+}
+
+// -- helpers ------------------------------------------------------------------
+
+static float randn(void)
+{
+    float u1 = ((float)rand() + 1.0f) / ((float)RAND_MAX + 1.0f);
+    float u2 = ((float)rand() + 1.0f) / ((float)RAND_MAX + 1.0f);
+    return sqrtf(-2.0f * logf(u1)) * cosf(2.0f * (float)M_PI * u2);
+}
+
+// -- plot output --------------------------------------------------------------
+
+static int cmp_float_pair(const void* a, const void* b)
+{
+    float va = ((const float*)a)[0], vb = ((const float*)b)[0];
+    return (va > vb) - (va < vb);
+}
+
+static void write_plot(const char* path, const float* scores,
+    const float* costs, int n)
+{
+    FILE* f = fopen(path, "w");
+    if (!f) {
+        fprintf(stderr, "cannot open %s\n", path);
+        return;
+    }
+
+    static const char* turbo[] = { "#30123b", "#4662d7", "#36aaf9", "#1ae4b6",
+        "#72fe5e", "#c8ef34", "#faba39", "#f6511d" };
+
+    float max_s = scores[0], sum_c = 0;
+    for (int i = 0; i < n; i++) {
+        if (scores[i] > max_s)
+            max_s = scores[i];
+        sum_c += costs[i];
+    }
+
+    float(*sorted)[2] = (float(*)[2])malloc((size_t)n * 2 * sizeof(float));
+    for (int i = 0; i < n; i++) {
+        sorted[i][0] = costs[i];
+        sorted[i][1] = (float)i;
+    }
+    qsort(sorted, n, 2 * sizeof(float), cmp_float_pair);
+
+    float* aoc_x = (float*)malloc((size_t)n * sizeof(float));
+    float* aoc_y = (float*)malloc((size_t)n * sizeof(float));
+    float cumsum = 0;
+    for (int i = 0; i < n; i++) {
+        cumsum += sorted[i][0];
+        aoc_x[i] = sorted[i][0];
+        aoc_y[i] = max_s * cumsum / sum_c;
+    }
+
+    float x_min = costs[0], x_max = costs[0];
+    float y_min = scores[0], y_max = scores[0];
+    for (int i = 1; i < n; i++) {
+        if (costs[i] < x_min)
+            x_min = costs[i];
+        if (costs[i] > x_max)
+            x_max = costs[i];
+        if (scores[i] < y_min)
+            y_min = scores[i];
+        if (scores[i] > y_max)
+            y_max = scores[i];
+    }
+    for (int i = 0; i < n; i++)
+        if (aoc_y[i] > y_max)
+            y_max = aoc_y[i];
+
+    int W = 800, H = 500, M = 60;
+    int pw = W - 2 * M, ph = H - 2 * M;
+
+#define PX(v) (M + (int)(((v)-x_min) / (x_max - x_min) * pw))
+#define PY(v) (M + ph - (int)(((v)-y_min) / (y_max - y_min) * ph))
+
+    fprintf(f,
+        "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+        "<title>Protein Sweep</title></head><body style='background:#222'>\n"
+        "<svg width='%d' height='%d' xmlns='http://www.w3.org/2000/svg'>\n"
+        "<rect width='100%%' height='100%%' fill='#FFF'/>\n",
+        W, H);
+
+    fprintf(f, "<g stroke='#444' stroke-width='1'>\n");
+    int n_ticks = 5;
+    for (int i = 0; i <= n_ticks; i++) {
+        float xv = x_min + (x_max - x_min) * i / n_ticks;
+        float yv = y_min + (y_max - y_min) * i / n_ticks;
+        fprintf(f, "<line x1='%d' y1='%d' x2='%d' y2='%d'/>\n", PX(xv), M, PX(xv),
+            M + ph);
+        fprintf(f, "<line x1='%d' y1='%d' x2='%d' y2='%d'/>\n", M, PY(yv), M + pw,
+            PY(yv));
+        fprintf(f,
+            "<text x='%d' y='%d' fill='#aaa' font-size='11' "
+            "text-anchor='middle'>%.0f</text>\n",
+            PX(xv), M + ph + 16, xv);
+        fprintf(f,
+            "<text x='%d' y='%d' fill='#aaa' font-size='11' "
+            "text-anchor='end' dominant-baseline='middle'>%.0f</text>\n",
+            M - 6, PY(yv), yv);
+    }
+    fprintf(f, "</g>\n");
+
+    fprintf(f,
+        "<text x='%d' y='%d' fill='#ccc' font-size='13' "
+        "text-anchor='middle'>Cost</text>\n",
+        W / 2, H - 8);
+    fprintf(f,
+        "<text x='14' y='%d' fill='#ccc' font-size='13' "
+        "text-anchor='middle' transform='rotate(-90,14,%d)'>Score</text>\n",
+        H / 2, H / 2);
+    fprintf(f,
+        "<text x='%d' y='20' fill='#eee' font-size='15' "
+        "text-anchor='middle'>Protein Sweep (synthetic linear, 21D)</text>\n",
+        W / 2);
+
+    fprintf(f,
+        "<polyline fill='none' stroke='#b06cff' stroke-width='2' points='");
+    for (int i = 0; i < n; i++)
+        fprintf(f, "%d,%d ", PX(aoc_x[i]), PY(aoc_y[i]));
+    fprintf(f, "'/>\n");
+
+    for (int i = 0; i < n; i++) {
+        int ci = (int)((float)i / fmaxf((float)(n - 1), 1.0f) * 7.0f);
+        if (ci > 7)
+            ci = 7;
+        fprintf(f, "<circle cx='%d' cy='%d' r='3' fill='%s' opacity='0.75'/>\n",
+            PX(costs[i]), PY(scores[i]), turbo[ci]);
+    }
+
+    fprintf(f, "</svg></body></html>\n");
+
+#undef PX
+#undef PY
+
+    free(sorted);
+    free(aoc_x);
+    free(aoc_y);
+    fclose(f);
+    printf("  Plot written to %s\n", path);
+}
+
+// -- main sweep loop ----------------------------------------------------------
+
+int main(int argc, char** argv)
+{
+    setbuf(stdout, NULL);
+    srand((unsigned)time(NULL));
+    const char* plot_base = (argc > 1) ? argv[1] : "sweep_plot";
+    char plot_path[512], csv_path[512];
+    snprintf(plot_path, sizeof(plot_path), "%s.html", plot_base);
+    snprintf(csv_path, sizeof(csv_path), "%s.csv", plot_base);
+    printf("=== Protein Sweep Test (synthetic linear, 21D) ===\n");
+    printf("  Plot output: %s\n\n", plot_path);
+
+    Hyperparameters* hp = build_default_search_space();
+
+    int num_runs = 200;
+    int num_random_samples = 10;
+    int downsample = 5;
+    int max_obs = num_runs * downsample + 10;
+    int gp_max_obs = 750;
+    int n_candidates = 4096;
+    int suggestions_per_pareto = 256;
+    int gp_train_iter = 50;
+    float gp_lr = 0.001f;
+    float expansion_rate = 1.0f;
+    int top_k = 5;
+    float max_suggestion_cost = 3600.0f;
+    int optimizer_reset_freq = 50;
+    float cost_random_suggestion = -0.8f;
+    float early_stop_quantile = 0.3f;
+
+    ProteinObs* obs = protein_obs_create(DIM, max_obs, max_obs / 10, top_k,
+        COST_IDX);
+
+    GPKernel* ks = gp_kernel_matern32_linear(DIM, 1.0f, 1.0f, 1.0f);
+    GPKernel* kc = gp_kernel_matern32_linear(DIM, 1.0f, 1.0f, 1.0f);
+    GaussianProcess* gp_s = gp_create(DIM, gp_max_obs, ks, 1e-2f);
+    GaussianProcess* gp_c = gp_create(DIM, gp_max_obs, kc, 1e-2f);
+    Adam* opt_s = adam_create(ks->n_params, gp_lr);
+    Adam* opt_c = adam_create(kc->n_params, gp_lr);
+    ProteinAcq* acq = protein_acq_create(DIM, n_candidates, hp->bounds_min,
+        hp->bounds_max, hp->scales, 42ULL);
+    Sobol* sobol = sobol_create(DIM, 73);
+
+    ProteinCostModel cost_model;
+    protein_cost_model_init(&cost_model, early_stop_quantile, 30);
+    float upper_cost_threshold = -FLT_MAX;
+
+    float ratio_pool[] = { 0.16f, 0.32f, 0.48f, 0.64f, 0.80f, 1.0f };
+    int ratio_remaining = 0;
+
+    float* gp_params = (float*)malloc((size_t)gp_max_obs * DIM * sizeof(float));
+    float* gp_scores = (float*)malloc((size_t)gp_max_obs * sizeof(float));
+    float* gp_costs = (float*)malloc((size_t)gp_max_obs * sizeof(float));
+    float* y_norm = (float*)malloc((size_t)gp_max_obs * sizeof(float));
+    float* c_norm = (float*)malloc((size_t)gp_max_obs * sizeof(float));
+
+    float* run_scores = (float*)malloc((size_t)num_runs * sizeof(float));
+    float* run_costs = (float*)malloc((size_t)num_runs * sizeof(float));
+    float suggestion[DIM];
+    float sobol_buf[DIM];
+    int suggestion_idx = 0;
+
+    float random_best = -FLT_MAX, guided_best = -FLT_MAX;
+    float random_sum = 0.0f, guided_sum = 0.0f;
+    int random_count = 0, guided_count = 0;
+
+    for (int run = 0; run < num_runs; run++) {
+        suggestion_idx++;
+        int is_random = (suggestion_idx <= num_random_samples);
+
+        if (is_random) {
+            sobol_next(sobol, sobol_buf);
+            for (int d = 0; d < DIM; d++)
+                suggestion[d] = 2.0f * sobol_buf[d] - 1.0f;
+            float cost_s = cost_random_suggestion + 0.1f * randn();
+            suggestion[COST_IDX] = fmaxf(-1.0f, fminf(1.0f, cost_s));
+        } else {
+            int n_gp = protein_obs_sample_for_gp(obs, gp_max_obs, 0.5f,
+                gp_params, gp_scores, gp_costs);
+            float min_s = obs->min_score, max_s = obs->max_score;
+            float lc_min = obs->log_c_min, lc_max = obs->log_c_max;
+
+            float s_range = fabsf(max_s - min_s) + PROTEIN_EPSILON;
+            float lc_range = fabsf(lc_max - lc_min) + PROTEIN_EPSILON;
+            for (int i = 0; i < n_gp; i++) {
+                y_norm[i] = (gp_scores[i] - min_s) / s_range;
+                float lc = logf(fmaxf(gp_costs[i], PROTEIN_EPSILON));
+                c_norm[i] = (lc - lc_min) / lc_range;
+            }
+
+            float loss_s = protein_train_gp(gp_s, opt_s, gp_params, y_norm, n_gp,
+                gp_train_iter, 0);
+            float loss_c = protein_train_gp(gp_c, opt_c, gp_params, c_norm, n_gp,
+                gp_train_iter, 0);
+
+            if (optimizer_reset_freq > 0 && suggestion_idx % optimizer_reset_freq == 0) {
+                adam_reset(opt_s);
+                adam_reset(opt_c);
+                printf("  [%4d] reset Adam optimizers\n", run);
+            }
+
+            ProteinObsList* suc = &obs->success;
+            int* pidx = (int*)malloc((size_t)suc->n * sizeof(int));
+            int np = protein_pareto_front(suc->scores, suc->costs, suc->n, pidx);
+            np = protein_prune_pareto(suc->scores, suc->costs, pidx, np,
+                0.5f, 0.98f);
+
+            if (np > 0) {
+                float pruned_max_cost = suc->costs[pidx[np - 1]];
+                if (upper_cost_threshold < 0)
+                    upper_cost_threshold = pruned_max_cost;
+                else if (upper_cost_threshold < pruned_max_cost)
+                    upper_cost_threshold *= 1.01f;
+            }
+            protein_cost_model_fit(&cost_model, suc->scores, suc->costs, suc->n,
+                upper_cost_threshold);
+
+            int max_centers = np + 2 * obs->n_top;
+            float* centers = (float*)malloc((size_t)max_centers * DIM * sizeof(float));
+            int nc = protein_build_search_centers(suc->params, DIM, pidx, np,
+                obs->top_idx, obs->n_top, COST_IDX, centers);
+
+            float target = protein_sample_target_cost(ratio_pool, &ratio_remaining,
+                PROTEIN_NUM_COST_RATIOS, expansion_rate);
+
+            int m = protein_acq_sample(acq, centers, nc, nc * suggestions_per_pareto,
+                1.0f, -1, NAN, PROTEIN_EPSILON, 0);
+            if (m == 0) {
+                sobol_next(sobol, sobol_buf);
+                for (int d = 0; d < DIM; d++)
+                    suggestion[d] = 2.0f * sobol_buf[d] - 1.0f;
+            } else {
+                ProteinAcqResult r = protein_acq_suggest(
+                    acq, m, gp_s, gp_c, min_s, max_s, lc_min, lc_max,
+                    max_suggestion_cost, target, 1, 0, NULL, 0);
+
+                protein_acq_get_candidate(acq, r.best_idx, suggestion, 0);
+
+                if (run % 50 == 0 || run == num_runs - 1) {
+                    printf("  [%4d] loss_s=%.3f loss_c=%.3f pareto=%d "
+                           "gp_obs=%d cands=%d rating=%.4f\n",
+                        run, loss_s, loss_c, np, n_gp, m, r.rating);
+                }
+            }
+
+            free(pidx);
+            free(centers);
+        }
+
+        float real_lr = space_unnormalize(&hp->spaces[LR_IDX], suggestion[LR_IDX]);
+        float real_ts = space_unnormalize(&hp->spaces[COST_IDX], suggestion[COST_IDX]);
+
+        float final_score = 0.0f, final_cost = 0.0f;
+
+        for (int ds = 1; ds <= downsample; ds++) {
+            float frac_ts = real_ts * (float)ds / (float)downsample;
+            float score, cost;
+            synthetic_linear(real_lr, frac_ts, &score, &cost);
+
+            float obs_p[DIM];
+            memcpy(obs_p, suggestion, (size_t)DIM * sizeof(float));
+            obs_p[COST_IDX] = space_normalize(&hp->spaces[COST_IDX], frac_ts);
+            protein_obs_add(obs, obs_p, score, cost, 0);
+
+            if (ds == downsample) {
+                final_score = score;
+                final_cost = cost;
+            }
+        }
+
+        run_scores[run] = final_score;
+        run_costs[run] = final_cost;
+
+        if (run < num_random_samples || run % 50 == 0 || run == num_runs - 1)
+            printf("  Run %4d (%s): lr=%.2e ts=%.2e "
+                   "score=%.4f cost=%.2f  [obs=%d]\n",
+                run, is_random ? "rand" : "  GP", real_lr, real_ts, final_score,
+                final_cost, obs->success.n);
+
+        if (is_random) {
+            if (final_score > random_best)
+                random_best = final_score;
+            random_sum += final_score;
+            random_count++;
+        } else {
+            if (final_score > guided_best)
+                guided_best = final_score;
+            guided_sum += final_score;
+            guided_count++;
+        }
+    }
+
+    float random_avg = random_sum / fmaxf((float)random_count, 1.0f);
+    float guided_avg = guided_sum / fmaxf((float)guided_count, 1.0f);
+
+    printf("\n=== Results ===\n");
+    printf("  Random: best=%.4f avg=%.4f (%d runs)\n", random_best, random_avg,
+        random_count);
+    printf("  GP-guided: best=%.4f avg=%.4f (%d runs)\n", guided_best, guided_avg,
+        guided_count);
+    printf("  Total observations: %d (success=%d failure=%d)\n",
+        obs->success.n + obs->failure.n, obs->success.n, obs->failure.n);
+
+    {
+        FILE* csv = fopen(csv_path, "w");
+        if (csv) {
+            fprintf(csv, "run,score,cost\n");
+            for (int i = 0; i < num_runs; i++)
+                fprintf(csv, "%d,%.6f,%.6f\n", i, run_scores[i], run_costs[i]);
+            fclose(csv);
+            printf("  Data written to %s\n", csv_path);
+        }
+    }
+
+    write_plot(plot_path, run_scores, run_costs, num_runs);
+
+    int pass = (guided_best >= random_best * 0.9f);
+    printf("\n=== %s ===\n", pass ? "PASS" : "FAIL");
+
+    free(run_scores);
+    free(run_costs);
+    free(gp_params);
+    free(gp_scores);
+    free(gp_costs);
+    free(y_norm);
+    free(c_norm);
+    sobol_destroy(sobol);
+    protein_acq_destroy(acq);
+    adam_destroy(opt_s);
+    adam_destroy(opt_c);
+    gp_destroy(gp_s);
+    gp_destroy(gp_c);
+    protein_obs_destroy(obs);
+    hyperparameters_destroy(hp);
+
+    return pass ? 0 : 1;
+}

--- a/tests/test_protein_sweep.cu
+++ b/tests/test_protein_sweep.cu
@@ -15,6 +15,21 @@
 #include "gp_cuda.cu"
 #include "protein.cu"
 
+// Helpers inlined from protein.cu / protein_util.h (removed from production code)
+static void test_cost_model_init(ProteinCostModel *m, float quantile, int min_samples) {
+    memset(m, 0, sizeof(*m));
+    m->quantile = quantile;
+    m->min_samples = min_samples;
+}
+static void test_sobol_next(Sobol *sob, float *out) {
+    CURAND_CHECK(curandGenerateUniform(sob->gen, out, sob->dim));
+}
+static void test_acq_get_candidate(const ProteinAcq *acq, int idx, float *out, cudaStream_t stream) {
+    CUDA_CHECK(cudaMemcpyAsync(out, &acq->d_candidates[(size_t)idx * acq->dim],
+        (size_t)acq->dim * sizeof(float), cudaMemcpyDeviceToHost, stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+}
+
 // -- default search space (21 dims, matches Python ordering) ------------------
 
 #define DIM 21
@@ -264,7 +279,7 @@ int main(int argc, char** argv)
     Sobol* sobol = sobol_create(DIM, 73);
 
     ProteinCostModel cost_model;
-    protein_cost_model_init(&cost_model, early_stop_quantile, 30);
+    test_cost_model_init(&cost_model, early_stop_quantile, 30);
     float upper_cost_threshold = -FLT_MAX;
 
     float ratio_pool[] = { 0.16f, 0.32f, 0.48f, 0.64f, 0.80f, 1.0f };
@@ -291,7 +306,7 @@ int main(int argc, char** argv)
         int is_random = (suggestion_idx <= num_random_samples);
 
         if (is_random) {
-            sobol_next(sobol, sobol_buf);
+            test_sobol_next(sobol, sobol_buf);
             for (int d = 0; d < DIM; d++)
                 suggestion[d] = 2.0f * sobol_buf[d] - 1.0f;
             float cost_s = cost_random_suggestion + 0.1f * randn();
@@ -348,7 +363,7 @@ int main(int argc, char** argv)
             int m = protein_acq_sample(acq, centers, nc, nc * suggestions_per_pareto,
                 1.0f, -1, NAN, PROTEIN_EPSILON, 0);
             if (m == 0) {
-                sobol_next(sobol, sobol_buf);
+                test_sobol_next(sobol, sobol_buf);
                 for (int d = 0; d < DIM; d++)
                     suggestion[d] = 2.0f * sobol_buf[d] - 1.0f;
             } else {
@@ -356,7 +371,7 @@ int main(int argc, char** argv)
                     acq, m, gp_s, gp_c, min_s, max_s, lc_min, lc_max,
                     max_suggestion_cost, target, 1, 0, NULL, 0);
 
-                protein_acq_get_candidate(acq, r.best_idx, suggestion, 0);
+                test_acq_get_candidate(acq, r.best_idx, suggestion, 0);
 
                 if (run % 50 == 0 || run == num_runs - 1) {
                     printf("  [%4d] loss_s=%.3f loss_c=%.3f pareto=%d "

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -76,7 +76,7 @@ def test_sweep(args):
 
     target_metric = args['sweep']['metric']
     scores, costs = [], []
-    for i in range(args['max_runs']):
+    for i in range(args['sweep']['max_runs']):
         seed = time.time_ns() & 0xFFFFFFFF
         random.seed(seed)
         np.random.seed(seed)
@@ -164,19 +164,26 @@ def visualize(args):
 
 
 if __name__ == '__main__':
+    import argparse
+    import sys
     from pufferlib import pufferl
 
-    parser = pufferl.make_parser()
-    parser.add_argument('--task', type=str, default='linear', help='Task to optimize')
-    parser.add_argument('--vis-path', type=str, default='',
+    custom_parser = argparse.ArgumentParser(add_help=False)
+    custom_parser.add_argument('--task', type=str, default='linear', help='Task to optimize')
+    custom_parser.add_argument('--vis-path', type=str, default='',
         help='Set to visualize a saved sweep')
-    parser.add_argument('--data-path', type=str, default='sweep',
+    custom_parser.add_argument('--data-path', type=str, default='sweep',
         help='Used for testing hparam algorithms')
+    custom_args, remaining_argv = custom_parser.parse_known_args()
+    sys.argv = [sys.argv[0]] + remaining_argv
 
-    args = pufferl.load_config('default', parser=parser)
+    args = pufferl.load_config('default')
+    args['task'] = custom_args.task
+    args['vis_path'] = custom_args.vis_path
+    args['data_path'] = custom_args.data_path
+
+    test_sweep(args)
 
     if args['vis_path']:
         visualize(args)
         exit(0)
-
-    test_sweep(args)


### PR DESCRIPTION
# Summary

Building on top of #587, so the diff will be updated once the GP port PR is accepted. Porting Protein to pure CUDA C:

- `src/protein_util.h`: Pure C utilities for Protein. Defines the search space type (linear, log, pow2, logit), normalizations, Pareto front utilities, and other numeric helpers (for example the Nelder Mead minimizer used [here](https://github.com/PufferAI/PufferLib/blob/4.0/pufferlib/sweep.py#L498)).
- `src/protein.cu`: Core implementation for Protein, implements [the original](https://github.com/PufferAI/PufferLib/blob/4.0/pufferlib/sweep.py#L522) as faithfully as I could make it. Has code for reqs like Adam, acquisition scoring, and other device-side numeric operations (e.g. for the classifier), which I don't know if would be preferred in a separate file. Currently ~1200 LoC.
- `tests/test_protein.cu`: Unit testing the components from `src/protein.cu`. Build with `nvcc -o test_protein tests/test_protein.cu -I src/ -lcublas -lcusolver -lcurand` and run with `./test_protein`.
- `tests/test_protein_sweep.cu`: Replicates the synthetic sweep test from [`tests/test_sweep.py`](https://github.com/PufferAI/PufferLib/blob/4.0/tests/test_sweep.py). Outputs an HTML with the plot, and a CSV with the results for registry. Build with `nvcc -o test_protein_sweep tests/test_protein_sweep.cu -I src/ -lcublas -lcusolver -lcurand` and run with `./test_protein_sweep`.

## Notes
Fair to note, this is a pure CUDA implementation. Unlike the GP port I mentioned in #587, I don't have a pure C CPU version for Protein currently.

This should build natively with PufferLib to run with `puffer sweep <env>`, but falls back to the original python implementation in case the Protein CUDA build isn't available.

# Numeric and qualitative results
## Unit testing

`tests/test_protein.cu` generally tests the following aspects:
- Do we get the actual Pareto-dominant points?
- Does the Pareto pruning actually prune bad results and keep the good ones?
- Do the cost models converge to the true cost in a toy setting?
- Is the logistic regression classifier good enough? Tests on a set of linearly separable points.
- Are the samples from the acquisition score within bounds?

Plus a small integration test fitting a toy cost function.

## Synthetic test

`tests/test_protein_sweep.cu` replicates the synthetic eval from [`tests/test_sweep.py`](https://github.com/PufferAI/PufferLib/blob/4.0/tests/test_sweep.py). Output from the CUDA C test:

<img width="2720" height="1640" alt="image" src="https://github.com/user-attachments/assets/2d13e57f-5076-47fc-a4de-742e077646c0" />

Original implementation with gpytorch:

<img width="1227" height="1192" alt="image" src="https://github.com/user-attachments/assets/075ef531-422c-43aa-b4ea-5bbe8e2cff58" />

## Breakout

Ran a 20 iteration sweep on Breakout. Sweep result on my laptop with one A100 GPU:

<img width="1945" height="1187" alt="image" src="https://github.com/user-attachments/assets/f2911f21-9e85-4b6d-b7aa-7891863c40ea" />

Playing with the top score hyperparameters:

<img width="580" height="404" alt="image" src="https://github.com/user-attachments/assets/742c3b48-3716-46ab-a2e4-5db4fcea9abd" />
