### PR TITLE
Adds native Windows support, CMake based

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+build.sh text eol=lf
+*.ps1 text eol=crlf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,102 @@
+name: build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linux-cmake:
+    name: linux cmake (cpu extension + standalone)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system deps
+        run: sudo apt-get update && sudo apt-get install -y clang ninja-build libgl1-mesa-dev xorg-dev
+
+      - name: Install python build deps
+        run: pip install pybind11 numpy
+
+      - name: Build CPU extension (breakout)
+        run: |
+          cmake --preset cpu -DENV=breakout
+          cmake --build --preset cpu
+
+      - name: Import test
+        run: python -c "from pufferlib import _C; print(_C.env_name, _C.gpu, _C.precision_bytes)"
+
+      - name: Build standalone executable (breakout)
+        run: |
+          cmake --preset fast -DENV=breakout
+          cmake --build --preset fast
+          test -x ./breakout
+
+  windows-cmake:
+    name: windows cmake (cpu extension + standalone)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install python build deps
+        run: pip install pybind11 numpy ninja
+
+      - name: Build CPU extension (breakout)
+        run: |
+          cmake --preset windows-cpu -DENV=breakout
+          cmake --build --preset windows-cpu
+
+      - name: Import test
+        run: python -c "from pufferlib import _C; print(_C.env_name, _C.gpu, _C.precision_bytes)"
+
+      - name: Build standalone executable (breakout)
+        run: |
+          cmake --preset windows-fast -DENV=breakout
+          cmake --build --preset windows-fast
+          if (-not (Test-Path .\breakout.exe)) { exit 1 }
+
+  windows-cuda-compile:
+    # Compile-only check of the CUDA extension (no GPU on hosted runners).
+    # continue-on-error until proven stable: the CUDA toolkit install and the
+    # cuDNN redist download are heavyweight moving parts.
+    name: windows cmake (cuda extension, compile only)
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.19
+        with:
+          cuda: "12.8.0"
+          method: network
+          sub-packages: '["nvcc", "cudart", "cublas_dev", "cublas", "cusolver_dev", "cusolver", "curand_dev", "curand", "nvml_dev", "profiler_api"]'
+
+      - name: Install python build deps
+        run: pip install pybind11 numpy ninja
+
+      - name: Cache cuDNN redist
+        uses: actions/cache@v4
+        with:
+          path: build/cuda/_deps/cudnn_redist-*
+          key: cudnn-redist-windows-9.23.2.1
+
+      - name: Build CUDA extension (breakout, sm_89)
+        run: |
+          cmake --preset windows-cuda -DENV=breakout -DPUFFER_FETCH_CUDNN=ON -DCMAKE_CUDA_ARCHITECTURES=89
+          cmake --build --preset windows-cuda

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ logs/
 
 # Build dir
 build/
+CMakeUserPresets.json
+*.pyd
+*.exe
+*.pdb
 
 # hipified cuda extensions dir [HIP/ROCM]
 pufferlib/extensions/hip/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,97 @@
+# Building PufferLib
+
+The native library (the `pufferlib._C` extension and standalone environment
+executables) is built with CMake. `build.sh` (Linux/macOS) and `build.ps1`
+(Windows) are thin wrappers over the presets in `CMakePresets.json`.
+
+One environment is statically linked per build:
+
+```bash
+./build.sh breakout              # CUDA _C extension (default)
+./build.sh breakout --float      # float32 precision (required for --slowly)
+./build.sh breakout --cpu       # CPU-only extension, torch backend only
+./build.sh breakout --debug      # Debug build
+./build.sh breakout --local      # Standalone executable (debug, sanitizers)
+./build.sh breakout --fast       # Standalone executable (optimized)
+./build.sh all                   # Everything
+```
+
+Or use the presets directly: `cmake --preset cuda -DENV=breakout && cmake --build --preset cuda`.
+
+Requirements (all platforms): CMake >= 3.24, Ninja, clang, Python with
+`pybind11` and `numpy` installed (extension builds only). ccache is picked up
+automatically when present. `compile_commands.json` is emitted into each
+build directory for clangd users.
+
+## CUDA dependencies
+
+- **CUDA toolkit**: discovered via the standard `CUDA_PATH` environment
+  variable (set by the NVIDIA installer), `nvcc` on PATH, or
+  `-DCUDAToolkit_ROOT=<dir>`. GPU architecture defaults to `native`
+  (the GPU in the build machine); override with `-DCMAKE_CUDA_ARCHITECTURES=89`
+  or the legacy `NVCC_ARCH` env var through the wrappers.
+- **cuDNN**: searched in `CUDNN_ROOT`/`CUDNN_PATH`, the CUDA toolkit dirs,
+  then the `nvidia-cudnn-cu12` pip wheel (Linux). See the Windows notes below.
+- **NCCL** (multi-GPU): system install or the `nvidia-nccl-cu12` wheel.
+  Linux only; without it, single-GPU training works and multi-GPU raises a
+  clear error at startup.
+
+## Windows
+
+Quickstart:
+
+1. Install: Visual Studio 2022 Build Tools (C++ workload), LLVM (clang),
+   CMake, Ninja, and the CUDA toolkit (12.x). Note: CUDA 12.x cannot use the
+   VS2026 (v14.5x) toolset as nvcc host compiler; VS2022 Build Tools can be
+   installed side by side with VS2026. CUDA >= 13.2 supports VS2026 directly.
+2. For CUDA extension builds, cuDNN import libraries are required. Either
+   install cuDNN from https://developer.nvidia.com/cudnn (set `CUDNN_ROOT` if
+   installed to a custom location), or let the build download the NVIDIA
+   redist archive once with `-FetchCudnn` (`-DPUFFER_FETCH_CUDNN=ON` via
+   `cmake` directly; ~1.7 GB).
+3. Build: `.\build.ps1 breakout` (add `-Cpu`, `-Fast`, `-Float`, `-DebugBuild`,
+   `-Local`, `-FetchCudnn` as needed). The script locates and loads the right
+   MSVC environment automatically (prefers VS2022 for CUDA builds).
+
+Runtime DLLs: `pufferlib/__init__.py` registers the CUDA `bin` directory and
+any NVIDIA pip-wheel `bin` directories on the DLL search path before loading
+`_C`. PyTorch is imported before `_C` by the trainer and its bundled cuDNN
+DLLs satisfy the extension, so no separate cuDNN runtime install is needed
+when torch is present.
+
+Windows notes:
+
+- Multi-GPU is unavailable (NCCL is Linux-only); training is single-GPU.
+- OpenMP is disabled inside the extension on Windows: torch's wheels ship
+  Intel's OpenMP runtime and loading LLVM's libomp alongside it aborts the
+  process (OMP Error #15). Env stepping still parallelizes across vecenv
+  buffer threads. Standalone executables do use OpenMP.
+- Environments that don't build on Windows yet: `nethack` (Linux syscalls),
+  `chess` (fork/exec engine), `boxoban` (mmap), `impulse_wars` (no Windows
+  box2d prebuilt), `trailer` (fork/wait), `onlyfish` standalone (dirent).
+  Everything else in `ocean/` builds; a few standalone demos are broken
+  upstream on all platforms (type mismatches caught by -Werror): `battle`,
+  `blastar`, `convert`, `convert_circle`, `snake`, `whisker_racer`, and
+  `matsci`/`shared_pool` need external libs (lammps, cpr).
+- POSIX shims live in `src/puffer_os.h` (pthreads, clock_gettime, rand_r,
+  usleep, aligned alloc, ...). It is force-included for env code on Windows.
+
+## Web builds (emscripten) — TODO
+
+The `web` preset exists in `CMakePresets.json` and the CMake branch for it is
+in place (mirrors the old `build.sh --web` emcc flags: ASYNCIFY, GLFW,
+`vendor/minshell.html` shell, `resources/<env>` preloads, raylib webassembly
+build). It has not been exercised yet. Remaining work:
+
+1. Install/activate emsdk and verify `cmake --preset web -DENV=breakout`
+   configures with `$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake`.
+2. Confirm `--preload-file` paths and output naming produce
+   `build/web/<env>/game.html` byte-equivalent to the old script's output.
+3. Envs without a `resources/<env>` directory need the preload made
+   conditional.
+4. Add a CI smoke job with `mymindstorm/setup-emsdk`.
+
+## Profile builds
+
+`./build.sh <env> --profile` builds `tests/profile_kernels.cu` into a
+standalone `profile` binary (Linux only).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,406 @@
+cmake_minimum_required(VERSION 3.24)
+
+# PufferLib native build.
+#
+# One environment per configure:
+#   cmake --preset cuda -DENV=breakout && cmake --build --preset cuda
+# or use ./build.sh (Linux/macOS) / ./build.ps1 (Windows) which map the
+# historical flags onto presets. See CMakePresets.json for the full list.
+#
+# Modes (PUFFER_MODE):
+#   cuda        pufferlib/_C extension with the CUDA training backend (default)
+#   cpu         pufferlib/_C extension, CPU-only training backend
+#   standalone  self-contained environment executable (local/fast presets)
+#   web         emscripten build (requires EMSDK toolchain, web preset)
+#   profile     kernel profiling binary (Linux)
+
+project(pufferlib LANGUAGES C CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+set(ENV "" CACHE STRING "Environment to build (e.g. breakout); see ocean/")
+set(PUFFER_MODE "cuda" CACHE STRING "Build mode: cuda | cpu | standalone | web | profile")
+option(PRECISION_FLOAT "Use float32 precision instead of bf16 (forced ON for cpu mode)" OFF)
+option(PUFFER_SANITIZE "Enable ASan/UBSan for standalone builds (non-Windows)" OFF)
+option(PUFFER_NO_OPENMP "Disable OpenMP in the environment vectorizer" OFF)
+
+if(NOT ENV)
+    message(FATAL_ERROR "Set -DENV=<name> (e.g. -DENV=breakout). Available: ocean/* directories, constellation, trailer")
+endif()
+if(PUFFER_MODE STREQUAL "cpu")
+    set(PRECISION_FLOAT ON)
+endif()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+# Parity with build.sh optimization levels (-O2, not CMake's -O3 default)
+if(NOT MSVC)
+    set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+endif()
+
+if(WIN32)
+    # UCRT: expose M_PI etc., silence fopen/strcpy deprecation spam
+    add_compile_definitions(_USE_MATH_DEFINES _CRT_SECURE_NO_WARNINGS)
+
+    # Help FindOpenMP locate LLVM's libomp next to clang (the GNU-driver clang
+    # does not add its own lib dir to the linker search path).
+    if(CMAKE_C_COMPILER_ID STREQUAL "Clang" OR NOT CMAKE_C_COMPILER_ID)
+        find_program(_puffer_clang clang)
+        if(_puffer_clang)
+            get_filename_component(_llvm_bin "${_puffer_clang}" DIRECTORY)
+            find_library(OpenMP_libomp_LIBRARY NAMES libomp HINTS "${_llvm_bin}/../lib")
+            if(OpenMP_libomp_LIBRARY)
+                set(OpenMP_C_FLAGS "-fopenmp=libomp" CACHE STRING "")
+                set(OpenMP_C_LIB_NAMES "libomp" CACHE STRING "")
+                set(PUFFER_LIBOMP_DLL "${_llvm_bin}/libomp.dll")
+            endif()
+        endif()
+    endif()
+endif()
+
+# ccache when available (content-based compiler check like build.sh did)
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    set(CMAKE_CUDA_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    if(MSVC)
+        set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug>:Embedded>")
+    endif()
+endif()
+
+# ----------------------------------------------------------------------------
+# Environment source resolution (mirrors the old build.sh special cases)
+# ----------------------------------------------------------------------------
+set(EXTRA_SRC "")
+set(OUTPUT_NAME "${ENV}")
+set(EXE_OUTPUT_DIR "${CMAKE_SOURCE_DIR}")
+set(ENV_EXTRA_LIBS "")
+set(ENV_EXTRA_INCLUDES "")
+
+set(PUFFER_WIN_UNSUPPORTED nethack impulse_wars boxoban chess trailer)
+if(WIN32 AND ENV IN_LIST PUFFER_WIN_UNSUPPORTED)
+    message(FATAL_ERROR
+        "Environment '${ENV}' is not yet supported on Windows "
+        "(POSIX-only dependencies: nethack=NLE/memfd, impulse_wars=box2d prebuilt, "
+        "boxoban=mmap, chess=fork/exec engine, trailer=fork/wait). "
+        "Build it on Linux/macOS/WSL.")
+endif()
+
+if(ENV STREQUAL "constellation")
+    set(SRC_DIR "${CMAKE_SOURCE_DIR}/constellation")
+    set(EXTRA_SRC "${CMAKE_SOURCE_DIR}/vendor/cJSON.c")
+    set(OUTPUT_NAME "seethestars")
+elseif(ENV STREQUAL "trailer")
+    set(SRC_DIR "${CMAKE_SOURCE_DIR}/trailer")
+    set(EXE_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/trailer")
+elseif(ENV STREQUAL "impulse_wars")
+    set(SRC_DIR "${CMAKE_SOURCE_DIR}/ocean/${ENV}")
+    include(FetchContent)
+    if(EMSCRIPTEN)
+        set(_box2d_name "box2d-web")
+    elseif(APPLE)
+        set(_box2d_name "box2d-macos-arm64")
+    else()
+        set(_box2d_name "box2d-linux-amd64")
+    endif()
+    FetchContent_Declare(box2d_bin
+        URL "https://github.com/capnspacehook/box2d/releases/latest/download/${_box2d_name}.tar.gz"
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(box2d_bin)
+    list(APPEND ENV_EXTRA_INCLUDES "${box2d_bin_SOURCE_DIR}/include" "${box2d_bin_SOURCE_DIR}/src")
+    list(APPEND ENV_EXTRA_LIBS "${box2d_bin_SOURCE_DIR}/libbox2d.a")
+elseif(ENV STREQUAL "nethack")
+    set(SRC_DIR "${CMAKE_SOURCE_DIR}/ocean/${ENV}")
+    set(NLE_DIR "${CMAKE_SOURCE_DIR}/vendor/nle")
+    if(NOT EXISTS "${NLE_DIR}/src")
+        message(STATUS "Cloning modified NLE...")
+        execute_process(
+            COMMAND git clone --depth 1 https://github.com/liujonathan24/NetHack.git "${NLE_DIR}"
+            RESULT_VARIABLE _nle_rc)
+        if(NOT _nle_rc EQUAL 0)
+            message(FATAL_ERROR "Failed to clone NLE for nethack")
+        endif()
+    endif()
+    set(NETHACK_LIB_DIR "${NLE_DIR}/src/build")
+    if(NOT EXISTS "${NETHACK_LIB_DIR}/libnethack.so")
+        message(STATUS "Building libnethack.so ...")
+        include(ProcessorCount)
+        ProcessorCount(_nproc)
+        execute_process(
+            COMMAND make -C "${NETHACK_LIB_DIR}" nethack -j${_nproc}
+            RESULT_VARIABLE _nh_rc)
+        if(NOT _nh_rc EQUAL 0)
+            message(FATAL_ERROR "Failed to build libnethack.so")
+        endif()
+    endif()
+    list(APPEND ENV_EXTRA_INCLUDES "${NLE_DIR}/include")
+    list(APPEND ENV_EXTRA_LIBS "-L${NETHACK_LIB_DIR}" nethack "-Wl,-rpath,${NETHACK_LIB_DIR}" dl)
+elseif(EXISTS "${CMAKE_SOURCE_DIR}/ocean/${ENV}")
+    set(SRC_DIR "${CMAKE_SOURCE_DIR}/ocean/${ENV}")
+else()
+    message(FATAL_ERROR "Environment '${ENV}' not found (no ocean/${ENV} directory)")
+endif()
+
+include(FetchRaylib)
+
+set(PUFFER_INCLUDES
+    "${CMAKE_SOURCE_DIR}"
+    "${CMAKE_SOURCE_DIR}/src"
+    "${SRC_DIR}"
+    "${CMAKE_SOURCE_DIR}/vendor"
+    ${ENV_EXTRA_INCLUDES}
+)
+
+# Warning set carried over from build.sh (clang/gcc only)
+set(PUFFER_C_WARNINGS
+    -Wall
+    -ferror-limit=3
+    -Werror=incompatible-pointer-types
+    -Werror=return-type
+    -Wno-error=incompatible-pointer-types-discards-qualifiers
+    -Wno-incompatible-pointer-types-discards-qualifiers
+    -Wno-error=array-parameter
+)
+# x86_64 SIMD used directly by drive.h and src/bf16.h
+set(PUFFER_SIMD_FLAGS -mavx2 -mfma)
+
+set(PUFFER_SANITIZE_FLAGS "")
+if(PUFFER_SANITIZE AND NOT WIN32 AND NOT APPLE AND NOT EMSCRIPTEN)
+    set(PUFFER_SANITIZE_FLAGS -fsanitize=address,undefined,bounds,pointer-overflow,leak -fno-omit-frame-pointer)
+endif()
+
+# ============================================================================
+# Web build (emscripten toolchain; separate preset)
+# ============================================================================
+if(EMSCRIPTEN)
+    if(NOT PUFFER_MODE STREQUAL "web")
+        message(FATAL_ERROR "Emscripten toolchain requires -DPUFFER_MODE=web")
+    endif()
+    add_executable(game "${SRC_DIR}/${ENV}.c" ${EXTRA_SRC})
+    target_include_directories(game PRIVATE ${PUFFER_INCLUDES})
+    target_compile_options(game PRIVATE -O3 -Wall)
+    target_compile_definitions(game PRIVATE NDEBUG PLATFORM_WEB GRAPHICS_API_OPENGL_ES3)
+    target_link_libraries(game PRIVATE raylib::raylib ${ENV_EXTRA_LIBS})
+    target_link_options(game PRIVATE
+        "-sASSERTIONS=2" "-gsource-map"
+        "-sUSE_GLFW=3" "-sUSE_WEBGL2=1" "-sASYNCIFY" "-sFILESYSTEM" "-sFORCE_FILESYSTEM=1"
+        "--shell-file=${CMAKE_SOURCE_DIR}/vendor/minshell.html"
+        "-sINITIAL_MEMORY=512MB" "-sALLOW_MEMORY_GROWTH" "-sSTACK_SIZE=512KB"
+        "--preload-file=${CMAKE_SOURCE_DIR}/resources/${ENV}@resources/${ENV}"
+        "--preload-file=${CMAKE_SOURCE_DIR}/resources/shared@resources/shared"
+    )
+    set_target_properties(game PROPERTIES
+        SUFFIX ".html"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/web/${ENV}"
+    )
+    set_property(TARGET game PROPERTY LINK_DEPENDS "${CMAKE_SOURCE_DIR}/vendor/minshell.html")
+    return()
+endif()
+
+# ============================================================================
+# Standalone environment executable (local/fast presets)
+# ============================================================================
+if(PUFFER_MODE STREQUAL "standalone")
+    add_executable(env_exe "${SRC_DIR}/${ENV}.c" ${EXTRA_SRC})
+    target_include_directories(env_exe PRIVATE ${PUFFER_INCLUDES})
+    target_compile_definitions(env_exe PRIVATE PLATFORM_DESKTOP)
+    if(WIN32)
+        # Env code assumes glibc niceties (rand_r, M_PI, usleep, ...); the shim
+        # provides them without per-file edits.
+        target_compile_options(env_exe PRIVATE "SHELL:-include ${CMAKE_SOURCE_DIR}/src/puffer_os.h")
+    endif()
+    target_compile_options(env_exe PRIVATE
+        ${PUFFER_C_WARNINGS} ${PUFFER_SIMD_FLAGS} ${PUFFER_SANITIZE_FLAGS})
+    target_link_options(env_exe PRIVATE ${PUFFER_SANITIZE_FLAGS})
+    target_link_libraries(env_exe PRIVATE raylib::raylib ${ENV_EXTRA_LIBS})
+    if(NOT WIN32)
+        target_link_libraries(env_exe PRIVATE m pthread)
+    endif()
+    if(UNIX AND NOT APPLE)
+        target_link_libraries(env_exe PRIVATE GL)
+    endif()
+    if(NOT PUFFER_NO_OPENMP)
+        find_package(OpenMP COMPONENTS C)
+        if(OpenMP_C_FOUND)
+            target_link_libraries(env_exe PRIVATE OpenMP::OpenMP_C)
+        endif()
+    endif()
+    set_target_properties(env_exe PROPERTIES
+        OUTPUT_NAME "${OUTPUT_NAME}"
+        RUNTIME_OUTPUT_DIRECTORY "${EXE_OUTPUT_DIR}"
+    )
+    return()
+endif()
+
+# ============================================================================
+# Python extension modes (cuda / cpu) and profile
+# ============================================================================
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module NumPy)
+
+execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"
+    OUTPUT_VARIABLE PY_EXT_SUFFIX OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+)
+execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -m pybind11 --cmakedir
+    OUTPUT_VARIABLE pybind11_DIR OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+)
+find_package(pybind11 CONFIG REQUIRED)
+
+if(PUFFER_MODE STREQUAL "cuda" OR PUFFER_MODE STREQUAL "profile")
+    enable_language(CUDA)
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES OR CMAKE_CUDA_ARCHITECTURES STREQUAL "")
+        set(CMAKE_CUDA_ARCHITECTURES native)
+    endif()
+    set(CMAKE_CUDA_STANDARD 20)
+    set(CMAKE_CUDA_FLAGS_RELEASE "-O2 --threads 0 -DNDEBUG")
+    find_package(CUDAToolkit REQUIRED)
+    find_package(CUDNN REQUIRED)
+    find_package(NCCL)  # optional; absent on Windows -> multi-GPU compiled out
+endif()
+
+# Extract OBS_TENSOR_T from binding.c (replaces the old awk hack)
+set(BINDING_SRC "${SRC_DIR}/binding.c")
+if(NOT EXISTS "${BINDING_SRC}")
+    message(FATAL_ERROR "${BINDING_SRC} not found")
+endif()
+file(READ "${BINDING_SRC}" _binding_content)
+string(REGEX MATCH "#define[ \t]+OBS_TENSOR_T[ \t]+([A-Za-z0-9_]+)" _obs_match "${_binding_content}")
+if(NOT CMAKE_MATCH_1)
+    message(FATAL_ERROR "Could not find '#define OBS_TENSOR_T <type>' in ${BINDING_SRC}")
+endif()
+set(OBS_TENSOR_T "${CMAKE_MATCH_1}")
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${BINDING_SRC}")
+
+# ---- Static environment library (C, compiled with clang on all platforms) ----
+add_library(env_static STATIC "${BINDING_SRC}")
+target_include_directories(env_static PRIVATE ${PUFFER_INCLUDES})
+target_compile_definitions(env_static PRIVATE PLATFORM_DESKTOP)
+target_compile_options(env_static PRIVATE
+    ${PUFFER_C_WARNINGS} ${PUFFER_SIMD_FLAGS}
+    -fvisibility=hidden
+)
+if(NOT WIN32)
+    target_compile_options(env_static PRIVATE -fno-semantic-interposition)
+    set_target_properties(env_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
+if(WIN32)
+    target_compile_options(env_static PRIVATE "SHELL:-include ${CMAKE_SOURCE_DIR}/src/puffer_os.h")
+endif()
+target_link_libraries(env_static PRIVATE raylib::raylib)  # include dirs
+
+if(WIN32)
+    # The extension runs inside a PyTorch process, and torch's Windows wheels
+    # ship Intel's OpenMP runtime (libiomp5md.dll). Loading LLVM's libomp.dll
+    # alongside it aborts with OMP Error #15, so the extension's env code is
+    # built without OpenMP: the parallel-for pragmas degrade to serial and
+    # vecenv's own buffer threads still provide parallelism.
+    set(PUFFER_NO_OPENMP ON)
+    message(STATUS "OpenMP disabled for the Python extension on Windows (torch ships its own OpenMP runtime)")
+endif()
+if(NOT PUFFER_NO_OPENMP)
+    find_package(OpenMP COMPONENTS C)
+    if(OpenMP_C_FOUND)
+        target_link_libraries(env_static PUBLIC OpenMP::OpenMP_C)
+    else()
+        message(WARNING "OpenMP for C not found; environment stepping will be serial")
+        target_compile_definitions(env_static PRIVATE PUFFER_NO_OPENMP)
+    endif()
+else()
+    target_compile_definitions(env_static PRIVATE PUFFER_NO_OPENMP)
+endif()
+
+# ---- Profile binary (Linux) ----
+if(PUFFER_MODE STREQUAL "profile")
+    add_executable(profile
+        "${CMAKE_SOURCE_DIR}/tests/profile_kernels.cu"
+        "${CMAKE_SOURCE_DIR}/vendor/ini.c")
+    target_include_directories(profile PRIVATE ${PUFFER_INCLUDES})
+    target_compile_definitions(profile PRIVATE
+        OBS_TENSOR_T=${OBS_TENSOR_T} ENV_NAME=${ENV} PLATFORM_DESKTOP
+        $<$<BOOL:${PRECISION_FLOAT}>:PRECISION_FLOAT>
+        $<$<TARGET_EXISTS:NCCL::nccl>:PUFFER_HAS_NCCL>)
+    target_link_libraries(profile PRIVATE
+        env_static raylib::raylib ${ENV_EXTRA_LIBS}
+        CUDA::cudart CUDA::cublas CUDA::curand CUDA::nvml CUDNN::cudnn
+        GL m pthread)
+    if(TARGET NCCL::nccl)
+        target_link_libraries(profile PRIVATE NCCL::nccl)
+    endif()
+    set_target_properties(profile PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    return()
+endif()
+
+# ---- _C Python extension ----
+if(PUFFER_MODE STREQUAL "cuda")
+    set(BINDINGS_SRC "${CMAKE_SOURCE_DIR}/src/bindings.cu")
+else()
+    set(BINDINGS_SRC "${CMAKE_SOURCE_DIR}/src/bindings_cpu.cpp")
+endif()
+
+add_library(_C MODULE "${BINDINGS_SRC}")
+target_include_directories(_C PRIVATE "${CMAKE_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/src")
+target_link_libraries(_C PRIVATE
+    pybind11::module Python3::Module Python3::NumPy
+    env_static raylib::raylib ${ENV_EXTRA_LIBS})
+target_compile_definitions(_C PRIVATE
+    OBS_TENSOR_T=${OBS_TENSOR_T}
+    ENV_NAME=${ENV}
+    PLATFORM_DESKTOP
+    NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
+    $<$<BOOL:${PRECISION_FLOAT}>:PRECISION_FLOAT>
+)
+set_target_properties(_C PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "_C"
+    SUFFIX "${PY_EXT_SUFFIX}"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/pufferlib"
+    POSITION_INDEPENDENT_CODE ON
+)
+
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # GCC libstdc++ ABI pin + symbol binding, as in build.sh
+    target_compile_definitions(_C PRIVATE _GLIBCXX_USE_CXX11_ABI=1)
+    target_link_options(_C PRIVATE "LINKER:-Bsymbolic-functions")
+endif()
+
+if(PUFFER_MODE STREQUAL "cuda")
+    target_link_libraries(_C PRIVATE
+        CUDA::cublas CUDA::cusolver CUDA::curand CUDA::nvml CUDNN::cudnn)
+    if(WIN32)
+        target_link_libraries(_C PRIVATE CUDA::cudart_static)
+    else()
+        target_link_libraries(_C PRIVATE CUDA::cudart)
+    endif()
+    if(TARGET NCCL::nccl)
+        target_compile_definitions(_C PRIVATE PUFFER_HAS_NCCL)
+        target_link_libraries(_C PRIVATE NCCL::nccl)
+    endif()
+    # rpaths so pip-wheel-provided cudnn/nccl resolve at runtime (Linux)
+    foreach(_wheel_dir IN LISTS CUDNN_WHEEL_LIB_DIR NCCL_WHEEL_LIB_DIR)
+        if(_wheel_dir)
+            target_link_options(_C PRIVATE "LINKER:-rpath,${_wheel_dir}")
+        endif()
+    endforeach()
+    if(WIN32)
+        # Host (cl.exe) side of nvcc compilation
+        target_compile_options(_C PRIVATE
+            $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/EHsc -Xcompiler=/Zc:__cplusplus>)
+    endif()
+else()
+    if(NOT WIN32)
+        target_link_libraries(_C PRIVATE m pthread)
+    endif()
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,139 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": { "major": 3, "minor": 24, "patch": 0 },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "unix-clang",
+      "hidden": true,
+      "inherits": "base",
+      "condition": { "type": "notEquals", "lhs": "${hostSystemName}", "rhs": "Windows" },
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang"
+      }
+    },
+    {
+      "name": "win-toolchain",
+      "hidden": true,
+      "inherits": "base",
+      "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" },
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_CUDA_HOST_COMPILER": "cl"
+      }
+    },
+
+    {
+      "name": "cuda",
+      "displayName": "CUDA extension (Release)",
+      "inherits": "unix-clang",
+      "binaryDir": "${sourceDir}/build/cuda",
+      "cacheVariables": { "PUFFER_MODE": "cuda", "CMAKE_BUILD_TYPE": "Release" }
+    },
+    {
+      "name": "cuda-debug",
+      "displayName": "CUDA extension (Debug)",
+      "inherits": "cuda",
+      "binaryDir": "${sourceDir}/build/cuda-debug",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+    },
+    {
+      "name": "cpu",
+      "displayName": "CPU extension (Release, float32)",
+      "inherits": "unix-clang",
+      "binaryDir": "${sourceDir}/build/cpu",
+      "cacheVariables": { "PUFFER_MODE": "cpu", "CMAKE_BUILD_TYPE": "Release" }
+    },
+    {
+      "name": "fast",
+      "displayName": "Standalone executable (Release)",
+      "inherits": "unix-clang",
+      "binaryDir": "${sourceDir}/build/fast",
+      "cacheVariables": { "PUFFER_MODE": "standalone", "CMAKE_BUILD_TYPE": "Release" }
+    },
+    {
+      "name": "local",
+      "displayName": "Standalone executable (Debug + sanitizers)",
+      "inherits": "unix-clang",
+      "binaryDir": "${sourceDir}/build/local",
+      "cacheVariables": {
+        "PUFFER_MODE": "standalone",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "PUFFER_SANITIZE": "ON"
+      }
+    },
+    {
+      "name": "profile",
+      "displayName": "Kernel profiling binary",
+      "inherits": "unix-clang",
+      "binaryDir": "${sourceDir}/build/profile",
+      "cacheVariables": { "PUFFER_MODE": "profile", "CMAKE_BUILD_TYPE": "Release" }
+    },
+    {
+      "name": "web",
+      "displayName": "Emscripten web build",
+      "inherits": "base",
+      "binaryDir": "${sourceDir}/build/web-build",
+      "toolchainFile": "$env{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake",
+      "cacheVariables": { "PUFFER_MODE": "web", "CMAKE_BUILD_TYPE": "Release" }
+    },
+
+    {
+      "name": "windows-cuda",
+      "displayName": "Windows CUDA extension (Release)",
+      "inherits": "win-toolchain",
+      "binaryDir": "${sourceDir}/build/cuda",
+      "cacheVariables": { "PUFFER_MODE": "cuda", "CMAKE_BUILD_TYPE": "Release", "CMAKE_CUDA_COMPILER": "nvcc" }
+    },
+    {
+      "name": "windows-cuda-debug",
+      "displayName": "Windows CUDA extension (Debug)",
+      "inherits": "windows-cuda",
+      "binaryDir": "${sourceDir}/build/cuda-debug",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+    },
+    {
+      "name": "windows-cpu",
+      "displayName": "Windows CPU extension (Release, float32)",
+      "inherits": "win-toolchain",
+      "binaryDir": "${sourceDir}/build/cpu",
+      "cacheVariables": { "PUFFER_MODE": "cpu", "CMAKE_BUILD_TYPE": "Release" }
+    },
+    {
+      "name": "windows-fast",
+      "displayName": "Windows standalone executable (Release)",
+      "inherits": "win-toolchain",
+      "binaryDir": "${sourceDir}/build/fast",
+      "cacheVariables": { "PUFFER_MODE": "standalone", "CMAKE_BUILD_TYPE": "Release" }
+    },
+    {
+      "name": "windows-local",
+      "displayName": "Windows standalone executable (Debug)",
+      "inherits": "win-toolchain",
+      "binaryDir": "${sourceDir}/build/local",
+      "cacheVariables": { "PUFFER_MODE": "standalone", "CMAKE_BUILD_TYPE": "Debug" }
+    }
+  ],
+  "buildPresets": [
+    { "name": "cuda", "configurePreset": "cuda" },
+    { "name": "cuda-debug", "configurePreset": "cuda-debug" },
+    { "name": "cpu", "configurePreset": "cpu" },
+    { "name": "fast", "configurePreset": "fast" },
+    { "name": "local", "configurePreset": "local" },
+    { "name": "profile", "configurePreset": "profile" },
+    { "name": "web", "configurePreset": "web" },
+    { "name": "windows-cuda", "configurePreset": "windows-cuda" },
+    { "name": "windows-cuda-debug", "configurePreset": "windows-cuda-debug" },
+    { "name": "windows-cpu", "configurePreset": "windows-cpu" },
+    { "name": "windows-fast", "configurePreset": "windows-fast" },
+    { "name": "windows-local", "configurePreset": "windows-local" }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ PufferLib is a fast and sane reinforcement learning library that can train tiny,
 
 All of our documentation is hosted at [puffer.ai](https://puffer.ai "PufferLib Documentation"). @jsuarez5341 on [Discord](https://discord.gg/puffer) for support. Post there before opening issues. We're always looking for new contributors!
 
+Build instructions for the native library (Linux, macOS, and Windows) are in [BUILDING.md](BUILDING.md).
+
 ## Star to puff up the project!
 
 <a href="https://star-history.com/#pufferai/pufferlib&Date">

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,76 @@
+# PufferLib Windows build wrapper over the CMake presets.
+#
+# Usage:
+#   .\build.ps1 breakout            # CUDA _C extension (default)
+#   .\build.ps1 breakout -Cpu       # CPU-only _C extension
+#   .\build.ps1 breakout -Float     # float32 precision
+#   .\build.ps1 breakout -DebugBuild # Debug build
+#   .\build.ps1 breakout -Fast      # Standalone optimized executable
+#   .\build.ps1 breakout -Local     # Standalone debug executable
+#   .\build.ps1 breakout -FetchCudnn # Auto-download cuDNN (~1.7 GB, one-time)
+#
+# Requirements: CMake + Ninja, LLVM clang, Visual Studio Build Tools (cl.exe),
+# CUDA toolkit (CUDA_PATH), and cuDNN for the CUDA extension (see README).
+
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$EnvName,
+    [switch]$Cpu,
+    [switch]$Float,
+    [switch]$DebugBuild,
+    [switch]$Fast,
+    [switch]$Local,
+    [switch]$FetchCudnn
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Make sure the MSVC environment (cl.exe, link.exe, Windows SDK) is loaded.
+# For CUDA builds the environment must come from a VS2022 (v143) toolset:
+# CUDA 12.x nvcc cannot parse VS2026 (v14.5x) headers. CPU/standalone builds
+# work with any MSVC.
+$needV143 = -not ($Cpu -or $Fast -or $Local)
+$vcvars = $env:VCVARS
+if (-not $vcvars) {
+    $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path $vswhere) {
+        $range = if ($needV143) { '[17.0,18.0)' } else { '[17.0,)' }
+        $vsroot = & $vswhere -latest -products * -version $range -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        if ($vsroot) { $vcvars = Join-Path @($vsroot)[0] 'VC\Auxiliary\Build\vcvars64.bat' }
+    }
+}
+if ((-not $vcvars -or -not (Test-Path $vcvars)) -and (Get-Command cl -ErrorAction SilentlyContinue)) {
+    # Already in a developer prompt; trust it (CUDA builds may still fail on VS2026)
+    $vcvars = $null
+} elseif (-not $vcvars -or -not (Test-Path $vcvars)) {
+    if ($needV143) {
+        throw "No VS2022 (v143) toolset found. CUDA 12.x requires it: install 'Visual Studio 2022 Build Tools' with the C++ workload, or set VCVARS to its vcvars64.bat. (Alternatively upgrade to CUDA >= 13.2 for VS2026 support.)"
+    }
+    throw "cl.exe not found and vcvars64.bat could not be located. Run from a 'x64 Native Tools' prompt or set VCVARS to your vcvars64.bat path."
+}
+if ($vcvars) {
+    Write-Host "Loading MSVC environment from $vcvars"
+    $envDump = cmd /c "`"$vcvars`" >nul 2>&1 && set"
+    foreach ($line in $envDump) {
+        if ($line -match '^([^=]+)=(.*)$') {
+            [System.Environment]::SetEnvironmentVariable($Matches[1], $Matches[2], 'Process')
+        }
+    }
+}
+
+$preset = 'windows-cuda'
+if ($Cpu)   { $preset = 'windows-cpu' }
+if ($Fast)  { $preset = 'windows-fast' }
+if ($Local) { $preset = 'windows-local' }
+if ($DebugBuild -and $preset -eq 'windows-cuda') { $preset = 'windows-cuda-debug' }
+
+$extra = @()
+if ($Float) { $extra += '-DPRECISION_FLOAT=ON' }
+if ($DebugBuild -and $preset -ne 'windows-cuda-debug') { $extra += '-DCMAKE_BUILD_TYPE=Debug' }
+if ($env:NVCC_ARCH) { $extra += "-DCMAKE_CUDA_ARCHITECTURES=$($env:NVCC_ARCH)" }
+if ($FetchCudnn) { $extra += '-DPUFFER_FETCH_CUDNN=ON' }
+
+cmake --preset $preset -DENV="$EnvName" @extra
+if ($LASTEXITCODE -ne 0) { throw "CMake configure failed" }
+cmake --build --preset $preset
+if ($LASTEXITCODE -ne 0) { throw "Build failed" }

--- a/build.sh
+++ b/build.sh
@@ -1,36 +1,47 @@
 #!/bin/bash
 set -e
 
+# Thin wrapper over the CMake build (see CMakeLists.txt / CMakePresets.json).
 # Usage:
-#   ./build.sh breakout              # Build _C.so with breakout statically linked
+#   ./build.sh breakout              # Build _C extension with breakout statically linked
 #   ./build.sh breakout --float      # float32 precision (required for --slowly)
 #   ./build.sh breakout --cpu        # CPU fallback, torch only
 #   ./build.sh breakout --debug      # Debug build
 #   ./build.sh breakout --local      # Standalone executable (debug, sanitizers)
 #   ./build.sh breakout --fast       # Standalone executable (optimized)
-#   ./build.sh breakout --web        # Emscripten web build
+#   ./build.sh breakout --web        # Emscripten web build (requires EMSDK)
 #   ./build.sh breakout --profile    # Kernel profiling binary
 #   ./build.sh all                   # Build all envs with default and --float
+#
+# On Windows use ./build.ps1 (or the cmake presets directly).
 
 if [ -z "$1" ]; then
-    echo "Usage: ./build.sh ENV_NAME [--float] [--debug] [--local|--fast|--web|--profile|--cpu|--all]"
+    echo "Usage: ./build.sh ENV_NAME [--float] [--debug] [--local|--fast|--web|--profile|--cpu]"
     exit 1
 fi
 ENV=$1
 shift
 
+PRESET=cuda
+EXTRA_ARGS=()
 for arg in "$@"; do
     case $arg in
-        --float) PRECISION="-DPRECISION_FLOAT" ;;
-        --debug) DEBUG=1 ;;
-        --local) MODE=local ;;
-        --fast)  MODE=fast ;;
-        --web)   MODE=web ;;
-        --profile) MODE=profile ;;
-        --cpu)   MODE=cpu; PRECISION="-DPRECISION_FLOAT" ;;
+        --float)   EXTRA_ARGS+=(-DPRECISION_FLOAT=ON) ;;
+        --debug)   DEBUG=1 ;;
+        --local)   PRESET=local ;;
+        --fast)    PRESET=fast ;;
+        --web)     PRESET=web ;;
+        --profile) PRESET=profile ;;
+        --cpu)     PRESET=cpu ;;
         *) echo "Error: unknown argument '$arg'" && exit 1 ;;
     esac
 done
+
+if [ "$PRESET" = "cuda" ] && [ -n "$DEBUG" ]; then
+    PRESET=cuda-debug
+elif [ -n "$DEBUG" ]; then
+    EXTRA_ARGS+=(-DCMAKE_BUILD_TYPE=Debug)
+fi
 
 if [ "$ENV" = "all" ]; then
     FAILED=""
@@ -50,299 +61,10 @@ if [ "$ENV" = "all" ]; then
     exit 0
 fi
 
-# Linux/mac
-PLATFORM="$(uname -s)"
-if [ "$PLATFORM" = "Linux" ]; then
-    RAYLIB_NAME='raylib-5.5_linux_amd64'
-    OMP_LIB=-lomp5
-    SANITIZE_FLAGS=(-fsanitize=address,undefined,bounds,pointer-overflow,leak -fno-omit-frame-pointer)
-    STANDALONE_LDFLAGS=(-lGL)
-    SHARED_LDFLAGS=(-Bsymbolic-functions)
-else
-    RAYLIB_NAME='raylib-5.5_macos'
-    OMP_LIB=-lomp
-    SANITIZE_FLAGS=()
-    STANDALONE_LDFLAGS=(-framework Cocoa -framework IOKit -framework CoreVideo -framework OpenGL)
-    SHARED_LDFLAGS=(-framework Cocoa -framework OpenGL -framework IOKit -undefined dynamic_lookup)
+# Legacy env var passthrough: NVCC_ARCH selects CUDA architectures (default native)
+if [ -n "$NVCC_ARCH" ]; then
+    EXTRA_ARGS+=(-DCMAKE_CUDA_ARCHITECTURES="$NVCC_ARCH")
 fi
 
-CLANG_WARN=(
-    -Wall
-    -ferror-limit=3
-    -Werror=incompatible-pointer-types
-    -Werror=return-type
-    -Wno-error=incompatible-pointer-types-discards-qualifiers
-    -Wno-incompatible-pointer-types-discards-qualifiers
-    -Wno-error=array-parameter
-)
-
-download() {
-    local name=$1 url=$2
-    [ -d "$name" ] && return
-    echo "Downloading $name..."
-    case "$url" in
-        *.zip) curl -sL "$url" -o "$name.zip" && unzip -q "$name.zip" && rm "$name.zip" ;;
-        *)     curl -sL "$url" -o "$name.tar.gz" && tar xf "$name.tar.gz" && rm "$name.tar.gz" ;;
-    esac
-}
-
-RAYLIB_URL="https://github.com/raysan5/raylib/releases/download/5.5"
-if [ "$MODE" = "web" ]; then
-    RAYLIB_NAME='raylib-5.5_webassembly'
-    download "$RAYLIB_NAME" "$RAYLIB_URL/$RAYLIB_NAME.zip"
-else
-    download "$RAYLIB_NAME" "$RAYLIB_URL/$RAYLIB_NAME.tar.gz"
-fi
-
-RAYLIB_A="$RAYLIB_NAME/lib/libraylib.a"
-INCLUDES=(-I./$RAYLIB_NAME/include -I./src -I./vendor)
-LINK_ARCHIVES=("$RAYLIB_A")
-EXTRA_SRC=""
-EXTRA_LDFLAGS=()
-
-if [ "$ENV" = "constellation" ]; then
-    SRC_DIR="constellation"
-    EXTRA_SRC="vendor/cJSON.c"
-    OUTPUT_NAME="seethestars"
-elif [ "$ENV" = "trailer" ]; then
-    SRC_DIR="trailer"
-    OUTPUT_NAME="trailer/trailer"
-elif [ "$ENV" = "impulse_wars" ]; then
-    SRC_DIR="ocean/$ENV"
-    if [ "$MODE" = "web" ]; then BOX2D_NAME='box2d-web'
-    elif [ "$PLATFORM" = "Linux" ]; then BOX2D_NAME='box2d-linux-amd64'
-    else BOX2D_NAME='box2d-macos-arm64'
-    fi
-    BOX2D_URL="https://github.com/capnspacehook/box2d/releases/latest/download"
-    download "$BOX2D_NAME" "$BOX2D_URL/$BOX2D_NAME.tar.gz"
-    INCLUDES+=(-I./$BOX2D_NAME/include -I./$BOX2D_NAME/src)
-    LINK_ARCHIVES+=("./$BOX2D_NAME/libbox2d.a")
-elif [ "$ENV" = "nethack" ]; then
-    SRC_DIR="ocean/$ENV"
-    NLE_DIR="vendor/nle"
-    NLE_REPO="https://github.com/liujonathan24/NetHack.git"
-    if [ ! -d "$NLE_DIR/src" ]; then
-        echo "Cloning modified NLE from $NLE_REPO ..."
-        git clone --depth 1 "$NLE_REPO" "$NLE_DIR"
-    fi
-    NETHACK_LIB_DIR="$(pwd)/$NLE_DIR/src/build"
-    if [ ! -f "$NETHACK_LIB_DIR/libnethack.so" ]; then
-        echo "Building libnethack.so ..."
-        make -C "$NETHACK_LIB_DIR" nethack -j$(nproc)
-    fi
-    INCLUDES+=(-I./$NLE_DIR/include)
-    EXTRA_LDFLAGS+=(-L"$NETHACK_LIB_DIR" -lnethack -Wl,-rpath,"$NETHACK_LIB_DIR" -ldl)
-elif [ -d "ocean/$ENV" ]; then
-    SRC_DIR="ocean/$ENV"
-else
-    echo "Error: environment '$ENV' not found" && exit 1
-fi
-
-OUTPUT_NAME=${OUTPUT_NAME:-$ENV}
-
-# Standalone environment build
-# -mavx2 enables AVX2 intrinsics (__m256, _mm256_*) which drive.h and
-# src/bf16.h use directly. x86_64 only — strip if porting to ARM/Apple Silicon.
-SIMD_FLAGS=(-mavx2 -mfma)
-if [ -n "$DEBUG" ] || [ "$MODE" = "local" ]; then
-    CLANG_OPT=(-g -O0 "${CLANG_WARN[@]}" "${SANITIZE_FLAGS[@]}" "${SIMD_FLAGS[@]}")
-    NVCC_OPT="-O0 -g"
-    LINK_OPT="-g"
-else
-    CLANG_OPT=(-O2 -DNDEBUG "${CLANG_WARN[@]}" "${SIMD_FLAGS[@]}")
-    NVCC_OPT="-O2 --threads 0"
-    LINK_OPT="-O2"
-fi
-if [ "$MODE" = "local" ] || [ "$MODE" = "fast" ]; then
-    FLAGS=(
-        "${INCLUDES[@]}"
-        "$SRC_DIR/$ENV.c" $EXTRA_SRC -o "$OUTPUT_NAME"
-        "${LINK_ARCHIVES[@]}"
-        "${EXTRA_LDFLAGS[@]}"
-        "${STANDALONE_LDFLAGS[@]}"
-        -lm -lpthread -fopenmp
-        -DPLATFORM_DESKTOP
-    )
-    echo "Compiling $ENV..."
-    ${CC:-clang} "${CLANG_OPT[@]}" "${FLAGS[@]}"
-    echo "Built: ./$OUTPUT_NAME"
-    exit 0
-elif [ "$MODE" = "web" ]; then
-    mkdir -p "build/web/$ENV"
-    echo "Compiling $ENV for web..."
-    emcc \
-        -o "build/web/$ENV/game.html" \
-        "$SRC_DIR/$ENV.c" $EXTRA_SRC \
-        -O3 -Wall \
-        "${LINK_ARCHIVES[@]}" \
-        "${INCLUDES[@]}" \
-        -L. -L./$RAYLIB_NAME/lib \
-        -sASSERTIONS=2 -gsource-map \
-        -sUSE_GLFW=3 -sUSE_WEBGL2=1 -sASYNCIFY -sFILESYSTEM -sFORCE_FILESYSTEM=1 \
-        --shell-file vendor/minshell.html \
-        -sINITIAL_MEMORY=512MB -sALLOW_MEMORY_GROWTH -sSTACK_SIZE=512KB \
-        -DNDEBUG -DPLATFORM_WEB -DGRAPHICS_API_OPENGL_ES3 \
-        --preload-file resources/$ENV@resources/$ENV \
-        --preload-file resources/shared@resources/shared
-    echo "Built: build/web/$ENV/game.html"
-    exit 0
-fi
-
-# Find cuDNN path
-CUDA_HOME=${CUDA_HOME:-${CUDA_PATH:-$(dirname "$(dirname "$(which nvcc)")")}}
-CUDNN_IFLAG=""
-CUDNN_LFLAG=""
-for dir in /usr/local/cuda/include /usr/include; do
-    if [ -f "$dir/cudnn.h" ]; then
-        CUDNN_IFLAG="-I$dir"
-        break
-    fi
-done
-for dir in /usr/local/cuda/lib64 /usr/lib/x86_64-linux-gnu; do
-    if [ -f "$dir/libcudnn.so" ]; then
-        CUDNN_LFLAG="-L$dir"
-        break
-    fi
-done
-if [ -z "$CUDNN_IFLAG" ]; then
-    CUDNN_IFLAG=$(python -c "import nvidia.cudnn, os; print('-I' + os.path.join(nvidia.cudnn.__path__[0], 'include'))" 2>/dev/null || echo "")
-fi
-if [ -z "$CUDNN_LFLAG" ]; then
-    CUDNN_LFLAG=$(python -c "import nvidia.cudnn, os; print('-L' + os.path.join(nvidia.cudnn.__path__[0], 'lib'))" 2>/dev/null || echo "")
-fi
-
-# NCCL include/lib fallback (mirrors the cuDNN fallback above).
-# Needed when NCCL is provided by the nvidia-nccl-cu12 wheel in the active venv.
-NCCL_IFLAG=""
-NCCL_LFLAG=""
-for dir in /usr/include /usr/local/cuda/include; do
-    if [ -f "$dir/nccl.h" ]; then NCCL_IFLAG="-I$dir"; break; fi
-done
-for dir in /usr/lib/x86_64-linux-gnu /usr/local/cuda/lib64; do
-    if [ -f "$dir/libnccl.so" ] || [ -f "$dir/libnccl.so.2" ]; then NCCL_LFLAG="-L$dir"; break; fi
-done
-if [ -z "$NCCL_IFLAG" ]; then
-    NCCL_IFLAG=$(python -c "import nvidia.nccl, os; print('-I' + os.path.join(nvidia.nccl.__path__[0], 'include'))" 2>/dev/null || echo "")
-fi
-if [ -z "$NCCL_LFLAG" ]; then
-    NCCL_LFLAG=$(python -c "import nvidia.nccl, os; print('-L' + os.path.join(nvidia.nccl.__path__[0], 'lib'))" 2>/dev/null || echo "")
-fi
-
-WHEEL_RPATH_FLAGS=()
-for lib_flag in "$CUDNN_LFLAG" "$NCCL_LFLAG"; do
-    if [[ "$lib_flag" == -L* ]]; then
-        WHEEL_RPATH_FLAGS+=("-Wl,-rpath,${lib_flag#-L}")
-    fi
-done
-
-export CCACHE_DIR="${CCACHE_DIR:-$HOME/.ccache}"
-export CCACHE_BASEDIR="$(pwd)"
-export CCACHE_COMPILERCHECK=content
-NVCC="ccache $CUDA_HOME/bin/nvcc"
-CC="${CC:-$(command -v ccache >/dev/null && echo 'ccache clang' || echo 'clang')}"
-ARCH=${NVCC_ARCH:-native}
-
-PYTHON_INCLUDE=$(python -c "import sysconfig; print(sysconfig.get_path('include'))")
-PYBIND_INCLUDE=$(python -c "import pybind11; print(pybind11.get_include())")
-NUMPY_INCLUDE=$(python -c "import numpy; print(numpy.get_include())")
-EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
-OUTPUT="pufferlib/_C${EXT_SUFFIX}"
-
-BINDING_SRC="$SRC_DIR/binding.c"
-mkdir -p build
-STATIC_OBJ="build/libstatic_${ENV}.o"
-STATIC_LIB="build/libstatic_${ENV}.a"
-
-if [ ! -f "$BINDING_SRC" ]; then
-    echo "Error: $BINDING_SRC not found"
-    exit 1
-fi
-
-echo "Compiling static library for $ENV..."
-${CC:-clang} -c "${CLANG_OPT[@]}" $EXTRA_CFLAGS \
-    -I. -Isrc -I$SRC_DIR -Ivendor \
-    "${INCLUDES[@]}" \
-    -I./$RAYLIB_NAME/include -I$CUDA_HOME/include \
-    -DPLATFORM_DESKTOP \
-    -fno-semantic-interposition -fvisibility=hidden \
-    -fPIC -fopenmp \
-    "$BINDING_SRC" -o "$STATIC_OBJ"
-ar rcs "$STATIC_LIB" "$STATIC_OBJ"
-
-# Brittle hack: have to extract the tensor type from the static lib to build trainer
-OBS_TENSOR_T=$(awk '/^#define OBS_TENSOR_T/{print $3}' "$BINDING_SRC")
-if [ -z "$OBS_TENSOR_T" ]; then
-    echo "Error: Could not find OBS_TENSOR_T in $BINDING_SRC"
-    exit 1
-fi
-
-if [ -z "$MODE" ]; then
-    echo "Compiling CUDA ($ARCH) training backend..."
-    $NVCC -c -arch=$ARCH -Xcompiler -fPIC \
-        -Xcompiler=-D_GLIBCXX_USE_CXX11_ABI=1 \
-        -Xcompiler=-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION \
-        -Xcompiler=-DPLATFORM_DESKTOP \
-        -std=c++17 \
-        -I. -Isrc \
-        -I$PYTHON_INCLUDE -I$PYBIND_INCLUDE -I$NUMPY_INCLUDE \
-        -I$CUDA_HOME/include $CUDNN_IFLAG $NCCL_IFLAG -I$RAYLIB_NAME/include \
-        -Xcompiler=-fopenmp \
-        -DOBS_TENSOR_T=$OBS_TENSOR_T \
-        -DENV_NAME=$ENV \
-        $PRECISION $NVCC_OPT \
-        src/bindings.cu -o build/bindings.o
-
-    LINK_CMD=(
-        ${CXX:-g++} -shared -fPIC -fopenmp
-        build/bindings.o "$STATIC_LIB" "$RAYLIB_A"
-        -L$CUDA_HOME/lib64 $CUDNN_LFLAG $NCCL_LFLAG
-        "${WHEEL_RPATH_FLAGS[@]}"
-        "${EXTRA_LDFLAGS[@]}"
-        -lcudart -lnccl -lnvidia-ml -lcublas -lcusolver -lcurand -lcudnn
-        $OMP_LIB $LINK_OPT
-        "${SHARED_LDFLAGS[@]}"
-        -o "$OUTPUT"
-    )
-    "${LINK_CMD[@]}"
-    echo "Built: $OUTPUT"
-
-elif [ "$MODE" = "cpu" ]; then
-    echo "Compiling CPU training backend..."
-    ${CXX:-g++} -c -fPIC -fopenmp \
-        -D_GLIBCXX_USE_CXX11_ABI=1 \
-        -DPLATFORM_DESKTOP \
-        -std=c++17 \
-        -I. -Isrc \
-        -I$PYTHON_INCLUDE -I$PYBIND_INCLUDE \
-        -DOBS_TENSOR_T=$OBS_TENSOR_T \
-        -DENV_NAME=$ENV \
-        $PRECISION $LINK_OPT \
-        src/bindings_cpu.cpp -o build/bindings_cpu.o
-    LINK_CMD=(
-        ${CXX:-g++} -shared -fPIC -fopenmp
-        build/bindings_cpu.o "$STATIC_LIB" "$RAYLIB_A"
-        "${EXTRA_LDFLAGS[@]}"
-        -lm -lpthread $OMP_LIB $LINK_OPT
-        "${SHARED_LDFLAGS[@]}"
-        -o "$OUTPUT"
-    )
-    "${LINK_CMD[@]}"
-    echo "Built: $OUTPUT"
-
-elif [ "$MODE" = "profile" ]; then
-    echo "Compiling profile binary ($ARCH)..."
-    $NVCC $NVCC_OPT -arch=$ARCH -std=c++17 \
-        -I. -Isrc -I$SRC_DIR -Ivendor \
-        -I$CUDA_HOME/include $CUDNN_IFLAG $NCCL_IFLAG -I$RAYLIB_NAME/include \
-        -DOBS_TENSOR_T=$OBS_TENSOR_T \
-        -DENV_NAME=$ENV \
-        -Xcompiler=-DPLATFORM_DESKTOP \
-        $PRECISION \
-        -Xcompiler=-fopenmp \
-        tests/profile_kernels.cu vendor/ini.c \
-        "$STATIC_LIB" "$RAYLIB_A" \
-        -lnccl -lnvidia-ml -lcublas -lcurand -lcudnn \
-        -lGL -lm -lpthread $OMP_LIB \
-        -o profile
-    echo "Built: ./profile"
-fi
+cmake --preset "$PRESET" -DENV="$ENV" "${EXTRA_ARGS[@]}"
+cmake --build --preset "$PRESET"

--- a/cmake/FetchRaylib.cmake
+++ b/cmake/FetchRaylib.cmake
@@ -1,0 +1,64 @@
+# Acquire prebuilt raylib 5.5 release binaries (same pinned archives build.sh used)
+# and expose them as the imported target raylib::raylib.
+#
+# Override with -DPUFFER_RAYLIB_ROOT=<dir> to use a local copy (offline builds).
+# <dir> must contain include/raylib.h and lib/libraylib.a (or raylib.lib on Windows).
+
+include(FetchContent)
+
+set(PUFFER_RAYLIB_ROOT "" CACHE PATH "Local raylib root (include/ + lib/), skips download")
+
+set(_RAYLIB_VERSION "5.5")
+set(_RAYLIB_URL_BASE "https://github.com/raysan5/raylib/releases/download/${_RAYLIB_VERSION}")
+
+if(PUFFER_RAYLIB_ROOT)
+    set(_raylib_dir "${PUFFER_RAYLIB_ROOT}")
+else()
+    if(EMSCRIPTEN)
+        set(_raylib_name "raylib-${_RAYLIB_VERSION}_webassembly")
+        set(_raylib_ext "zip")
+    elseif(WIN32)
+        set(_raylib_name "raylib-${_RAYLIB_VERSION}_win64_msvc16")
+        set(_raylib_ext "zip")
+    elseif(APPLE)
+        set(_raylib_name "raylib-${_RAYLIB_VERSION}_macos")
+        set(_raylib_ext "tar.gz")
+    else()
+        set(_raylib_name "raylib-${_RAYLIB_VERSION}_linux_amd64")
+        set(_raylib_ext "tar.gz")
+    endif()
+
+    FetchContent_Declare(raylib_bin
+        URL "${_RAYLIB_URL_BASE}/${_raylib_name}.${_raylib_ext}"
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(raylib_bin)
+    set(_raylib_dir "${raylib_bin_SOURCE_DIR}")
+endif()
+
+find_library(PUFFER_RAYLIB_LIBRARY
+    NAMES raylib libraylib.a
+    PATHS "${_raylib_dir}/lib"
+    NO_DEFAULT_PATH
+)
+if(NOT PUFFER_RAYLIB_LIBRARY OR NOT EXISTS "${_raylib_dir}/include/raylib.h")
+    message(FATAL_ERROR "raylib not found under ${_raylib_dir} (expected include/raylib.h and lib/)")
+endif()
+
+add_library(raylib::raylib STATIC IMPORTED)
+set_target_properties(raylib::raylib PROPERTIES
+    IMPORTED_LOCATION "${PUFFER_RAYLIB_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${_raylib_dir}/include"
+)
+
+# Platform link requirements of the static raylib
+if(WIN32)
+    set_property(TARGET raylib::raylib APPEND PROPERTY
+        INTERFACE_LINK_LIBRARIES winmm gdi32 opengl32 user32 shell32)
+elseif(APPLE)
+    set_property(TARGET raylib::raylib APPEND PROPERTY
+        INTERFACE_LINK_OPTIONS "SHELL:-framework Cocoa" "SHELL:-framework IOKit" "SHELL:-framework CoreVideo")
+elseif(NOT EMSCRIPTEN)
+    set_property(TARGET raylib::raylib APPEND PROPERTY
+        INTERFACE_LINK_LIBRARIES m pthread)
+endif()

--- a/cmake/FindCUDNN.cmake
+++ b/cmake/FindCUDNN.cmake
@@ -1,0 +1,99 @@
+# FindCUDNN
+# ---------
+# Locates cuDNN. Search order:
+#   1. CUDNN_ROOT / CUDNN_PATH (cache or environment; covers the NVIDIA Windows
+#      installer default C:/Program Files/NVIDIA/CUDNN/v9.x and manual unpacks)
+#   2. The CUDA toolkit directories (typical Linux system installs)
+#   3. The nvidia-cudnn pip wheel in the active Python environment.
+#      NOTE: only useful for LINKING on Linux (the win_amd64 wheel ships DLLs
+#      and headers but no .lib import libraries).
+#   4. Windows only, opt-in: -DPUFFER_FETCH_CUDNN=ON downloads the NVIDIA
+#      redistributable archive (~1.7 GB) into the build tree.
+#
+# Result variables / targets:
+#   CUDNN_FOUND, CUDNN_INCLUDE_DIR, CUDNN_LIBRARY, target CUDNN::cudnn
+
+option(PUFFER_FETCH_CUDNN "Download the NVIDIA cuDNN redist archive if not found locally (Windows, large download)" OFF)
+
+set(_cudnn_hints "")
+foreach(_v CUDNN_ROOT CUDNN_PATH)
+    if(DEFINED ${_v})
+        list(APPEND _cudnn_hints "${${_v}}")
+    endif()
+    if(DEFINED ENV{${_v}})
+        list(APPEND _cudnn_hints "$ENV{${_v}}")
+    endif()
+endforeach()
+
+# Windows installer layout: C:/Program Files/NVIDIA/CUDNN/v9.x/{include,lib}/<cuda-ver>/
+if(WIN32)
+    file(GLOB _cudnn_prog_dirs "$ENV{ProgramFiles}/NVIDIA/CUDNN/v9*")
+    list(APPEND _cudnn_hints ${_cudnn_prog_dirs})
+endif()
+
+if(CUDAToolkit_FOUND)
+    list(APPEND _cudnn_hints "${CUDAToolkit_LIBRARY_ROOT}" "${CUDAToolkit_LIBRARY_DIR}/..")
+endif()
+
+macro(_puffer_cudnn_search)
+    find_path(CUDNN_INCLUDE_DIR cudnn.h
+        HINTS ${_cudnn_hints}
+        PATH_SUFFIXES include include/12.9 include/12.8 include/13.0
+    )
+    find_library(CUDNN_LIBRARY
+        NAMES cudnn cudnn9
+        HINTS ${_cudnn_hints}
+        PATH_SUFFIXES lib lib64 lib/x64 lib/12.9/x64 lib/12.8/x64 lib/13.0/x64
+    )
+endmacro()
+
+_puffer_cudnn_search()
+
+# Pip wheel fallback (Linux linking; on Windows headers only, so skip for linking)
+if((NOT CUDNN_INCLUDE_DIR OR NOT CUDNN_LIBRARY) AND NOT WIN32)
+    execute_process(
+        COMMAND "${Python3_EXECUTABLE}" -c "import nvidia.cudnn, os; print(os.path.dirname(nvidia.cudnn.__file__))"
+        OUTPUT_VARIABLE _cudnn_wheel_dir OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET RESULT_VARIABLE _cudnn_wheel_rc
+    )
+    if(_cudnn_wheel_rc EQUAL 0 AND _cudnn_wheel_dir)
+        list(APPEND _cudnn_hints "${_cudnn_wheel_dir}")
+        _puffer_cudnn_search()
+        if(CUDNN_LIBRARY)
+            # Consumers add an rpath so the wheel .so resolves at runtime
+            get_filename_component(CUDNN_WHEEL_LIB_DIR "${CUDNN_LIBRARY}" DIRECTORY)
+            set(CUDNN_FROM_WHEEL TRUE)
+        endif()
+    endif()
+endif()
+
+# Windows opt-in redist download (includes the .lib import libraries the wheel lacks)
+if((NOT CUDNN_INCLUDE_DIR OR NOT CUDNN_LIBRARY) AND WIN32 AND PUFFER_FETCH_CUDNN)
+    include(FetchContent)
+    set(_cudnn_redist_ver "9.23.2.1")  # verified present in the redist index, cuda12 variant
+    FetchContent_Declare(cudnn_redist
+        URL "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-${_cudnn_redist_ver}_cuda12-archive.zip"
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    message(STATUS "Downloading cuDNN ${_cudnn_redist_ver} redist archive (large download, one-time)...")
+    FetchContent_MakeAvailable(cudnn_redist)
+    list(APPEND _cudnn_hints "${cudnn_redist_SOURCE_DIR}")
+    _puffer_cudnn_search()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CUDNN
+    REQUIRED_VARS CUDNN_LIBRARY CUDNN_INCLUDE_DIR
+    REASON_FAILURE_MESSAGE
+    "cuDNN not found. Options: set CUDNN_ROOT to an SDK install. On Linux 'pip install nvidia-cudnn-cu12'. On Windows install cuDNN from https://developer.nvidia.com/cudnn or configure with -DPUFFER_FETCH_CUDNN=ON (large download). Note: the Windows pip wheel has no import libraries and cannot be used for building."
+)
+
+if(CUDNN_FOUND AND NOT TARGET CUDNN::cudnn)
+    add_library(CUDNN::cudnn UNKNOWN IMPORTED)
+    set_target_properties(CUDNN::cudnn PROPERTIES
+        IMPORTED_LOCATION "${CUDNN_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${CUDNN_INCLUDE_DIR}"
+    )
+endif()
+
+mark_as_advanced(CUDNN_INCLUDE_DIR CUDNN_LIBRARY)

--- a/cmake/FindNCCL.cmake
+++ b/cmake/FindNCCL.cmake
@@ -1,0 +1,67 @@
+# FindNCCL
+# --------
+# Locates NCCL (multi-GPU collectives). NCCL has no Windows build, so this
+# module reports NOT FOUND on Windows unconditionally; the build then defines
+# no PUFFER_HAS_NCCL and multi-GPU support is compiled out.
+#
+# Search order on Linux: NCCL_ROOT env/cache, system dirs, CUDA toolkit dirs,
+# then the nvidia-nccl pip wheel in the active Python environment.
+#
+# Result variables / targets:
+#   NCCL_FOUND, NCCL_INCLUDE_DIR, NCCL_LIBRARY, target NCCL::nccl
+
+if(WIN32 OR EMSCRIPTEN)
+    set(NCCL_FOUND FALSE)
+    if(NCCL_FIND_REQUIRED)
+        message(FATAL_ERROR "NCCL is not available on this platform (Linux only)")
+    endif()
+    return()
+endif()
+
+set(_nccl_hints "")
+foreach(_v NCCL_ROOT NCCL_PATH)
+    if(DEFINED ${_v})
+        list(APPEND _nccl_hints "${${_v}}")
+    endif()
+    if(DEFINED ENV{${_v}})
+        list(APPEND _nccl_hints "$ENV{${_v}}")
+    endif()
+endforeach()
+if(CUDAToolkit_FOUND)
+    list(APPEND _nccl_hints "${CUDAToolkit_LIBRARY_ROOT}")
+endif()
+
+find_path(NCCL_INCLUDE_DIR nccl.h HINTS ${_nccl_hints} PATH_SUFFIXES include)
+find_library(NCCL_LIBRARY NAMES nccl HINTS ${_nccl_hints} PATH_SUFFIXES lib lib64)
+
+# Pip wheel fallback (nvidia-nccl-cu12)
+if(NOT NCCL_INCLUDE_DIR OR NOT NCCL_LIBRARY)
+    execute_process(
+        COMMAND "${Python3_EXECUTABLE}" -c "import nvidia.nccl, os; print(os.path.dirname(nvidia.nccl.__file__))"
+        OUTPUT_VARIABLE _nccl_wheel_dir OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET RESULT_VARIABLE _nccl_wheel_rc
+    )
+    if(_nccl_wheel_rc EQUAL 0 AND _nccl_wheel_dir)
+        find_path(NCCL_INCLUDE_DIR nccl.h HINTS "${_nccl_wheel_dir}" PATH_SUFFIXES include)
+        find_library(NCCL_LIBRARY NAMES nccl HINTS "${_nccl_wheel_dir}" PATH_SUFFIXES lib)
+        if(NCCL_LIBRARY)
+            get_filename_component(NCCL_WHEEL_LIB_DIR "${NCCL_LIBRARY}" DIRECTORY)
+            set(NCCL_FROM_WHEEL TRUE)
+        endif()
+    endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(NCCL
+    REQUIRED_VARS NCCL_LIBRARY NCCL_INCLUDE_DIR
+)
+
+if(NCCL_FOUND AND NOT TARGET NCCL::nccl)
+    add_library(NCCL::nccl UNKNOWN IMPORTED)
+    set_target_properties(NCCL::nccl PROPERTIES
+        IMPORTED_LOCATION "${NCCL_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${NCCL_INCLUDE_DIR}"
+    )
+endif()
+
+mark_as_advanced(NCCL_INCLUDE_DIR NCCL_LIBRARY)

--- a/ocean/breakout/breakout.h
+++ b/ocean/breakout/breakout.h
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <assert.h>
-#include <unistd.h>
+#include "puffer_os.h"
 #include <limits.h>
 #include <string.h>
 #include "raylib.h"

--- a/ocean/drive/drive.c
+++ b/ocean/drive/drive.c
@@ -1,5 +1,5 @@
 #include <time.h>
-#include <unistd.h>
+#include "puffer_os.h"
 #include "drive.h"
 #include "puffernet.h"
 

--- a/ocean/drive/drive.h
+++ b/ocean/drive/drive.h
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stddef.h>
-#include <unistd.h>
+#include "puffer_os.h"
 #include <math.h>
 #include <assert.h>
 #include <string.h>

--- a/ocean/drone/physics.h
+++ b/ocean/drone/physics.h
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "dronelib.h"
+#include "puffer_os.h"  // puffer_aligned_alloc/free
 
 #define DRONE_LANES 8
 
@@ -246,10 +247,10 @@ static inline void physics_init(Physics* phys, int num_drones, int integrator) {
     phys->num_drones = num_drones;
     phys->integrator = integrator;
 
-    phys->params = (Paramsv*)aligned_alloc(32, num_blocks * sizeof(Paramsv));
+    phys->params = (Paramsv*)puffer_aligned_alloc(32, num_blocks * sizeof(Paramsv));
     memset(phys->params, 0, num_blocks * sizeof(Paramsv));
 
-    phys->state = (Statev*)aligned_alloc(32, num_blocks * sizeof(Statev));
+    phys->state = (Statev*)puffer_aligned_alloc(32, num_blocks * sizeof(Statev));
     memset(phys->state, 0, num_blocks * sizeof(Statev));
     for (int b = 0; b < num_blocks; b++)
         for (int l = 0; l < DRONE_LANES; l++)
@@ -257,8 +258,8 @@ static inline void physics_init(Physics* phys, int num_drones, int integrator) {
 }
 
 static inline void physics_close(Physics* phys) {
-    free(phys->params);
-    free(phys->state);
+    puffer_aligned_free(phys->params);
+    puffer_aligned_free(phys->state);
 }
 
 static inline void physics_set_drone(Physics* phys, int i, const Params* p, const State* st) {

--- a/ocean/enduro/enduro.h
+++ b/ocean/enduro/enduro.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <math.h>
 #include <stdio.h>
-#include <unistd.h>
+#include "puffer_os.h"
 #include <time.h>
 #include <stddef.h>
 #include <limits.h>

--- a/ocean/freeway/freeway.c
+++ b/ocean/freeway/freeway.c
@@ -1,7 +1,7 @@
 #include <time.h>
 #include "freeway.h"
 #include "puffernet.h"
-#include <unistd.h>
+#include "puffer_os.h"
 
 void demo() {
     Weights* weights = load_weights("resources/freeway/freeway_weights.bin");

--- a/ocean/freeway/freeway.h
+++ b/ocean/freeway/freeway.h
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <assert.h>
-#include <unistd.h>
+#include "puffer_os.h"
 #include <limits.h>
 #include <string.h>
 #include "raylib.h"

--- a/ocean/rware/rware.c
+++ b/ocean/rware/rware.c
@@ -1,5 +1,5 @@
 #include <time.h>
-#include <unistd.h>
+#include "puffer_os.h"
 #include "rware.h"
 #include "puffernet.h"
 #define MAP_TINY_WIDTH 640

--- a/ocean/shared_pool/shared_pool.c
+++ b/ocean/shared_pool/shared_pool.c
@@ -1,5 +1,5 @@
 #include <raylib.h>
-#include <unistd.h>
+#include "puffer_os.h"
 #include "cpr.h"
 #include "puffernet.h"
 #include "shared_pool.h"

--- a/ocean/terraform/terraform.h
+++ b/ocean/terraform/terraform.h
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
+#include "puffer_os.h"
 #include <time.h>
 #include <math.h>
 #include <limits.h>

--- a/ocean/tetris/tetris.h
+++ b/ocean/tetris/tetris.h
@@ -5,7 +5,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
+#include "puffer_os.h"
 
 static inline int min(int a, int b) { return a < b ? a : b; }
 static inline int max(int a, int b) { return a > b ? a : b; }

--- a/ocean/tower_climb/tower_climb.c
+++ b/ocean/tower_climb/tower_climb.c
@@ -1,5 +1,5 @@
 #include <time.h>
-#include <unistd.h>
+#include "puffer_os.h"
 #include "tower_climb.h"
 #include "puffernet.h"
 

--- a/ocean/tower_climb/tower_climb.h
+++ b/ocean/tower_climb/tower_climb.h
@@ -8,7 +8,7 @@
 #include "raymath.h"
 #include "rlgl.h"
 #include <time.h>
-#include <unistd.h>
+#include "puffer_os.h"
 
 #if defined(PLATFORM_DESKTOP)
     #define GLSL_VERSION            330

--- a/ocean/whisker_racer/whisker_racer.h
+++ b/ocean/whisker_racer/whisker_racer.h
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <assert.h>
-#include <unistd.h>
+#include "puffer_os.h"
 #include <limits.h>
 #include <string.h>
 #include "raylib.h"

--- a/pufferlib/__init__.py
+++ b/pufferlib/__init__.py
@@ -1,1 +1,26 @@
 __version__ = 4.0
+
+import os as _os
+import sys as _sys
+
+if _sys.platform == 'win32':
+    # The _C extension links against CUDA/cuDNN/libomp DLLs that are not on
+    # the default search path. Register their directories before any import.
+    def _add_dll_dir(path):
+        if path and _os.path.isdir(path):
+            _os.add_dll_directory(path)
+
+    _cuda = _os.environ.get('CUDA_PATH') or _os.environ.get('CUDA_HOME')
+    if _cuda:
+        _add_dll_dir(_os.path.join(_cuda, 'bin'))
+
+    # NVIDIA pip wheels (nvidia-cudnn-cu12 etc.) ship runtime DLLs in bin/
+    for _mod in ('cudnn', 'cublas', 'cusolver', 'curand'):
+        try:
+            _m = __import__(f'nvidia.{_mod}', fromlist=['__path__'])
+            _add_dll_dir(_os.path.join(_m.__path__[0], 'bin'))
+        except ImportError:
+            pass
+
+    # libomp.dll (and any DLLs copied next to the extension)
+    _add_dll_dir(_os.path.dirname(_os.path.abspath(__file__)))

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -23,7 +23,15 @@ import pufferlib
 try:
     from pufferlib import _C
 except ImportError:
-    raise ImportError('Failed to import PufferLib C++ backend. If you have non-default PyTorch, try installing with --no-build-isolation')
+    _build_cmd = 'build.ps1 <env>' if sys.platform == 'win32' else './build.sh <env>'
+    _hint = ''
+    if sys.platform == 'win32':
+        _hint = (' On Windows, also check that CUDA_PATH is set and cuDNN is available'
+                 ' (pip install nvidia-cudnn-cu12).')
+    raise ImportError(
+        f'Failed to import the PufferLib C++ backend (pufferlib._C). '
+        f'Build it first with {_build_cmd}.'
+        f' If you have non-default PyTorch, try installing with --no-build-isolation.{_hint}')
 
 from pufferlib import selfplay
 
@@ -35,6 +43,13 @@ rich.traceback.install(show_locals=False)
 
 import signal # Aggressively exit on ctrl+c
 signal.signal(signal.SIGINT, lambda sig, frame: os._exit(0))
+
+if sys.platform == 'win32':
+    # Windows consoles/pipes often default to cp1252, which cannot encode the
+    # dashboard's unicode (e.g. the pufferfish). Force UTF-8 output.
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, 'reconfigure'):
+            _stream.reconfigure(encoding='utf-8', errors='replace')
 
 def unroll_nested_dict(d):
     if not isinstance(d, dict):
@@ -384,7 +399,13 @@ def train(env_name, args=None, gpus=None, **kwargs):
     gpus = list(gpus or range(args['train']['gpus']))
     args['train']['total_timesteps'] //= len(gpus)
     args['world_size'] = len(gpus)
-    args['nccl_id'] = _C.get_nccl_id() if len(gpus) > 1 else b''
+    if len(gpus) > 1:
+        try:
+            args['nccl_id'] = _C.get_nccl_id()
+        except RuntimeError as e:
+            raise RuntimeError('Multi-GPU training requires NCCL, which is only available on Linux') from e
+    else:
+        args['nccl_id'] = b''
 
     if not subprocess:
         gpus = gpus[-1:] + gpus[:-1]  # Main process gets rank 0
@@ -407,7 +428,7 @@ def sweep(env_name, args=None, pareto=False):
     '''Train entry point. Handles single-GPU, multi-GPU DDP, and sweeps.'''
     args = args or load_config(env_name)
     exp_gpus = args['train']['gpus']
-    sweep_gpus = args['sweep']['gpus'] or len(os.listdir('/proc/driver/nvidia/gpus'))
+    sweep_gpus = args['sweep']['gpus'] or torch.cuda.device_count()
     args['vec']['num_threads'] //= (sweep_gpus // exp_gpus)
     args['no_model_upload'] = True
 

--- a/src/bindings.cu
+++ b/src/bindings.cu
@@ -83,15 +83,7 @@ pybind11::dict puf_log(pybind11::object pufferl_obj) {
     util_dict["vram_used_gb"] = (float)(cuda_total - cuda_free) / (1024.0f * 1024.0f * 1024.0f);
     util_dict["vram_total_gb"] = (float)cuda_total / (1024.0f * 1024.0f * 1024.0f);
 
-    long rss_kb = 0;
-    FILE* f = fopen("/proc/self/status", "r");
-    if (f) {
-        char line[256];
-        while (fgets(line, sizeof(line), f)) {
-            if (sscanf(line, "VmRSS: %ld", &rss_kb) == 1) break;
-        }
-        fclose(f);
-    }
+    long rss_kb = puffer_resident_kb();
     util_dict["cpu_mem_gb"] = (float)rss_kb / (1024.0f * 1024.0f);
     result["util"] = util_dict;
 
@@ -468,9 +460,14 @@ std::unique_ptr<PuffeRL> create_pufferl(py::dict args) {
 PYBIND11_MODULE(_C, m) {
     // Multi-GPU: generate NCCL unique ID (call on rank 0, pass bytes to all ranks)
     m.def("get_nccl_id", []() {
+#ifdef PUFFER_HAS_NCCL
         ncclUniqueId id;
         ncclGetUniqueId(&id);
         return py::bytes(reinterpret_cast<char*>(&id), sizeof(id));
+#else
+        throw std::runtime_error("Multi-GPU training requires NCCL, which is unavailable on this platform (Linux only)");
+        return py::bytes();  // unreachable
+#endif
     });
     // Standalone utilization monitor (no PuffeRL instance needed)
     m.def("get_utilization", [](int gpu_id) {
@@ -494,15 +491,7 @@ PYBIND11_MODULE(_C, m) {
         util_dict["vram_used_gb"] = (float)(cuda_total - cuda_free) / (1024.0f * 1024.0f * 1024.0f);
         util_dict["vram_total_gb"] = (float)cuda_total / (1024.0f * 1024.0f * 1024.0f);
 
-        long rss_kb = 0;
-        FILE* f = fopen("/proc/self/status", "r");
-        if (f) {
-            char line[256];
-            while (fgets(line, sizeof(line), f)) {
-                if (sscanf(line, "VmRSS: %ld", &rss_kb) == 1) break;
-            }
-            fclose(f);
-        }
+        long rss_kb = puffer_resident_kb();
         util_dict["cpu_mem_gb"] = (float)rss_kb / (1024.0f * 1024.0f);
 
         return util_dict;

--- a/src/models.cu
+++ b/src/models.cu
@@ -440,7 +440,7 @@ static void encoder_reg_params(void* w, Allocator* alloc) {
 static void encoder_reg_train(void* w, void* activations, Allocator* acts, Allocator* grads, int B_TT) {
     EncoderWeights* ew = (EncoderWeights*)w;
     EncoderActivations* a = (EncoderActivations*)activations;
-    *a = (EncoderActivations){
+    *a = EncoderActivations{
         .out =              {.shape = {B_TT, ew->out_dim}},
         .saved_input =      {.shape = {B_TT, ew->in_dim}},
         .wgrad_scratch =    {.shape = {ew->out_dim, ew->in_dim}},
@@ -515,7 +515,7 @@ static void decoder_reg_train(void* w, void* activations, Allocator* acts, Alloc
     DecoderWeights* dw = (DecoderWeights*)w;
     DecoderActivations* a = (DecoderActivations*)activations;
     int od1 = dw->output_dim + 1;
-    *a = (DecoderActivations){
+    *a = DecoderActivations{
         .out =              {.shape = {B_TT, od1}},
         .grad_out =         {.shape = {B_TT, od1}},
         .saved_input =      {.shape = {B_TT, dw->hidden_dim}},

--- a/src/muon.cu
+++ b/src/muon.cu
@@ -1,4 +1,4 @@
-#include <nccl.h>
+#include "nccl_compat.h"
 
 __global__ void muon_norm_reduce(float* __restrict__ out, const float* __restrict__ partials, int num_blocks) {
     __shared__ float sdata[256];
@@ -158,10 +158,12 @@ void muon_post_create(Muon* m) {
 
 void muon_step(Muon* m, FloatTensor weights, PrecisionTensor grads, float max_grad_norm, cudaStream_t stream = 0) {
     // Multi-GPU support: simple all-reduce over a contiguous grad buffer
+#ifdef PUFFER_HAS_NCCL
     if (m->nccl_comm != nullptr && m->world_size > 1) {
         ncclAllReduce(grads.data, grads.data, numel(grads.shape),
             NCCL_PRECISION, ncclAvg, m->nccl_comm, stream);
     }
+#endif
 
     // Clip gradients by norm
     int clip_blocks = min((int)grid_size(numel(grads.shape)), 256);

--- a/src/nccl_compat.h
+++ b/src/nccl_compat.h
@@ -1,0 +1,18 @@
+// nccl_compat.h - NCCL include indirection.
+//
+// NCCL has no Windows build, so multi-GPU support is compile-time optional:
+// CMake defines PUFFER_HAS_NCCL when NCCL is found (Linux). Without it, this
+// header provides just enough for single-GPU code paths to compile; all
+// actual NCCL calls are guarded by #ifdef PUFFER_HAS_NCCL at their call sites,
+// and requesting world_size > 1 raises a runtime error instead.
+
+#ifndef PUFFER_NCCL_COMPAT_H
+#define PUFFER_NCCL_COMPAT_H
+
+#ifdef PUFFER_HAS_NCCL
+#include <nccl.h>
+#else
+typedef void* ncclComm_t;
+#endif
+
+#endif  // PUFFER_NCCL_COMPAT_H

--- a/src/puffer_os.h
+++ b/src/puffer_os.h
@@ -1,0 +1,237 @@
+// puffer_os.h - portability shim for POSIX APIs used by PufferLib.
+//
+// On POSIX platforms this is a pass-through to the real headers. On Windows it
+// emulates the small POSIX surface the codebase uses (pthread create/join,
+// clock_gettime, sleep/usleep, access) so call sites stay unchanged.
+//
+// Deliberately does NOT include windows.h: raylib and windows.h have symbol
+// clashes (Rectangle, CloseWindow, ShowCursor, ...). The few Win32 imports
+// needed are declared by hand instead.
+
+#ifndef PUFFER_OS_H
+#define PUFFER_OS_H
+
+#include <time.h>
+#include <stdio.h>
+
+#ifndef _WIN32
+// ============================================================================
+// POSIX: real headers
+// ============================================================================
+#include <unistd.h>
+#include <pthread.h>
+
+#else
+// ============================================================================
+// Windows
+// ============================================================================
+#include <io.h>       // _access
+#include <malloc.h>   // _aligned_malloc
+#include <process.h>  // _beginthreadex
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// glibc leaks this legacy typedef via sys/types.h; some sources rely on it.
+// Linux 'unsigned long' is 64-bit, so match that width here.
+typedef unsigned long long ulong;
+
+// Hand-declared Win32 imports (see header comment for why not windows.h).
+// When windows.h is already included (e.g. via CUDA's nvml.h), use its
+// declarations instead: redeclaring with different pointer types is an error.
+#ifdef _WINDOWS_
+#define PUFFER_QPC(p)  QueryPerformanceCounter((LARGE_INTEGER*)(p))
+#define PUFFER_QPF(p)  QueryPerformanceFrequency((LARGE_INTEGER*)(p))
+#define PUFFER_FTIME(p) GetSystemTimePreciseAsFileTime((FILETIME*)(p))
+#else
+__declspec(dllimport) unsigned long __stdcall WaitForSingleObject(void* handle, unsigned long ms);
+__declspec(dllimport) int __stdcall CloseHandle(void* handle);
+__declspec(dllimport) void __stdcall Sleep(unsigned long ms);
+__declspec(dllimport) int __stdcall QueryPerformanceCounter(long long* count);
+__declspec(dllimport) int __stdcall QueryPerformanceFrequency(long long* freq);
+__declspec(dllimport) void __stdcall GetSystemTimePreciseAsFileTime(unsigned long long* filetime);
+#define PUFFER_QPC(p)  QueryPerformanceCounter(p)
+#define PUFFER_QPF(p)  QueryPerformanceFrequency(p)
+#define PUFFER_FTIME(p) GetSystemTimePreciseAsFileTime(p)
+#endif
+
+// UCRT stdlib.h defines min/max macros in C mode; glibc does not, and env
+// code defines its own inline min/max. Neutralize the macros.
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+
+// ---- access() ----
+#ifndef F_OK
+#define F_OK 0
+#endif
+#ifndef R_OK
+#define R_OK 4
+#endif
+#define access _access
+
+// ---- sleep()/usleep() ----
+static __inline void puffer_sleep_ms_(unsigned long ms) { Sleep(ms); }
+#define sleep(s) puffer_sleep_ms_(1000ul * (unsigned long)(s))
+#define usleep(us) puffer_sleep_ms_((unsigned long)((us) / 1000))
+
+// ---- random() ---- (31-bit; backed by the rand_r shim below)
+static __inline int rand_r(unsigned int* seed);
+static __inline long random(void) {
+    static unsigned int puffer_random_state_ = 0x853c49e6u;
+    return (long)rand_r(&puffer_random_state_);
+}
+
+// ---- rand_r() ---- (glibc's algorithm, for distribution parity)
+static __inline int rand_r(unsigned int* seed) {
+    unsigned int next = *seed;
+    int result;
+    next = next * 1103515245u + 12345u;
+    result = (int)((next / 65536u) % 2048u);
+    next = next * 1103515245u + 12345u;
+    result <<= 10;
+    result ^= (int)((next / 65536u) % 1024u);
+    next = next * 1103515245u + 12345u;
+    result <<= 10;
+    result ^= (int)((next / 65536u) % 1024u);
+    *seed = next;
+    return result;
+}
+
+// ---- clock_gettime() ----
+#ifndef CLOCK_REALTIME
+#define CLOCK_REALTIME 0
+#endif
+#ifndef CLOCK_MONOTONIC
+#define CLOCK_MONOTONIC 1
+#endif
+
+static __inline int clock_gettime(int clock_id, struct timespec* ts) {
+    if (clock_id == CLOCK_MONOTONIC) {
+        static long long freq = 0;
+        long long count;
+        if (freq == 0) PUFFER_QPF(&freq);
+        PUFFER_QPC(&count);
+        ts->tv_sec = (time_t)(count / freq);
+        ts->tv_nsec = (long)((count % freq) * 1000000000ll / freq);
+        return 0;
+    }
+    // CLOCK_REALTIME: FILETIME is 100ns ticks since 1601-01-01
+    unsigned long long ft;
+    PUFFER_FTIME(&ft);
+    ft -= 116444736000000000ull;  // to Unix epoch
+    ts->tv_sec = (time_t)(ft / 10000000ull);
+    ts->tv_nsec = (long)(ft % 10000000ull) * 100;
+    return 0;
+}
+
+// ---- minimal pthreads (create/join only, as used by src/vecenv.h) ----
+typedef uintptr_t pthread_t;
+
+typedef struct puffer_thread_tramp_ {
+    void* (*fn)(void*);
+    void* arg;
+} puffer_thread_tramp_;
+
+static unsigned __stdcall puffer_thread_entry_(void* p) {
+    puffer_thread_tramp_ t = *(puffer_thread_tramp_*)p;
+    free(p);
+    t.fn(t.arg);
+    return 0;
+}
+
+static __inline int pthread_create(pthread_t* thread, const void* attr,
+        void* (*fn)(void*), void* arg) {
+    (void)attr;
+    puffer_thread_tramp_* t = (puffer_thread_tramp_*)malloc(sizeof(*t));
+    if (!t) return -1;
+    t->fn = fn;
+    t->arg = arg;
+    *thread = _beginthreadex(NULL, 0, puffer_thread_entry_, t, 0, NULL);
+    if (*thread == 0) {
+        free(t);
+        return -1;
+    }
+    return 0;
+}
+
+static __inline int pthread_join(pthread_t thread, void** retval) {
+    (void)retval;
+    WaitForSingleObject((void*)thread, 0xFFFFFFFFul);  // INFINITE
+    CloseHandle((void*)thread);
+    return 0;
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // _WIN32
+
+// ============================================================================
+// Aligned allocation. C11 aligned_alloc memory is released with plain free(),
+// which MSVC's UCRT cannot do (_aligned_malloc requires _aligned_free), so
+// call sites needing aligned memory use this pair instead.
+// ============================================================================
+#ifdef _WIN32
+#define puffer_aligned_alloc(alignment, size) _aligned_malloc((size), (alignment))
+#define puffer_aligned_free _aligned_free
+#else
+#define puffer_aligned_alloc(alignment, size) aligned_alloc((alignment), (size))
+#define puffer_aligned_free free
+#endif
+
+// ============================================================================
+// Resident memory (RSS) in kilobytes; 0 if unavailable. All platforms.
+// ============================================================================
+#ifdef _WIN32
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct puffer_pmc_ {
+    unsigned long cb;
+    unsigned long PageFaultCount;
+    size_t PeakWorkingSetSize;
+    size_t WorkingSetSize;
+    size_t QuotaPeakPagedPoolUsage;
+    size_t QuotaPagedPoolUsage;
+    size_t QuotaPeakNonPagedPoolUsage;
+    size_t QuotaNonPagedPoolUsage;
+    size_t PagefileUsage;
+    size_t PeakPagefileUsage;
+} puffer_pmc_;
+__declspec(dllimport) void* __stdcall GetCurrentProcess(void);
+__declspec(dllimport) int __stdcall K32GetProcessMemoryInfo(void* process, puffer_pmc_* counters, unsigned long cb);
+
+static __inline long puffer_resident_kb(void) {
+    puffer_pmc_ pmc;
+    pmc.cb = (unsigned long)sizeof(pmc);
+    if (!K32GetProcessMemoryInfo(GetCurrentProcess(), &pmc, pmc.cb)) return 0;
+    return (long)(pmc.WorkingSetSize / 1024);
+}
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+#else
+static inline long puffer_resident_kb(void) {
+    long rss_kb = 0;
+    FILE* f = fopen("/proc/self/status", "r");  // Linux; absent elsewhere -> 0
+    if (f) {
+        char line[256];
+        while (fgets(line, sizeof(line), f)) {
+            if (sscanf(line, "VmRSS: %ld", &rss_kb) == 1) break;
+        }
+        fclose(f);
+    }
+    return rss_kb;
+}
+#endif
+
+#endif  // PUFFER_OS_H

--- a/src/pufferlib.cu
+++ b/src/pufferlib.cu
@@ -2,7 +2,8 @@
 #include <cuda_profiler_api.h>
 #include <nvtx3/nvToolsExt.h>
 #include <nvml.h>
-#include <nccl.h>
+#include "nccl_compat.h"
+#include "puffer_os.h"  // clock_gettime on Windows
 #include <vector>
 
 #include <time.h>
@@ -64,7 +65,7 @@ struct RolloutBuf {
 // stores the shape and data pointer. Memory is only allocated after all buffers are registered.
 void register_rollout_buffers(RolloutBuf& bufs, Allocator* alloc, int T, int B, int input_size,
         int num_atns, int mask_size) {
-    bufs = (RolloutBuf){
+    bufs = RolloutBuf{
         .observations = {.shape = {T, B, input_size}},
         .actions      = {.shape = {T, B, num_atns}},
         .values       = {.shape = {T, B}},
@@ -108,7 +109,7 @@ struct TrainGraph {
 
 void register_train_buffers(TrainGraph& bufs, Allocator* alloc, int B, int T, int input_size,
         int hidden_size, int num_atns, int num_layers, int mask_size) {
-    bufs = (TrainGraph){
+    bufs = TrainGraph{
         .mb_state =         {.shape = {num_layers, B, hidden_size}},
         .mb_obs =           {.shape = {B, T, input_size}},
         .mb_actions =       {.shape = {B, T, num_atns}},
@@ -178,7 +179,7 @@ struct PPOBuffersPuf {
 
 void register_ppo_buffers(PPOBuffersPuf& bufs, Allocator* alloc, int N, int T, int A_total, bool is_continuous) {
     long total = (long)N * T;
-    bufs = (PPOBuffersPuf){
+    bufs = PPOBuffersPuf{
         .loss_output = {.shape = {1}},
         .grad_loss = {.shape = {1}},
         .saved_for_bwd = {.shape = {total, 5}},
@@ -206,7 +207,7 @@ struct PrioBuffers {
 };
 
 void register_prio_buffers(PrioBuffers& bufs, Allocator* alloc, int B, int minibatch_segments) {
-    bufs = (PrioBuffers){
+    bufs = PrioBuffers{
         .prio_probs = {.shape = {B}},
         .cdf = {.shape = {B}},
         .mb_prio = {.shape = {minibatch_segments}},
@@ -1235,7 +1236,7 @@ __global__ void multinomial_sample(int* __restrict__ out_idx, const float* __res
 // whether it is important for your task
 void prio_replay_cuda(PrecisionTensor& advantages, float prio_alpha,
         int minibatch_segments, int total_agents, float anneal_beta,
-        PrioBuffers& bufs, ulong seed, long* offset_ptr, cudaStream_t stream) {
+        PrioBuffers& bufs, ulong seed, int64_t* offset_ptr, cudaStream_t stream) {
     int B = advantages.shape[0], T = advantages.shape[1];
     compute_prio_adv_reduction<<<B, PRIO_WARP_SIZE, 0, stream>>>(
         advantages.data, bufs.prio_probs.data, prio_alpha, T);
@@ -1585,7 +1586,7 @@ void train_impl(PuffeRL& pufferl) {
 
         profile_begin("compute_prio", hypers.profile);
         // Use the training RNG offset slot (last slot, index num_buffers)
-        long* train_rng_offset = pufferl.rng_offset_puf.data + hypers.num_buffers;
+        int64_t* train_rng_offset = pufferl.rng_offset_puf.data + hypers.num_buffers;
         prio_replay_cuda(advantages_puf, prio_alpha, minibatch_segments,
             hypers.total_agents, anneal_beta,
             pufferl.prio_bufs, pufferl.seed, train_rng_offset, train_stream);
@@ -1935,12 +1936,16 @@ std::unique_ptr<PuffeRL> create_pufferl_impl(HypersT& hypers,
 
     // Multi-GPU: initialize NCCL
     if (hypers.world_size > 1) {
+#ifdef PUFFER_HAS_NCCL
         if (hypers.nccl_id.size() != sizeof(ncclUniqueId))
             throw std::runtime_error("nccl_id must be " + std::to_string(sizeof(ncclUniqueId)) + " bytes");
         ncclUniqueId nccl_id;
         memcpy(&nccl_id, hypers.nccl_id.data(), sizeof(nccl_id));
         ncclCommInitRank(&pufferl->nccl_comm, hypers.world_size, nccl_id, hypers.rank);
         printf("Rank %d/%d: NCCL initialized\n", hypers.rank, hypers.world_size);
+#else
+        throw std::runtime_error("Multi-GPU training requires NCCL, which is unavailable on this platform (Linux only)");
+#endif
     }
 
     ulong seed = hypers.seed + hypers.rank;
@@ -2266,7 +2271,9 @@ void close_impl(PuffeRL& pufferl) {
     free(pufferl.frozen_banks);
     free(pufferl.bank_layout);
 
+#ifdef PUFFER_HAS_NCCL
     if (pufferl.nccl_comm != nullptr) {
         ncclCommDestroy(pufferl.nccl_comm);
     }
+#endif
 }

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -16,7 +16,7 @@ typedef struct {
 } ByteTensor;
 
 typedef struct {
-    long* data;
+    int64_t* data;
     int64_t shape[PUF_MAX_DIMS];
 } LongTensor;
 

--- a/src/vecenv.h
+++ b/src/vecenv.h
@@ -173,11 +173,9 @@ static inline size_t obs_element_size(void) {
 #define  STRINGIFY(x)  _STRINGIFY(x)
 const char dtype_symbol[] = STRINGIFY(OBS_TENSOR_T);
 
-#include <omp.h>
 #include <stdatomic.h>
-#include <pthread.h>
 #include <stdbool.h>
-#include <time.h>
+#include "puffer_os.h"  // pthreads, clock_gettime (POSIX passthrough / Windows shim)
 
 // Forward declare CUDA types and functions to avoid conflicts with raylib's float3
 typedef int cudaError_t;


### PR DESCRIPTION
## Summary

Adds native Windows support for PufferLib and modernizes the whole native build around CMake, replacing the bash-only `build.sh` internals (the script keeps its exact CLI as a thin wrapper; Windows gets `build.ps1`).

### Build system
- Single `CMakeLists.txt` + `CMakePresets.json` (Ninja) covering: per-env `_C` extension (CUDA or CPU), standalone env executables, kernel profiling, and a scaffolded (not yet exercised) emscripten web mode
- Dependency discovery: `find_package(CUDAToolkit)` (honors `CUDA_PATH`), `FindCUDNN.cmake` (env vars, toolkit dirs, pip wheel on Linux, opt-in NVIDIA redist download on Windows via `-DPUFFER_FETCH_CUDNN=ON` - the Windows pip wheel ships no import libraries), `FindNCCL.cmake` (Linux only), pinned raylib 5.5 prebuilts per platform
- ccache integration and `compile_commands.json` out of the box

### Windows portability
- `src/puffer_os.h`: POSIX emulation without `windows.h` (raylib symbol clashes) - pthreads over `_beginthreadex`, `clock_gettime` via QPC, `rand_r`/`random` (glibc algorithm), `sleep`/`usleep`, `access`, aligned-alloc pair, RSS query replacing `/proc/self/status`
- NCCL is compile-time optional (`PUFFER_HAS_NCCL`); Windows is single-GPU with clear errors on multi-GPU requests
- MSVC C++ conformance fixes in CUDA sources (compound literals, `LongTensor` `long*` -> `int64_t*`)
- Extension builds without OpenMP on Windows: torch wheels ship Intel libiomp5md and loading LLVM libomp alongside aborts the process (OMP Error 15); vecenv buffer threads still parallelize
- Python layer: DLL search path setup before `_C` import, UTF-8 console on win32, portable GPU count

### CI + docs
- New `build.yml`: Linux + Windows CPU-extension builds with import tests and standalone exe builds; compile-only Windows CUDA job (no GPU on hosted runners, `continue-on-error`)
- `BUILDING.md` with quickstarts, the CUDA dependency story, the Windows env support matrix, and TODO notes for the postponed web build

## Verified on Windows 11 / RTX Ada, CUDA 12.8, VS2022 BT host + clang 21)
- `breakout.exe` standalone renders; 47/59 env standalone builds pass (excluded: nethack/chess/boxoban/impulse_wars/trailer as POSIX-bound; a few demos are broken upstream on all platforms by `-Werror` type mismatches)
- CPU `_C.pyd`: imports, trains via torch backend (~430K SPS)
- CUDA `_C.pyd` (bf16): `puffer train breakout` at ~13.8M SPS, GPU 80%, score improves
- Float variant + `--slowly` torch GPU backend train correctly
- Linux parity is by construction (same flags/link libs); exercised by the new CI