### PR TITLE
Add Chain Reaction env

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -238,13 +238,8 @@ done
 export CCACHE_DIR="${CCACHE_DIR:-$HOME/.ccache}"
 export CCACHE_BASEDIR="$(pwd)"
 export CCACHE_COMPILERCHECK=content
-if command -v ccache >/dev/null 2>&1; then
-    NVCC="ccache $CUDA_HOME/bin/nvcc"
-    CC="${CC:-ccache clang}"
-else
-    NVCC="$CUDA_HOME/bin/nvcc"
-    CC="${CC:-clang}"
-fi
+NVCC="ccache $CUDA_HOME/bin/nvcc"
+CC="${CC:-$(command -v ccache >/dev/null && echo 'ccache clang' || echo 'clang')}"
 ARCH=${NVCC_ARCH:-native}
 
 PYTHON_INCLUDE=$(python -c "import sysconfig; print(sysconfig.get_path('include'))")

--- a/build.sh
+++ b/build.sh
@@ -238,8 +238,13 @@ done
 export CCACHE_DIR="${CCACHE_DIR:-$HOME/.ccache}"
 export CCACHE_BASEDIR="$(pwd)"
 export CCACHE_COMPILERCHECK=content
-NVCC="ccache $CUDA_HOME/bin/nvcc"
-CC="${CC:-$(command -v ccache >/dev/null && echo 'ccache clang' || echo 'clang')}"
+if command -v ccache >/dev/null 2>&1; then
+    NVCC="ccache $CUDA_HOME/bin/nvcc"
+    CC="${CC:-ccache clang}"
+else
+    NVCC="$CUDA_HOME/bin/nvcc"
+    CC="${CC:-clang}"
+fi
 ARCH=${NVCC_ARCH:-native}
 
 PYTHON_INCLUDE=$(python -c "import sysconfig; print(sysconfig.get_path('include'))")

--- a/config/chain_reaction.ini
+++ b/config/chain_reaction.ini
@@ -1,0 +1,48 @@
+[base]
+env_name = chain_reaction
+
+[vec]
+total_agents = 1024
+num_buffers = 4
+num_threads = 2
+
+[env]
+num_agents = 2
+rows = 9
+cols = 6
+max_steps = 132
+opponent_policy = 1
+win_reward = 1.0
+loss_reward = -1.0
+invalid_move_reward = -1.0
+
+[policy]
+hidden_size = 256
+num_layers = 1
+expansion_factor = 1
+
+[train]
+gpus = 1
+seed = 42
+total_timesteps = 10000000
+learning_rate = 0.001
+anneal_lr = 1
+min_lr_ratio = 0
+gamma = 0.99
+gae_lambda = 0.95
+replay_ratio = 2
+clip_coef = 0.2
+vf_coef = 1.0
+vf_clip_coef = 1.0
+max_grad_norm = 0.5
+ent_coef = 0.01
+beta1 = 0.9
+beta2 = 0.999
+eps = 1e-08
+minibatch_size = 4096
+horizon = 32
+vtrace_rho_clip = 1.0
+vtrace_c_clip = 1.0
+prio_alpha = 0.0
+prio_beta0 = 0.0
+use_rnn = 1

--- a/config/chain_reaction.ini
+++ b/config/chain_reaction.ini
@@ -1,10 +1,23 @@
 [base]
 env_name = chain_reaction
 
+[selfplay]
+enabled = 1
+max_size = 16
+swap_winrate = 0.55
+min_games = 512
+elo_init = 0.0
+elo_k = 16.0
+seed = 42
+snapshot_interval = 10_000_000
+opp_timeout_steps = 20_000_000
+
 [vec]
 total_agents = 1024
 num_buffers = 4
 num_threads = 2
+num_frozen_banks = 1
+frozen_bank_pct = 0.1
 
 [env]
 num_agents = 2

--- a/ocean/chain_reaction/binding.c
+++ b/ocean/chain_reaction/binding.c
@@ -79,20 +79,12 @@ void my_init(Env* env, Dict* kwargs) {
     env->loss_reward = dict_get(kwargs, "loss_reward")->value;
     env->invalid_move_reward = dict_get(kwargs, "invalid_move_reward")->value;
 
-    if (env->rows < 2) {
-        env->rows = 2;
-    }
-    if (env->cols < 2) {
-        env->cols = 2;
-    }
-    if (env->rows > MAX_ROWS) {
-        env->rows = MAX_ROWS;
-    }
-    if (env->cols > MAX_COLS) {
-        env->cols = MAX_COLS;
-    }
-    if (env->max_steps < 1) {
-        env->max_steps = 1;
+    if (env->rows < 2 || env->rows > MAX_ROWS ||
+            env->cols < 2 || env->cols > MAX_COLS || env->max_steps < 1) {
+        fprintf(stderr,
+            "chain_reaction requires rows 2-%d, cols 2-%d, and positive max_steps; got %d, %d, %d\n",
+            MAX_ROWS, MAX_COLS, env->rows, env->cols, env->max_steps);
+        exit(1);
     }
 
     init(env);

--- a/ocean/chain_reaction/binding.c
+++ b/ocean/chain_reaction/binding.c
@@ -1,0 +1,90 @@
+#include "chain_reaction.h"
+
+#define OBS_SIZE CHAINENV_OBS_SIZE
+#define NUM_ATNS 1
+#define ACT_SIZES {CHAINENV_MAX_ACTIONS}
+#define OBS_TENSOR_T FloatTensor
+#define MY_ACTION_MASK CHAINENV_MAX_ACTIONS
+#define MY_VEC_INIT
+
+#define Env ChainEnv
+#include "vecenv.h"
+
+static int chainenv_binding_num_agents(Dict* kwargs) {
+    int num_agents = (int)dict_get(kwargs, "num_agents")->value;
+    if (num_agents < 1) num_agents = 1;
+    if (num_agents > CHAINENV_MAX_SLOTS) num_agents = CHAINENV_MAX_SLOTS;
+    return num_agents;
+}
+
+Env* my_vec_init(int* num_envs_out, int* buffer_env_starts, int* buffer_env_counts,
+                 Dict* vec_kwargs, Dict* env_kwargs) {
+    int total_agents = (int)dict_get(vec_kwargs, "total_agents")->value;
+    int num_buffers = (int)dict_get(vec_kwargs, "num_buffers")->value;
+    int agents_per_buffer = total_agents / num_buffers;
+    int agents_per_env = chainenv_binding_num_agents(env_kwargs);
+    if (total_agents % agents_per_env != 0) {
+        fprintf(stderr,
+            "chain_reaction requires total_agents (%d) divisible by num_agents (%d)\n",
+            total_agents, agents_per_env);
+        exit(1);
+    }
+
+    int num_envs = total_agents / agents_per_env;
+    Env* envs = (Env*)calloc(num_envs, sizeof(Env));
+    for (int i = 0; i < num_envs; i++) {
+        envs[i].rng = i;
+        my_init(&envs[i], env_kwargs);
+    }
+
+    int buf = 0;
+    int buf_agents = 0;
+    buffer_env_starts[0] = 0;
+    buffer_env_counts[0] = 0;
+    for (int i = 0; i < num_envs; i++) {
+        buf_agents += agents_per_env;
+        buffer_env_counts[buf]++;
+        if (buf_agents >= agents_per_buffer && buf < num_buffers - 1) {
+            buf++;
+            buffer_env_starts[buf] = i + 1;
+            buffer_env_counts[buf] = 0;
+            buf_agents = 0;
+        }
+    }
+
+    *num_envs_out = num_envs;
+    return envs;
+}
+
+void my_init(Env* env, Dict* kwargs) {
+    env->num_agents = chainenv_binding_num_agents(kwargs);
+    env->rows = (int)dict_get(kwargs, "rows")->value;
+    env->cols = (int)dict_get(kwargs, "cols")->value;
+    env->max_steps = (int)dict_get(kwargs, "max_steps")->value;
+    env->opponent_policy = (int)dict_get(kwargs, "opponent_policy")->value;
+    env->win_reward = (float)dict_get(kwargs, "win_reward")->value;
+    env->loss_reward = (float)dict_get(kwargs, "loss_reward")->value;
+    env->invalid_move_reward = (float)dict_get(kwargs, "invalid_move_reward")->value;
+
+    if (env->rows < 2) env->rows = 2;
+    if (env->cols < 2) env->cols = 2;
+    if (env->rows > CHAINENV_MAX_ROWS) env->rows = CHAINENV_MAX_ROWS;
+    if (env->cols > CHAINENV_MAX_COLS) env->cols = CHAINENV_MAX_COLS;
+    if (env->max_steps < 1) env->max_steps = 1;
+
+    init_chainenv(env);
+}
+
+void my_log(Log* log, Dict* out) {
+    float n = log->n > 0.0f ? log->n : 1.0f;
+    dict_set(out, "perf", log->perf / n);
+    dict_set(out, "score", log->score / n);
+    dict_set(out, "episode_return", log->episode_return / n);
+    dict_set(out, "episode_length", log->episode_length / n);
+    dict_set(out, "chain_bursts", log->chain_bursts / n);
+    dict_set(out, "invalid_rate", log->invalid_rate / n);
+    dict_set(out, "slot_0_score", log->slot_0_score / n);
+    dict_set(out, "slot_1_score", log->slot_1_score / n);
+    dict_set(out, "draw_rate", log->draw_rate / n);
+    dict_set(out, "n", log->n);
+}

--- a/ocean/chain_reaction/binding.c
+++ b/ocean/chain_reaction/binding.c
@@ -1,10 +1,11 @@
+#include <unistd.h>
+
 #include "chain_reaction.h"
 
-#define OBS_SIZE CHAINENV_OBS_SIZE
 #define NUM_ATNS 1
-#define ACT_SIZES {CHAINENV_MAX_ACTIONS}
+#define ACT_SIZES {MAX_ACTIONS}
 #define OBS_TENSOR_T FloatTensor
-#define MY_ACTION_MASK CHAINENV_MAX_ACTIONS
+#define MY_ACTION_MASK MAX_ACTIONS
 #define MY_VEC_INIT
 #define MY_USES_PERM
 #define MY_USES_TAGS
@@ -29,37 +30,39 @@ void my_setup_perm(StaticVec* vec, Env* env, int slot_base) {
 
 Env* my_vec_init(int* num_envs_out, int* buffer_env_starts, int* buffer_env_counts,
                  Dict* vec_kwargs, Dict* env_kwargs) {
-    int total_agents = (int)dict_get(vec_kwargs, "total_agents")->value;
-    int num_buffers = (int)dict_get(vec_kwargs, "num_buffers")->value;
-    int agents_per_buffer = total_agents / num_buffers;
-    int agents_per_env = (int)dict_get(env_kwargs, "num_agents")->value;
-    if (total_agents % agents_per_env != 0) {
+    int total_agents = dict_get(vec_kwargs, "total_agents")->value;
+    int num_buffers = dict_get(vec_kwargs, "num_buffers")->value;
+    int agents_per_env = dict_get(env_kwargs, "num_agents")->value;
+    if (agents_per_env < 1 || agents_per_env > MAX_SLOTS) {
+        fprintf(stderr, "chain_reaction num_agents must be 1 or 2, got %d\n", agents_per_env);
+        exit(1);
+    }
+    if (total_agents < 1 || num_buffers < 1 || total_agents % num_buffers != 0) {
         fprintf(stderr,
-            "chain_reaction requires total_agents (%d) divisible by num_agents (%d)\n",
-            total_agents, agents_per_env);
+            "chain_reaction requires positive total_agents (%d) divisible by num_buffers (%d)\n",
+            total_agents, num_buffers);
+        exit(1);
+    }
+
+    int agents_per_buffer = total_agents / num_buffers;
+    if (agents_per_buffer % agents_per_env != 0) {
+        fprintf(stderr,
+            "chain_reaction requires %d agents per buffer divisible by num_agents (%d)\n",
+            agents_per_buffer, agents_per_env);
         exit(1);
     }
 
     int num_envs = total_agents / agents_per_env;
-    Env* envs = (Env*)calloc(num_envs, sizeof(Env));
+    int envs_per_buffer = agents_per_buffer / agents_per_env;
+    Env* envs = calloc(num_envs, sizeof(Env));
+    unsigned int process_rng = (unsigned int)getpid();
     for (int i = 0; i < num_envs; i++) {
-        envs[i].rng = i;
+        envs[i].rng = rand_r(&process_rng);
         my_init(&envs[i], env_kwargs);
     }
-
-    int buf = 0;
-    int buf_agents = 0;
-    buffer_env_starts[0] = 0;
-    buffer_env_counts[0] = 0;
-    for (int i = 0; i < num_envs; i++) {
-        buf_agents += agents_per_env;
-        buffer_env_counts[buf]++;
-        if (buf_agents >= agents_per_buffer && buf < num_buffers - 1) {
-            buf++;
-            buffer_env_starts[buf] = i + 1;
-            buffer_env_counts[buf] = 0;
-            buf_agents = 0;
-        }
+    for (int buffer = 0; buffer < num_buffers; buffer++) {
+        buffer_env_starts[buffer] = buffer * envs_per_buffer;
+        buffer_env_counts[buffer] = envs_per_buffer;
     }
 
     *num_envs_out = num_envs;
@@ -67,33 +70,35 @@ Env* my_vec_init(int* num_envs_out, int* buffer_env_starts, int* buffer_env_coun
 }
 
 void my_init(Env* env, Dict* kwargs) {
-    env->num_agents = (int)dict_get(kwargs, "num_agents")->value;
-    env->rows = (int)dict_get(kwargs, "rows")->value;
-    env->cols = (int)dict_get(kwargs, "cols")->value;
-    env->max_steps = (int)dict_get(kwargs, "max_steps")->value;
-    env->opponent_policy = (int)dict_get(kwargs, "opponent_policy")->value;
-    env->win_reward = (float)dict_get(kwargs, "win_reward")->value;
-    env->loss_reward = (float)dict_get(kwargs, "loss_reward")->value;
-    env->invalid_move_reward = (float)dict_get(kwargs, "invalid_move_reward")->value;
+    env->num_agents = dict_get(kwargs, "num_agents")->value;
+    env->rows = dict_get(kwargs, "rows")->value;
+    env->cols = dict_get(kwargs, "cols")->value;
+    env->max_steps = dict_get(kwargs, "max_steps")->value;
+    env->opponent_policy = dict_get(kwargs, "opponent_policy")->value;
+    env->win_reward = dict_get(kwargs, "win_reward")->value;
+    env->loss_reward = dict_get(kwargs, "loss_reward")->value;
+    env->invalid_move_reward = dict_get(kwargs, "invalid_move_reward")->value;
 
-    if (env->rows < 2) env->rows = 2;
-    if (env->cols < 2) env->cols = 2;
-    if (env->rows > CHAINENV_MAX_ROWS) env->rows = CHAINENV_MAX_ROWS;
-    if (env->cols > CHAINENV_MAX_COLS) env->cols = CHAINENV_MAX_COLS;
-    if (env->max_steps < 1) env->max_steps = 1;
+    if (env->rows < 2) {
+        env->rows = 2;
+    }
+    if (env->cols < 2) {
+        env->cols = 2;
+    }
+    if (env->rows > MAX_ROWS) {
+        env->rows = MAX_ROWS;
+    }
+    if (env->cols > MAX_COLS) {
+        env->cols = MAX_COLS;
+    }
+    if (env->max_steps < 1) {
+        env->max_steps = 1;
+    }
 
-    init_chainenv(env);
+    init(env);
 }
 
 void my_log(Log* log, Dict* out) {
-    static const char* hist_score_keys[CHAINENV_MAX_BANKS] = {
-        "hist_score_bank_0", "hist_score_bank_1", "hist_score_bank_2", "hist_score_bank_3",
-        "hist_score_bank_4", "hist_score_bank_5", "hist_score_bank_6", "hist_score_bank_7",
-    };
-    static const char* hist_n_keys[CHAINENV_MAX_BANKS] = {
-        "hist_n_bank_0", "hist_n_bank_1", "hist_n_bank_2", "hist_n_bank_3",
-        "hist_n_bank_4", "hist_n_bank_5", "hist_n_bank_6", "hist_n_bank_7",
-    };
     dict_set(out, "perf", log->perf);
     dict_set(out, "score", log->score);
     dict_set(out, "episode_return", log->episode_return);
@@ -102,10 +107,22 @@ void my_log(Log* log, Dict* out) {
     dict_set(out, "invalid_rate", log->invalid_rate);
     dict_set(out, "hist_score", log->hist_score);
     dict_set(out, "hist_n", log->hist_n);
-    for (int bank = 0; bank < CHAINENV_MAX_BANKS; bank++) {
-        dict_set(out, hist_score_keys[bank], log->hist_score_bank[bank]);
-        dict_set(out, hist_n_keys[bank], log->hist_n_bank[bank]);
-    }
+    dict_set(out, "hist_score_bank_0", log->hist_score_bank[0]);
+    dict_set(out, "hist_score_bank_1", log->hist_score_bank[1]);
+    dict_set(out, "hist_score_bank_2", log->hist_score_bank[2]);
+    dict_set(out, "hist_score_bank_3", log->hist_score_bank[3]);
+    dict_set(out, "hist_score_bank_4", log->hist_score_bank[4]);
+    dict_set(out, "hist_score_bank_5", log->hist_score_bank[5]);
+    dict_set(out, "hist_score_bank_6", log->hist_score_bank[6]);
+    dict_set(out, "hist_score_bank_7", log->hist_score_bank[7]);
+    dict_set(out, "hist_n_bank_0", log->hist_n_bank[0]);
+    dict_set(out, "hist_n_bank_1", log->hist_n_bank[1]);
+    dict_set(out, "hist_n_bank_2", log->hist_n_bank[2]);
+    dict_set(out, "hist_n_bank_3", log->hist_n_bank[3]);
+    dict_set(out, "hist_n_bank_4", log->hist_n_bank[4]);
+    dict_set(out, "hist_n_bank_5", log->hist_n_bank[5]);
+    dict_set(out, "hist_n_bank_6", log->hist_n_bank[6]);
+    dict_set(out, "hist_n_bank_7", log->hist_n_bank[7]);
     dict_set(out, "slot_0_score", log->slot_0_score);
     dict_set(out, "slot_1_score", log->slot_1_score);
     dict_set(out, "draw_rate", log->draw_rate);

--- a/ocean/chain_reaction/binding.c
+++ b/ocean/chain_reaction/binding.c
@@ -6,15 +6,25 @@
 #define OBS_TENSOR_T FloatTensor
 #define MY_ACTION_MASK CHAINENV_MAX_ACTIONS
 #define MY_VEC_INIT
+#define MY_USES_PERM
+#define MY_USES_TAGS
 
 #define Env ChainEnv
 #include "vecenv.h"
 
-static int chainenv_binding_num_agents(Dict* kwargs) {
-    int num_agents = (int)dict_get(kwargs, "num_agents")->value;
-    if (num_agents < 1) num_agents = 1;
-    if (num_agents > CHAINENV_MAX_SLOTS) num_agents = CHAINENV_MAX_SLOTS;
-    return num_agents;
+void my_setup_perm(StaticVec* vec, Env* env, int slot_base) {
+    size_t obs_elem_size = obs_element_size();
+    for (int slot = 0; slot < env->num_agents; slot++) {
+        int phys = vec->agent_perm != NULL
+            ? vec->agent_perm[slot_base + slot]
+            : slot_base + slot;
+        env->obs_ptr[slot] = (float*)((char*)vec->observations
+            + (size_t)phys * OBS_SIZE * obs_elem_size);
+        env->action_ptr[slot] = vec->actions + (size_t)phys * NUM_ATNS;
+        env->reward_ptr[slot] = vec->rewards + phys;
+        env->terminal_ptr[slot] = vec->terminals + phys;
+        env->action_mask_ptr[slot] = vec->action_mask + (size_t)phys * MY_ACTION_MASK;
+    }
 }
 
 Env* my_vec_init(int* num_envs_out, int* buffer_env_starts, int* buffer_env_counts,
@@ -22,7 +32,7 @@ Env* my_vec_init(int* num_envs_out, int* buffer_env_starts, int* buffer_env_coun
     int total_agents = (int)dict_get(vec_kwargs, "total_agents")->value;
     int num_buffers = (int)dict_get(vec_kwargs, "num_buffers")->value;
     int agents_per_buffer = total_agents / num_buffers;
-    int agents_per_env = chainenv_binding_num_agents(env_kwargs);
+    int agents_per_env = (int)dict_get(env_kwargs, "num_agents")->value;
     if (total_agents % agents_per_env != 0) {
         fprintf(stderr,
             "chain_reaction requires total_agents (%d) divisible by num_agents (%d)\n",
@@ -57,7 +67,7 @@ Env* my_vec_init(int* num_envs_out, int* buffer_env_starts, int* buffer_env_coun
 }
 
 void my_init(Env* env, Dict* kwargs) {
-    env->num_agents = chainenv_binding_num_agents(kwargs);
+    env->num_agents = (int)dict_get(kwargs, "num_agents")->value;
     env->rows = (int)dict_get(kwargs, "rows")->value;
     env->cols = (int)dict_get(kwargs, "cols")->value;
     env->max_steps = (int)dict_get(kwargs, "max_steps")->value;
@@ -76,15 +86,27 @@ void my_init(Env* env, Dict* kwargs) {
 }
 
 void my_log(Log* log, Dict* out) {
-    float n = log->n > 0.0f ? log->n : 1.0f;
-    dict_set(out, "perf", log->perf / n);
-    dict_set(out, "score", log->score / n);
-    dict_set(out, "episode_return", log->episode_return / n);
-    dict_set(out, "episode_length", log->episode_length / n);
-    dict_set(out, "chain_bursts", log->chain_bursts / n);
-    dict_set(out, "invalid_rate", log->invalid_rate / n);
-    dict_set(out, "slot_0_score", log->slot_0_score / n);
-    dict_set(out, "slot_1_score", log->slot_1_score / n);
-    dict_set(out, "draw_rate", log->draw_rate / n);
-    dict_set(out, "n", log->n);
+    static const char* hist_score_keys[CHAINENV_MAX_BANKS] = {
+        "hist_score_bank_0", "hist_score_bank_1", "hist_score_bank_2", "hist_score_bank_3",
+        "hist_score_bank_4", "hist_score_bank_5", "hist_score_bank_6", "hist_score_bank_7",
+    };
+    static const char* hist_n_keys[CHAINENV_MAX_BANKS] = {
+        "hist_n_bank_0", "hist_n_bank_1", "hist_n_bank_2", "hist_n_bank_3",
+        "hist_n_bank_4", "hist_n_bank_5", "hist_n_bank_6", "hist_n_bank_7",
+    };
+    dict_set(out, "perf", log->perf);
+    dict_set(out, "score", log->score);
+    dict_set(out, "episode_return", log->episode_return);
+    dict_set(out, "episode_length", log->episode_length);
+    dict_set(out, "chain_bursts", log->chain_bursts);
+    dict_set(out, "invalid_rate", log->invalid_rate);
+    dict_set(out, "hist_score", log->hist_score);
+    dict_set(out, "hist_n", log->hist_n);
+    for (int bank = 0; bank < CHAINENV_MAX_BANKS; bank++) {
+        dict_set(out, hist_score_keys[bank], log->hist_score_bank[bank]);
+        dict_set(out, hist_n_keys[bank], log->hist_n_bank[bank]);
+    }
+    dict_set(out, "slot_0_score", log->slot_0_score);
+    dict_set(out, "slot_1_score", log->slot_1_score);
+    dict_set(out, "draw_rate", log->draw_rate);
 }

--- a/ocean/chain_reaction/chain_reaction.c
+++ b/ocean/chain_reaction/chain_reaction.c
@@ -3,7 +3,7 @@
 
 #include "chain_reaction.h"
 
-static void demo(void) {
+int main(void) {
     ChainEnv env = {0};
     env.num_agents = 1;
     env.rows = 9;
@@ -26,12 +26,10 @@ static void demo(void) {
     env.reward_ptr[0] = reward_buf;
     env.terminal_ptr[0] = terminal_buf;
     env.action_mask_ptr[0] = action_mask_buf;
-    env.client = make_client();
+    c_render(&env);
     c_reset(&env);
 
     while (true) {
-        layout_board(&env);
-
         bool allow_input = env.client->animation_clock
             >= env.client->animation_total - 1.0e-4f;
         if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) {
@@ -52,7 +50,7 @@ static void demo(void) {
                     if (!is_legal_move(&env, action, RED_PLAYER)) {
                         env.client->invalid_hint_time = 1.9f;
                     } else {
-                        clear_invalid_hint(env.client);
+                        env.client->invalid_hint_time = 0.0f;
                         *env.action_ptr[0] = (float)action;
                         c_step(&env);
                     }
@@ -66,9 +64,4 @@ static void demo(void) {
 
         c_render(&env);
     }
-}
-
-int main(void) {
-    demo();
-    return 0;
 }

--- a/ocean/chain_reaction/chain_reaction.c
+++ b/ocean/chain_reaction/chain_reaction.c
@@ -1,4 +1,5 @@
 #include <time.h>
+#include <unistd.h>
 
 #include "chain_reaction.h"
 
@@ -8,23 +9,18 @@ static void demo(void) {
     env.rows = 9;
     env.cols = 6;
     env.max_steps = 132;
-    env.opponent_policy = CHAINENV_OPPONENT_HEURISTIC;
+    env.opponent_policy = HEURISTIC_OPPONENT;
     env.win_reward = 1.0f;
     env.loss_reward = -1.0f;
     env.invalid_move_reward = -1.0f;
-    env.rng = (unsigned int)time(NULL);
-    init_chainenv(&env);
+    env.rng = (unsigned int)time(NULL) ^ (unsigned int)getpid();
+    init(&env);
 
-    float observation_buf[CHAINENV_OBS_SIZE] = {0};
+    float observation_buf[OBS_SIZE] = {0};
     float action_buf[1] = {0};
     float reward_buf[1] = {0};
     float terminal_buf[1] = {0};
-    unsigned char action_mask_buf[CHAINENV_MAX_ACTIONS] = {0};
-    env.observations = observation_buf;
-    env.actions = action_buf;
-    env.rewards = reward_buf;
-    env.terminals = terminal_buf;
-    env.action_mask = action_mask_buf;
+    unsigned char action_mask_buf[MAX_ACTIONS] = {0};
     env.obs_ptr[0] = observation_buf;
     env.action_ptr[0] = action_buf;
     env.reward_ptr[0] = reward_buf;
@@ -34,20 +30,30 @@ static void demo(void) {
     c_reset(&env);
 
     while (true) {
-        chainenv_layout_board(env.client, &env);
+        layout_board(&env);
 
-        bool allow_input = !chainenv_animation_active(&env);
+        bool allow_input = env.client->animation_clock
+            >= env.client->animation_total - 1.0e-4f;
         if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) {
             if (env.end_game) {
                 c_reset(&env);
             } else if (allow_input) {
-                int action = chainenv_pick_action(&env, env.client, GetMousePosition());
-                if (action >= 0) {
-                    if (!chainenv_is_legal_move(&env, action, CHAINENV_PLAYER_RED)) {
-                        chainenv_show_invalid_hint(&env);
+                Vector2 mouse = GetMousePosition();
+                float board_w = env.client->cell_size * env.cols;
+                float board_h = env.client->cell_size * env.rows;
+                bool on_board = mouse.x >= env.client->board_x
+                    && mouse.x < env.client->board_x + board_w
+                    && mouse.y >= env.client->board_y
+                    && mouse.y < env.client->board_y + board_h;
+                if (on_board) {
+                    int col = (int)((mouse.x - env.client->board_x) / env.client->cell_size);
+                    int row = (int)((mouse.y - env.client->board_y) / env.client->cell_size);
+                    int action = row * env.cols + col;
+                    if (!is_legal_move(&env, action, RED_PLAYER)) {
+                        env.client->invalid_hint_time = 1.9f;
                     } else {
-                        chainenv_clear_invalid_hint(&env);
-                        env.actions[0] = (float)action;
+                        clear_invalid_hint(env.client);
+                        *env.action_ptr[0] = (float)action;
                         c_step(&env);
                     }
                 }

--- a/ocean/chain_reaction/chain_reaction.c
+++ b/ocean/chain_reaction/chain_reaction.c
@@ -1,0 +1,65 @@
+#include <time.h>
+
+#include "chain_reaction.h"
+
+static void demo(void) {
+    ChainEnv env = {0};
+    env.num_agents = 1;
+    env.rows = 9;
+    env.cols = 6;
+    env.max_steps = 132;
+    env.opponent_policy = CHAINENV_OPPONENT_HEURISTIC;
+    env.win_reward = 1.0f;
+    env.loss_reward = -1.0f;
+    env.invalid_move_reward = -1.0f;
+    env.rng = (unsigned int)time(NULL);
+    init_chainenv(&env);
+
+    float observation_buf[CHAINENV_OBS_SIZE] = {0};
+    float action_buf[1] = {0};
+    float reward_buf[1] = {0};
+    float terminal_buf[1] = {0};
+    unsigned char action_mask_buf[CHAINENV_MAX_ACTIONS] = {0};
+    env.observations = observation_buf;
+    env.actions = action_buf;
+    env.rewards = reward_buf;
+    env.terminals = terminal_buf;
+    env.action_mask = action_mask_buf;
+    env.client = make_client();
+    c_reset(&env);
+
+    while (true) {
+        if (env.client != NULL) {
+            chainenv_layout_board(env.client, &env);
+        }
+
+        bool allow_input = !chainenv_animation_active(&env);
+        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) {
+            if (env.end_game) {
+                c_reset(&env);
+            } else if (allow_input && env.client != NULL) {
+                int action = chainenv_pick_action(&env, env.client, GetMousePosition());
+                if (action >= 0) {
+                    if (!chainenv_is_legal_move(&env, action, CHAINENV_PLAYER_RED)) {
+                        chainenv_show_invalid_hint(&env);
+                    } else {
+                        chainenv_clear_invalid_hint(&env);
+                        env.actions[0] = (float)action;
+                        c_step(&env);
+                    }
+                }
+            }
+        }
+
+        if (IsKeyPressed(KEY_R)) {
+            c_reset(&env);
+        }
+
+        c_render(&env);
+    }
+}
+
+int main(void) {
+    demo();
+    return 0;
+}

--- a/ocean/chain_reaction/chain_reaction.c
+++ b/ocean/chain_reaction/chain_reaction.c
@@ -25,19 +25,22 @@ static void demo(void) {
     env.rewards = reward_buf;
     env.terminals = terminal_buf;
     env.action_mask = action_mask_buf;
+    env.obs_ptr[0] = observation_buf;
+    env.action_ptr[0] = action_buf;
+    env.reward_ptr[0] = reward_buf;
+    env.terminal_ptr[0] = terminal_buf;
+    env.action_mask_ptr[0] = action_mask_buf;
     env.client = make_client();
     c_reset(&env);
 
     while (true) {
-        if (env.client != NULL) {
-            chainenv_layout_board(env.client, &env);
-        }
+        chainenv_layout_board(env.client, &env);
 
         bool allow_input = !chainenv_animation_active(&env);
         if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) {
             if (env.end_game) {
                 c_reset(&env);
-            } else if (allow_input && env.client != NULL) {
+            } else if (allow_input) {
                 int action = chainenv_pick_action(&env, env.client, GetMousePosition());
                 if (action >= 0) {
                     if (!chainenv_is_legal_move(&env, action, CHAINENV_PLAYER_RED)) {

--- a/ocean/chain_reaction/chain_reaction.h
+++ b/ocean/chain_reaction/chain_reaction.h
@@ -14,6 +14,7 @@
 #define CHAINENV_MAX_ACTIONS (CHAINENV_MAX_CELLS + 1)
 #define CHAINENV_NOOP_ACTION CHAINENV_MAX_CELLS
 #define CHAINENV_MAX_SLOTS 2
+#define CHAINENV_MAX_BANKS 8
 #define CHAINENV_OBS_CHANNELS 4
 #define CHAINENV_GLOBAL_OBS 5
 #define CHAINENV_OBS_SIZE (CHAINENV_MAX_CELLS * CHAINENV_OBS_CHANNELS + CHAINENV_GLOBAL_OBS)
@@ -24,7 +25,7 @@
 #define CHAINENV_OPPONENT_HEURISTIC 1
 #define CHAINENV_MAX_RENDER_TRANSFERS 768
 #define CHAINENV_MAX_RENDER_BURSTS 256
-#define CHAINENV_MAX_SNAPSHOTS (2 * CHAINENV_MAX_RENDER_WAVES + 8)
+#define CHAINENV_MAX_SNAPSHOTS (CHAINENV_MAX_RENDER_WAVES + 2)
 #define CHAINENV_BURST_DURATION 0.36f
 #define CHAINENV_TRANSFER_DURATION 0.28f
 #define CHAINENV_WAVE_DELAY 0.10f
@@ -41,6 +42,10 @@ struct Log {
     float episode_length;
     float chain_bursts;
     float invalid_rate;
+    float hist_score;
+    float hist_n;
+    float hist_score_bank[CHAINENV_MAX_BANKS];
+    float hist_n_bank[CHAINENV_MAX_BANKS];
     float slot_0_score;
     float slot_1_score;
     float draw_rate;
@@ -92,8 +97,6 @@ struct Client {
 typedef struct ResolveStats ResolveStats;
 struct ResolveStats {
     int bursts;
-    int waves;
-    int transfers;
     float end_time;
 };
 
@@ -104,6 +107,12 @@ struct ChainEnv {
     float* rewards;
     float* terminals;
     unsigned char* action_mask;
+    // Logical slots may be non-adjacent during historical self-play.
+    float* obs_ptr[CHAINENV_MAX_SLOTS];
+    float* action_ptr[CHAINENV_MAX_SLOTS];
+    float* reward_ptr[CHAINENV_MAX_SLOTS];
+    float* terminal_ptr[CHAINENV_MAX_SLOTS];
+    unsigned char* action_mask_ptr[CHAINENV_MAX_SLOTS];
     int num_agents;
     Log log;
     Client* client;
@@ -128,8 +137,13 @@ struct ChainEnv {
     int last_player_action;
     int last_env_action;
     int last_chain_bursts;
-    int last_chain_waves;
     int winner;
+    // Selfplay-pool tagging. tag = 0 means pure selfplay; tag = 1..N means
+    // slot 0 (primary) is playing frozen bank tag-1. boundary_reached is set
+    // on historical episode end and cleared by pufferl_count_aligned after a
+    // pending opponent swap has safely aligned all tagged envs.
+    int tag;
+    int boundary_reached;
     unsigned int rng;
 };
 
@@ -170,12 +184,6 @@ static inline bool chainenv_cell_active(const ChainEnv* env, int row, int col) {
     return row >= 0 && row < env->rows && col >= 0 && col < env->cols;
 }
 
-static inline bool chainenv_board_idx_active(const ChainEnv* env, int idx) {
-    int row = idx / CHAINENV_MAX_COLS;
-    int col = idx % CHAINENV_MAX_COLS;
-    return chainenv_cell_active(env, row, col);
-}
-
 static inline int chainenv_action_to_board_idx(const ChainEnv* env, int action) {
     if (action < 0 || action >= env->rows * env->cols) {
         return -1;
@@ -184,16 +192,6 @@ static inline int chainenv_action_to_board_idx(const ChainEnv* env, int action) 
     int row = action / env->cols;
     int col = action % env->cols;
     return chainenv_slot(row, col);
-}
-
-static inline int chainenv_board_idx_to_action(const ChainEnv* env, int board_idx) {
-    int row = board_idx / CHAINENV_MAX_COLS;
-    int col = board_idx % CHAINENV_MAX_COLS;
-    if (!chainenv_cell_active(env, row, col)) {
-        return -1;
-    }
-
-    return row * env->cols + col;
 }
 
 static inline int chainenv_critical_mass(const ChainEnv* env, int row, int col) {
@@ -212,7 +210,7 @@ static inline int chainenv_stable_capacity(const ChainEnv* env) {
 }
 
 static inline void chainenv_add_log(ChainEnv* env, int invalid) {
-    float reward = env->rewards[0];
+    float reward = *env->reward_ptr[0];
     env->log.perf += reward > 0.0f ? 1.0f : (reward == 0.0f ? 0.5f : 0.0f);
     env->log.score += reward;
     env->log.episode_return += reward;
@@ -220,19 +218,33 @@ static inline void chainenv_add_log(ChainEnv* env, int invalid) {
     env->log.chain_bursts += (float)env->last_chain_bursts;
     env->log.invalid_rate += invalid ? 1.0f : 0.0f;
     if (env->num_agents > 1) {
-        float slot0_reward = env->rewards[0];
-        float slot1_reward = env->rewards[1];
-        if (fabsf(slot0_reward - slot1_reward) <= 1.0e-6f) {
+        if (env->winner == 0) {
             env->log.slot_0_score += 0.5f;
             env->log.slot_1_score += 0.5f;
             env->log.draw_rate += 1.0f;
-        } else if (slot0_reward > slot1_reward) {
-            env->log.slot_0_score += 1.0f;
         } else {
-            env->log.slot_1_score += 1.0f;
+            int winner_slot = chainenv_slot_for_player(env, env->winner);
+            if (winner_slot == 0) env->log.slot_0_score += 1.0f;
+            else env->log.slot_1_score += 1.0f;
         }
     }
     env->log.n += 1.0f;
+}
+
+static inline void chainenv_add_historical_log(ChainEnv* env) {
+    if (env->num_agents < 2 || env->tag <= 0 || env->tag > CHAINENV_MAX_BANKS) {
+        return;
+    }
+
+    float primary_score = env->winner == 0
+        ? 0.5f
+        : (chainenv_player_for_slot(env, 0) == env->winner ? 1.0f : 0.0f);
+    int bank_idx = env->tag - 1;
+    env->log.hist_score_bank[bank_idx] += primary_score;
+    env->log.hist_n_bank[bank_idx] += 1.0f;
+    env->log.hist_score += primary_score;
+    env->log.hist_n += 1.0f;
+    env->boundary_reached = 1;
 }
 
 static inline void chainenv_layout_board(Client* client, const ChainEnv* env) {
@@ -296,13 +308,7 @@ static inline void chainenv_record_snapshot(ChainEnv* env, float reveal_time) {
     }
 
     Client* client = env->client;
-    int snapshot_idx = client->snapshot_count;
-    if (snapshot_idx >= CHAINENV_MAX_SNAPSHOTS) {
-        snapshot_idx = CHAINENV_MAX_SNAPSHOTS - 1;
-    } else {
-        client->snapshot_count += 1;
-    }
-
+    int snapshot_idx = client->snapshot_count++;
     chainenv_copy_board(
         client->snapshot_owner[snapshot_idx],
         client->snapshot_orbs[snapshot_idx],
@@ -382,8 +388,8 @@ static inline void chainenv_recount(const ChainEnv* env, int* red_total, int* gr
 
 static inline void chainenv_zero_outputs(ChainEnv* env) {
     for (int slot = 0; slot < env->num_agents; slot++) {
-        env->rewards[slot] = 0.0f;
-        env->terminals[slot] = 0.0f;
+        *env->reward_ptr[slot] = 0.0f;
+        *env->terminal_ptr[slot] = 0.0f;
     }
 }
 
@@ -394,12 +400,12 @@ static inline void chainenv_compute_observations(ChainEnv* env) {
     int red_total = 0;
     int green_total = 0;
     chainenv_recount(env, &red_total, &green_total);
-    memset(env->observations, 0, env->num_agents * CHAINENV_OBS_SIZE * sizeof(float));
 
     float area = (float)(env->rows * env->cols);
     for (int slot = 0; slot < env->num_agents; slot++) {
+        float* obs = env->obs_ptr[slot];
+        memset(obs, 0, CHAINENV_OBS_SIZE * sizeof(float));
         int player = chainenv_player_for_slot(env, slot);
-        float* obs = env->observations + slot * CHAINENV_OBS_SIZE;
 
         for (int row = 0; row < env->rows; row++) {
             for (int col = 0; col < env->cols; col++) {
@@ -428,27 +434,23 @@ static inline void chainenv_compute_observations(ChainEnv* env) {
 }
 
 static inline void chainenv_update_action_mask(ChainEnv* env) {
-    if (env->action_mask == NULL) {
-        return;
+    for (int slot = 0; slot < env->num_agents; slot++) {
+        memset(env->action_mask_ptr[slot], 0, CHAINENV_MAX_ACTIONS);
     }
 
-    memset(env->action_mask, 0, env->num_agents * CHAINENV_MAX_ACTIONS * sizeof(unsigned char));
     if (env->end_game) {
         for (int slot = 0; slot < env->num_agents; slot++) {
-            env->action_mask[slot * CHAINENV_MAX_ACTIONS + CHAINENV_NOOP_ACTION] = 1;
+            env->action_mask_ptr[slot][CHAINENV_NOOP_ACTION] = 1;
         }
         return;
     }
 
     if (!chainenv_is_selfplay(env)) {
+        unsigned char* mask = env->action_mask_ptr[0];
         for (int action = 0; action < env->rows * env->cols; action++) {
             int idx = chainenv_action_to_board_idx(env, action);
-            if (idx < 0) {
-                continue;
-            }
-
             if (env->owner[idx] == 0 || env->owner[idx] == CHAINENV_PLAYER_RED) {
-                env->action_mask[action] = 1;
+                mask[action] = 1;
             }
         }
         return;
@@ -456,7 +458,7 @@ static inline void chainenv_update_action_mask(ChainEnv* env) {
 
     int active_slot = chainenv_slot_for_player(env, env->current_player);
     for (int slot = 0; slot < env->num_agents; slot++) {
-        unsigned char* mask = env->action_mask + slot * CHAINENV_MAX_ACTIONS;
+        unsigned char* mask = env->action_mask_ptr[slot];
         if (slot != active_slot) {
             mask[CHAINENV_NOOP_ACTION] = 1;
             continue;
@@ -514,7 +516,6 @@ static inline ResolveStats chainenv_resolve_chain(ChainEnv* env, int player, flo
             break;
         }
 
-        stats.waves += 1;
         bool record_wave = wave < CHAINENV_MAX_RENDER_WAVES;
         float delay = start_delay + recorded_waves * CHAINENV_WAVE_DELAY;
         for (int i = 0; i < unstable_count; i++) {
@@ -553,7 +554,6 @@ static inline ResolveStats chainenv_resolve_chain(ChainEnv* env, int player, flo
 
                 int nidx = chainenv_slot(nr, nc);
                 chainenv_apply_single_orb(env, nidx, player);
-                stats.transfers += 1;
                 if (record_wave) {
                     chainenv_record_transfer(env, src_row, src_col, nr, nc, player, delay);
                 }
@@ -634,10 +634,6 @@ static inline int chainenv_timeout_winner(const ChainEnv* env) {
 
 static inline float chainenv_move_score(const ChainEnv* env, int action, int player) {
     int idx = chainenv_action_to_board_idx(env, action);
-    if (idx < 0) {
-        return -1.0e9f;
-    }
-
     int row = idx / CHAINENV_MAX_COLS;
     int col = idx % CHAINENV_MAX_COLS;
     int critical = chainenv_critical_mass(env, row, col);
@@ -694,10 +690,6 @@ static inline int chainenv_choose_env_action(ChainEnv* env) {
     int legal_count = 0;
     for (int action = 0; action < env->rows * env->cols; action++) {
         int idx = chainenv_action_to_board_idx(env, action);
-        if (idx < 0) {
-            continue;
-        }
-
         if (env->owner[idx] == 0 || env->owner[idx] == CHAINENV_PLAYER_GREEN) {
             legal_actions[legal_count++] = action;
         }
@@ -713,14 +705,12 @@ static inline int chainenv_choose_env_action(ChainEnv* env) {
 
     float scores[CHAINENV_MAX_CELLS];
     float best_score = -1.0e9f;
-    int best_action = legal_actions[0];
     for (int i = 0; i < legal_count; i++) {
         int action = legal_actions[i];
         float score = chainenv_move_score(env, action, CHAINENV_PLAYER_GREEN);
         scores[i] = score;
-        if (score > best_score + 1.0e-6f) {
+        if (score > best_score) {
             best_score = score;
-            best_action = action;
         }
     }
 
@@ -732,7 +722,7 @@ static inline int chainenv_choose_env_action(ChainEnv* env) {
     float weights[CHAINENV_MAX_CELLS];
 
     for (int i = 0; i < legal_count; i++) {
-        if (scores[i] + 1.0e-6f < threshold) {
+        if (scores[i] < threshold) {
             continue;
         }
 
@@ -741,10 +731,6 @@ static inline int chainenv_choose_env_action(ChainEnv* env) {
         weights[candidate_count] = weight;
         total_weight += weight;
         candidate_count += 1;
-    }
-
-    if (candidate_count == 0 || total_weight <= 1.0e-6f) {
-        return best_action;
     }
 
     float sample = ((float)(rand_r(&env->rng) % 100000) / 100000.0f) * total_weight;
@@ -773,21 +759,16 @@ static inline float chainenv_reward_for_player(
 }
 
 static inline void chainenv_finish_game(ChainEnv* env, int winner, int invalid_player) {
-    if (env->num_agents == 1) {
-        env->rewards[0] = chainenv_reward_for_player(
-            env, CHAINENV_PLAYER_RED, winner, invalid_player);
-        env->terminals[0] = 1.0f;
-    } else {
-        for (int slot = 0; slot < env->num_agents; slot++) {
-            int player = chainenv_player_for_slot(env, slot);
-            env->rewards[slot] = chainenv_reward_for_player(
-                env, player, winner, invalid_player);
-            env->terminals[slot] = 1.0f;
-        }
+    for (int slot = 0; slot < env->num_agents; slot++) {
+        int player = chainenv_player_for_slot(env, slot);
+        *env->reward_ptr[slot] = chainenv_reward_for_player(
+            env, player, winner, invalid_player);
+        *env->terminal_ptr[slot] = 1.0f;
     }
 
-    env->end_game = 1;
     env->winner = winner;
+    chainenv_add_historical_log(env);
+    env->end_game = 1;
     chainenv_update_action_mask(env);
     chainenv_add_log(env, invalid_player != 0);
 }
@@ -803,12 +784,7 @@ static inline void chainenv_reset_slot_mapping(ChainEnv* env) {
 
 static inline ResolveStats chainenv_execute_turn(
         ChainEnv* env, int player, int action, float start_delay) {
-    ResolveStats stats = {0};
     int board_idx = chainenv_action_to_board_idx(env, action);
-    if (board_idx < 0) {
-        return stats;
-    }
-
     env->turns_taken[chainenv_player_index(player)] += 1;
     env->move_count += 1;
     if (player == CHAINENV_PLAYER_RED) {
@@ -840,14 +816,10 @@ static inline void chainenv_maybe_open_scripted_duel(ChainEnv* env) {
     chainenv_begin_animation(env);
     ResolveStats env_stats = chainenv_execute_turn(env, CHAINENV_PLAYER_GREEN, env_action, 0.0f);
     env->last_chain_bursts = env_stats.bursts;
-    env->last_chain_waves = env_stats.waves;
     env->current_player = CHAINENV_PLAYER_RED;
 }
 
 static inline void init_chainenv(ChainEnv* env) {
-    if (env->num_agents < 1) env->num_agents = 1;
-    if (env->num_agents > CHAINENV_MAX_SLOTS) env->num_agents = CHAINENV_MAX_SLOTS;
-    if (env->max_steps < 1) env->max_steps = 1;
     int stable_capacity = chainenv_stable_capacity(env);
     if (env->max_steps > stable_capacity) env->max_steps = stable_capacity;
     env->tick = 0;
@@ -859,7 +831,6 @@ static inline void init_chainenv(ChainEnv* env) {
     env->last_player_action = -1;
     env->last_env_action = -1;
     env->last_chain_bursts = 0;
-    env->last_chain_waves = 0;
     env->winner = 0;
     chainenv_set_slot_players(env, CHAINENV_PLAYER_RED, CHAINENV_PLAYER_GREEN);
     chainenv_reset_render_animations(env);
@@ -887,7 +858,6 @@ static inline void c_reset(ChainEnv* env) {
     env->last_player_action = -1;
     env->last_env_action = -1;
     env->last_chain_bursts = 0;
-    env->last_chain_waves = 0;
     env->winner = 0;
     chainenv_reset_slot_mapping(env);
     chainenv_zero_outputs(env);
@@ -908,19 +878,17 @@ static inline void c_step(ChainEnv* env) {
     }
 
     env->last_chain_bursts = 0;
-    env->last_chain_waves = 0;
 
     if (chainenv_is_selfplay(env)) {
         int active_slot = chainenv_slot_for_player(env, env->current_player);
-        int action = (int)env->actions[active_slot];
+        int action = (int)*env->action_ptr[active_slot];
         if (env->current_player == CHAINENV_PLAYER_RED) {
             env->last_player_action = action;
         } else {
             env->last_env_action = action;
         }
 
-        if (action == CHAINENV_NOOP_ACTION ||
-                !chainenv_is_legal_move(env, action, env->current_player)) {
+        if (!chainenv_is_legal_move(env, action, env->current_player)) {
             chainenv_compute_observations(env);
             chainenv_finish_game(env, -env->current_player, env->current_player);
             return;
@@ -929,7 +897,6 @@ static inline void c_step(ChainEnv* env) {
         chainenv_begin_animation(env);
         ResolveStats stats = chainenv_execute_turn(env, env->current_player, action, 0.0f);
         env->last_chain_bursts = stats.bursts;
-        env->last_chain_waves = stats.waves;
 
         int winner = chainenv_check_winner(env);
         if (winner == 0 && env->move_count >= env->max_steps) {
@@ -948,7 +915,7 @@ static inline void c_step(ChainEnv* env) {
         return;
     }
 
-    int action = (int)env->actions[0];
+    int action = (int)*env->action_ptr[0];
     env->last_env_action = -1;
     if (!chainenv_is_legal_move(env, action, CHAINENV_PLAYER_RED)) {
         env->last_player_action = action;
@@ -960,7 +927,6 @@ static inline void c_step(ChainEnv* env) {
     chainenv_begin_animation(env);
     ResolveStats player_stats = chainenv_execute_turn(env, CHAINENV_PLAYER_RED, action, 0.0f);
     env->last_chain_bursts = player_stats.bursts;
-    env->last_chain_waves = player_stats.waves;
 
     int winner = chainenv_check_winner(env);
     if (winner == 0 && env->move_count >= env->max_steps) {
@@ -983,7 +949,6 @@ static inline void c_step(ChainEnv* env) {
     ResolveStats env_stats = chainenv_execute_turn(
         env, CHAINENV_PLAYER_GREEN, env_action, env_start);
     env->last_chain_bursts += env_stats.bursts;
-    env->last_chain_waves += env_stats.waves;
 
     winner = chainenv_check_winner(env);
     if (winner == 0 && env->move_count >= env->max_steps) {

--- a/ocean/chain_reaction/chain_reaction.h
+++ b/ocean/chain_reaction/chain_reaction.h
@@ -8,34 +8,34 @@
 
 #include "raylib.h"
 
-#define CHAINENV_MAX_ROWS 9
-#define CHAINENV_MAX_COLS 9
-#define CHAINENV_MAX_CELLS (CHAINENV_MAX_ROWS * CHAINENV_MAX_COLS)
-#define CHAINENV_MAX_ACTIONS (CHAINENV_MAX_CELLS + 1)
-#define CHAINENV_NOOP_ACTION CHAINENV_MAX_CELLS
-#define CHAINENV_MAX_SLOTS 2
-#define CHAINENV_MAX_BANKS 8
-#define CHAINENV_OBS_CHANNELS 4
-#define CHAINENV_GLOBAL_OBS 5
-#define CHAINENV_OBS_SIZE (CHAINENV_MAX_CELLS * CHAINENV_OBS_CHANNELS + CHAINENV_GLOBAL_OBS)
-#define CHAINENV_MAX_RENDER_WAVES 256
-#define CHAINENV_PLAYER_RED 1
-#define CHAINENV_PLAYER_GREEN -1
-#define CHAINENV_OPPONENT_RANDOM 0
-#define CHAINENV_OPPONENT_HEURISTIC 1
-#define CHAINENV_MAX_RENDER_TRANSFERS 768
-#define CHAINENV_MAX_RENDER_BURSTS 256
-#define CHAINENV_MAX_SNAPSHOTS (CHAINENV_MAX_RENDER_WAVES + 2)
-#define CHAINENV_BURST_DURATION 0.36f
-#define CHAINENV_TRANSFER_DURATION 0.28f
-#define CHAINENV_WAVE_DELAY 0.10f
-#define CHAINENV_PLACEMENT_DURATION 0.11f
-#define CHAINENV_TURN_GAP 0.08f
-#define CHAINENV_RED_ORBIT_SPEED 0.90f
-#define CHAINENV_GREEN_ORBIT_SPEED -0.78f
+#define MAX_ROWS 9
+#define MAX_COLS 9
+#define MAX_CELLS (MAX_ROWS * MAX_COLS)
+#define MAX_ACTIONS (MAX_CELLS + 1)
+#define NOOP_ACTION MAX_CELLS
+#define MAX_SLOTS 2
+#define MAX_BANKS 8
+#define OBS_CHANNELS 4
+#define GLOBAL_OBS 5
+#define OBS_SIZE (MAX_CELLS * OBS_CHANNELS + GLOBAL_OBS)
+#define MAX_RENDER_WAVES 256
+#define RED_PLAYER 1
+#define GREEN_PLAYER -1
+#define RANDOM_OPPONENT 0
+#define HEURISTIC_OPPONENT 1
+#define MAX_RENDER_TRANSFERS 768
+#define MAX_RENDER_BURSTS 256
+// Scripted mode animates both players' turns without resetting the client.
+#define MAX_SNAPSHOTS (2 * (MAX_RENDER_WAVES + 2))
+#define BURST_DURATION 0.36f
+#define TRANSFER_DURATION 0.28f
+#define WAVE_DELAY 0.10f
+#define PLACEMENT_DURATION 0.11f
+#define TURN_GAP 0.08f
+#define RED_ORBIT_SPEED 0.90f
+#define GREEN_ORBIT_SPEED -0.78f
 
-typedef struct Log Log;
-struct Log {
+typedef struct {
     float perf;
     float score;
     float episode_return;
@@ -44,16 +44,15 @@ struct Log {
     float invalid_rate;
     float hist_score;
     float hist_n;
-    float hist_score_bank[CHAINENV_MAX_BANKS];
-    float hist_n_bank[CHAINENV_MAX_BANKS];
+    float hist_score_bank[MAX_BANKS];
+    float hist_n_bank[MAX_BANKS];
     float slot_0_score;
     float slot_1_score;
     float draw_rate;
     float n;
-};
+} Log;
 
-typedef struct OrbTransferAnim OrbTransferAnim;
-struct OrbTransferAnim {
+typedef struct {
     int src_row;
     int src_col;
     int dst_row;
@@ -61,19 +60,17 @@ struct OrbTransferAnim {
     int color;
     float delay;
     float duration;
-};
+} OrbTransferAnim;
 
-typedef struct BurstAnim BurstAnim;
-struct BurstAnim {
+typedef struct {
     int row;
     int col;
     int color;
     float delay;
     float duration;
-};
+} BurstAnim;
 
-typedef struct Client Client;
-struct Client {
+typedef struct {
     int screen_width;
     int screen_height;
     float board_x;
@@ -82,37 +79,36 @@ struct Client {
     float animation_clock;
     float animation_total;
     float invalid_hint_time;
-    OrbTransferAnim transfers[CHAINENV_MAX_RENDER_TRANSFERS];
-    BurstAnim bursts[CHAINENV_MAX_RENDER_BURSTS];
-    int base_owner[CHAINENV_MAX_CELLS];
-    int base_orbs[CHAINENV_MAX_CELLS];
-    int snapshot_owner[CHAINENV_MAX_SNAPSHOTS][CHAINENV_MAX_CELLS];
-    int snapshot_orbs[CHAINENV_MAX_SNAPSHOTS][CHAINENV_MAX_CELLS];
-    float snapshot_time[CHAINENV_MAX_SNAPSHOTS];
+    OrbTransferAnim transfers[MAX_RENDER_TRANSFERS];
+    BurstAnim bursts[MAX_RENDER_BURSTS];
+    int8_t base_owner[MAX_CELLS];
+    uint16_t base_orbs[MAX_CELLS];
+    int8_t snapshot_owner[MAX_SNAPSHOTS][MAX_CELLS];
+    uint16_t snapshot_orbs[MAX_SNAPSHOTS][MAX_CELLS];
+    float snapshot_time[MAX_SNAPSHOTS];
     int snapshot_count;
     int transfer_count;
     int burst_count;
-};
+} Client;
 
-typedef struct ResolveStats ResolveStats;
-struct ResolveStats {
+typedef struct {
     int bursts;
+    int winner;
     float end_time;
-};
+} ResolveStats;
 
-typedef struct ChainEnv ChainEnv;
-struct ChainEnv {
+typedef struct {
     float* observations;
     float* actions;
     float* rewards;
     float* terminals;
     unsigned char* action_mask;
     // Logical slots may be non-adjacent during historical self-play.
-    float* obs_ptr[CHAINENV_MAX_SLOTS];
-    float* action_ptr[CHAINENV_MAX_SLOTS];
-    float* reward_ptr[CHAINENV_MAX_SLOTS];
-    float* terminal_ptr[CHAINENV_MAX_SLOTS];
-    unsigned char* action_mask_ptr[CHAINENV_MAX_SLOTS];
+    float* obs_ptr[MAX_SLOTS];
+    float* action_ptr[MAX_SLOTS];
+    float* reward_ptr[MAX_SLOTS];
+    float* terminal_ptr[MAX_SLOTS];
+    unsigned char* action_mask_ptr[MAX_SLOTS];
     int num_agents;
     Log log;
     Client* client;
@@ -125,15 +121,19 @@ struct ChainEnv {
     float loss_reward;
     float invalid_move_reward;
 
-    int owner[CHAINENV_MAX_CELLS];
-    int orbs[CHAINENV_MAX_CELLS];
+    int8_t owner[MAX_CELLS];
+    uint16_t orbs[MAX_CELLS];
+    uint8_t action_cell[MAX_CELLS];
+    uint8_t critical_mass[MAX_CELLS];
+    uint8_t neighbor_count[MAX_CELLS];
+    uint8_t neighbors[MAX_CELLS][4];
     int move_count;
     int tick;
     int end_game;
     int turns_taken[2];
     int current_player;
-    int player_for_slot[CHAINENV_MAX_SLOTS];
-    int slot_for_player[CHAINENV_MAX_SLOTS];
+    int player_for_slot[MAX_SLOTS];
+    int slot_for_player[MAX_SLOTS];
     int last_player_action;
     int last_env_action;
     int last_chain_bursts;
@@ -145,109 +145,45 @@ struct ChainEnv {
     int tag;
     int boundary_reached;
     unsigned int rng;
-};
+} ChainEnv;
 
-static inline int chainenv_slot(int row, int col) {
-    return row * CHAINENV_MAX_COLS + col;
+static int board_index(int row, int col) {
+    return row * MAX_COLS + col;
 }
 
-static inline int chainenv_player_index(int player) {
-    return (player == CHAINENV_PLAYER_RED) ? 0 : 1;
+static int player_index(int player) {
+    return (player == RED_PLAYER) ? 0 : 1;
 }
 
-static inline bool chainenv_is_selfplay(const ChainEnv* env) {
+static bool is_selfplay(ChainEnv* env) {
     return env->num_agents > 1;
 }
 
-static inline int chainenv_slot_for_player(const ChainEnv* env, int player) {
-    return env->slot_for_player[chainenv_player_index(player)];
+static int slot_for_player(ChainEnv* env, int player) {
+    return env->slot_for_player[player_index(player)];
 }
 
-static inline int chainenv_player_for_slot(const ChainEnv* env, int slot) {
+static int player_for_slot(ChainEnv* env, int slot) {
     return env->player_for_slot[slot];
 }
 
-static inline void chainenv_set_slot_players(ChainEnv* env, int slot0_player, int slot1_player) {
+static void set_slot_players(ChainEnv* env, int slot0_player, int slot1_player) {
     env->player_for_slot[0] = slot0_player;
     env->player_for_slot[1] = slot1_player;
-    env->slot_for_player[chainenv_player_index(slot0_player)] = 0;
-    env->slot_for_player[chainenv_player_index(slot1_player)] = 1;
+    env->slot_for_player[player_index(slot0_player)] = 0;
+    env->slot_for_player[player_index(slot1_player)] = 1;
 }
 
-static inline void chainenv_copy_board(
-        int* dst_owner, int* dst_orbs, const int* src_owner, const int* src_orbs) {
-    memcpy(dst_owner, src_owner, sizeof(int) * CHAINENV_MAX_CELLS);
-    memcpy(dst_orbs, src_orbs, sizeof(int) * CHAINENV_MAX_CELLS);
+// Rendering snapshots whole board states so chain waves can be replayed visually.
+static void copy_render_board(
+        int8_t* dst_owner, uint16_t* dst_orbs,
+        int8_t* src_owner, uint16_t* src_orbs) {
+    memcpy(dst_owner, src_owner, sizeof(int8_t) * MAX_CELLS);
+    memcpy(dst_orbs, src_orbs, sizeof(uint16_t) * MAX_CELLS);
 }
 
-static inline bool chainenv_cell_active(const ChainEnv* env, int row, int col) {
-    return row >= 0 && row < env->rows && col >= 0 && col < env->cols;
-}
-
-static inline int chainenv_action_to_board_idx(const ChainEnv* env, int action) {
-    if (action < 0 || action >= env->rows * env->cols) {
-        return -1;
-    }
-
-    int row = action / env->cols;
-    int col = action % env->cols;
-    return chainenv_slot(row, col);
-}
-
-static inline int chainenv_critical_mass(const ChainEnv* env, int row, int col) {
-    int mass = 0;
-    mass += chainenv_cell_active(env, row - 1, col) ? 1 : 0;
-    mass += chainenv_cell_active(env, row + 1, col) ? 1 : 0;
-    mass += chainenv_cell_active(env, row, col - 1) ? 1 : 0;
-    mass += chainenv_cell_active(env, row, col + 1) ? 1 : 0;
-    return mass;
-}
-
-static inline int chainenv_stable_capacity(const ChainEnv* env) {
-    // Stable cells hold at most (critical_mass - 1) orbs, so this is the
-    // largest turn count that can still admit a stable board on the chosen grid.
-    return 3 * env->rows * env->cols - 2 * env->rows - 2 * env->cols;
-}
-
-static inline void chainenv_add_log(ChainEnv* env, int invalid) {
-    float reward = *env->reward_ptr[0];
-    env->log.perf += reward > 0.0f ? 1.0f : (reward == 0.0f ? 0.5f : 0.0f);
-    env->log.score += reward;
-    env->log.episode_return += reward;
-    env->log.episode_length += (float)env->tick;
-    env->log.chain_bursts += (float)env->last_chain_bursts;
-    env->log.invalid_rate += invalid ? 1.0f : 0.0f;
-    if (env->num_agents > 1) {
-        if (env->winner == 0) {
-            env->log.slot_0_score += 0.5f;
-            env->log.slot_1_score += 0.5f;
-            env->log.draw_rate += 1.0f;
-        } else {
-            int winner_slot = chainenv_slot_for_player(env, env->winner);
-            if (winner_slot == 0) env->log.slot_0_score += 1.0f;
-            else env->log.slot_1_score += 1.0f;
-        }
-    }
-    env->log.n += 1.0f;
-}
-
-static inline void chainenv_add_historical_log(ChainEnv* env) {
-    if (env->num_agents < 2 || env->tag <= 0 || env->tag > CHAINENV_MAX_BANKS) {
-        return;
-    }
-
-    float primary_score = env->winner == 0
-        ? 0.5f
-        : (chainenv_player_for_slot(env, 0) == env->winner ? 1.0f : 0.0f);
-    int bank_idx = env->tag - 1;
-    env->log.hist_score_bank[bank_idx] += primary_score;
-    env->log.hist_n_bank[bank_idx] += 1.0f;
-    env->log.hist_score += primary_score;
-    env->log.hist_n += 1.0f;
-    env->boundary_reached = 1;
-}
-
-static inline void chainenv_layout_board(Client* client, const ChainEnv* env) {
+static void layout_board(ChainEnv* env) {
+    Client* client = env->client;
     float sidebar_w = fminf(250.0f, (float)client->screen_width * 0.26f);
     float gutter = fmaxf(30.0f, (float)client->screen_width * 0.04f);
     float board_area_x = sidebar_w + gutter;
@@ -261,55 +197,31 @@ static inline void chainenv_layout_board(Client* client, const ChainEnv* env) {
     client->board_y = ((float)client->screen_height - cell_size * env->rows) * 0.5f + 6.0f;
 }
 
-static inline void chainenv_reset_render_animations(ChainEnv* env) {
-    if (env->client == NULL) {
-        return;
-    }
-
-    env->client->animation_clock = 0.0f;
-    env->client->animation_total = 0.0f;
-    env->client->snapshot_count = 0;
-    env->client->transfer_count = 0;
-    env->client->burst_count = 0;
+static void reset_animations(Client* client) {
+    client->animation_clock = 0.0f;
+    client->animation_total = 0.0f;
+    client->snapshot_count = 0;
+    client->transfer_count = 0;
+    client->burst_count = 0;
 }
 
-static inline void chainenv_clear_invalid_hint(ChainEnv* env) {
-    if (env->client == NULL) {
-        return;
-    }
-
-    env->client->invalid_hint_time = 0.0f;
+static void clear_invalid_hint(Client* client) {
+    client->invalid_hint_time = 0.0f;
 }
 
-static inline void chainenv_show_invalid_hint(ChainEnv* env) {
-    if (env->client == NULL) {
-        return;
-    }
-
-    env->client->invalid_hint_time = 1.9f;
-}
-
-static inline void chainenv_begin_animation(ChainEnv* env) {
-    if (env->client == NULL) {
-        return;
-    }
-
-    chainenv_reset_render_animations(env);
-    chainenv_copy_board(
+static void begin_animation(ChainEnv* env) {
+    reset_animations(env->client);
+    copy_render_board(
         env->client->base_owner,
         env->client->base_orbs,
         env->owner,
         env->orbs);
 }
 
-static inline void chainenv_record_snapshot(ChainEnv* env, float reveal_time) {
-    if (env->client == NULL) {
-        return;
-    }
-
+static void record_snapshot(ChainEnv* env, float reveal_time) {
     Client* client = env->client;
     int snapshot_idx = client->snapshot_count++;
-    chainenv_copy_board(
+    copy_render_board(
         client->snapshot_owner[snapshot_idx],
         client->snapshot_orbs[snapshot_idx],
         env->owner,
@@ -321,62 +233,15 @@ static inline void chainenv_record_snapshot(ChainEnv* env, float reveal_time) {
     }
 }
 
-static inline void chainenv_record_burst(ChainEnv* env, int row, int col, int color, float delay) {
-    if (env->client == NULL) {
-        return;
-    }
-
-    Client* client = env->client;
-    if (client->burst_count < CHAINENV_MAX_RENDER_BURSTS) {
-        client->bursts[client->burst_count++] = (BurstAnim) {
-            .row = row,
-            .col = col,
-            .color = color,
-            .delay = delay,
-            .duration = CHAINENV_BURST_DURATION,
-        };
-    }
-
-    float end_time = delay + CHAINENV_BURST_DURATION;
-    if (end_time > client->animation_total) {
-        client->animation_total = end_time;
-    }
-}
-
-static inline void chainenv_record_transfer(
-        ChainEnv* env, int src_row, int src_col, int dst_row, int dst_col, int color, float delay) {
-    if (env->client == NULL) {
-        return;
-    }
-
-    Client* client = env->client;
-    if (client->transfer_count < CHAINENV_MAX_RENDER_TRANSFERS) {
-        client->transfers[client->transfer_count++] = (OrbTransferAnim) {
-            .src_row = src_row,
-            .src_col = src_col,
-            .dst_row = dst_row,
-            .dst_col = dst_col,
-            .color = color,
-            .delay = delay,
-            .duration = CHAINENV_TRANSFER_DURATION,
-        };
-    }
-
-    float end_time = delay + CHAINENV_TRANSFER_DURATION;
-    if (end_time > client->animation_total) {
-        client->animation_total = end_time;
-    }
-}
-
-static inline void chainenv_recount(const ChainEnv* env, int* red_total, int* green_total) {
+static void count_orbs(ChainEnv* env, int* red_total, int* green_total) {
     int red = 0;
     int green = 0;
     for (int row = 0; row < env->rows; row++) {
         for (int col = 0; col < env->cols; col++) {
-            int idx = chainenv_slot(row, col);
-            if (env->owner[idx] == CHAINENV_PLAYER_RED) {
+            int idx = board_index(row, col);
+            if (env->owner[idx] == RED_PLAYER) {
                 red += env->orbs[idx];
-            } else if (env->owner[idx] == CHAINENV_PLAYER_GREEN) {
+            } else if (env->owner[idx] == GREEN_PLAYER) {
                 green += env->orbs[idx];
             }
         }
@@ -386,33 +251,38 @@ static inline void chainenv_recount(const ChainEnv* env, int* red_total, int* gr
     *green_total = green;
 }
 
-static inline void chainenv_zero_outputs(ChainEnv* env) {
+static void zero_outputs(ChainEnv* env) {
     for (int slot = 0; slot < env->num_agents; slot++) {
         *env->reward_ptr[slot] = 0.0f;
         *env->terminal_ptr[slot] = 0.0f;
     }
 }
 
-static inline bool chainenv_is_legal_move(const ChainEnv* env, int action, int player);
-static inline int chainenv_check_winner(const ChainEnv* env);
+static bool is_legal_move(ChainEnv* env, int action, int player) {
+    if (action < 0 || action >= env->rows * env->cols) {
+        return false;
+    }
+    int owner = env->owner[env->action_cell[action]];
+    return owner == 0 || owner == player;
+}
 
-static inline void chainenv_compute_observations(ChainEnv* env) {
+static void compute_observations(ChainEnv* env) {
     int red_total = 0;
     int green_total = 0;
-    chainenv_recount(env, &red_total, &green_total);
+    count_orbs(env, &red_total, &green_total);
 
     float area = (float)(env->rows * env->cols);
     for (int slot = 0; slot < env->num_agents; slot++) {
         float* obs = env->obs_ptr[slot];
-        memset(obs, 0, CHAINENV_OBS_SIZE * sizeof(float));
-        int player = chainenv_player_for_slot(env, slot);
+        memset(obs, 0, OBS_SIZE * sizeof(float));
+        int player = player_for_slot(env, slot);
 
         for (int row = 0; row < env->rows; row++) {
             for (int col = 0; col < env->cols; col++) {
-                int idx = chainenv_slot(row, col);
-                int obs_idx = idx * CHAINENV_OBS_CHANNELS;
+                int idx = board_index(row, col);
+                int obs_idx = idx * OBS_CHANNELS;
                 obs[obs_idx + 0] = 1.0f;
-                obs[obs_idx + 1] = chainenv_critical_mass(env, row, col) / 4.0f;
+                obs[obs_idx + 1] = env->critical_mass[idx] / 4.0f;
 
                 if (env->owner[idx] == player) {
                     obs[obs_idx + 2] = env->orbs[idx] / 4.0f;
@@ -422,292 +292,127 @@ static inline void chainenv_compute_observations(ChainEnv* env) {
             }
         }
 
-        int self_total = player == CHAINENV_PLAYER_RED ? red_total : green_total;
-        int opp_total = player == CHAINENV_PLAYER_RED ? green_total : red_total;
-        int base = CHAINENV_MAX_CELLS * CHAINENV_OBS_CHANNELS;
-        obs[base + 0] = env->rows / (float)CHAINENV_MAX_ROWS;
-        obs[base + 1] = env->cols / (float)CHAINENV_MAX_COLS;
-        obs[base + 2] = area > 0.0f ? self_total / (area * 4.0f) : 0.0f;
-        obs[base + 3] = area > 0.0f ? opp_total / (area * 4.0f) : 0.0f;
+        int self_total = player == RED_PLAYER ? red_total : green_total;
+        int opp_total = player == RED_PLAYER ? green_total : red_total;
+        int base = MAX_CELLS * OBS_CHANNELS;
+        obs[base + 0] = env->rows / (float)MAX_ROWS;
+        obs[base + 1] = env->cols / (float)MAX_COLS;
+        obs[base + 2] = self_total / (area * 4.0f);
+        obs[base + 3] = opp_total / (area * 4.0f);
         obs[base + 4] = env->current_player == player ? 1.0f : 0.0f;
     }
 }
 
-static inline void chainenv_update_action_mask(ChainEnv* env) {
+static void compute_action_masks(ChainEnv* env) {
     for (int slot = 0; slot < env->num_agents; slot++) {
-        memset(env->action_mask_ptr[slot], 0, CHAINENV_MAX_ACTIONS);
+        memset(env->action_mask_ptr[slot], 0, MAX_ACTIONS);
     }
 
     if (env->end_game) {
         for (int slot = 0; slot < env->num_agents; slot++) {
-            env->action_mask_ptr[slot][CHAINENV_NOOP_ACTION] = 1;
+            env->action_mask_ptr[slot][NOOP_ACTION] = 1;
         }
         return;
     }
 
-    if (!chainenv_is_selfplay(env)) {
+    if (!is_selfplay(env)) {
         unsigned char* mask = env->action_mask_ptr[0];
         for (int action = 0; action < env->rows * env->cols; action++) {
-            int idx = chainenv_action_to_board_idx(env, action);
-            if (env->owner[idx] == 0 || env->owner[idx] == CHAINENV_PLAYER_RED) {
+            int idx = env->action_cell[action];
+            if (env->owner[idx] == 0 || env->owner[idx] == RED_PLAYER) {
                 mask[action] = 1;
             }
         }
         return;
     }
 
-    int active_slot = chainenv_slot_for_player(env, env->current_player);
+    int active_slot = slot_for_player(env, env->current_player);
     for (int slot = 0; slot < env->num_agents; slot++) {
         unsigned char* mask = env->action_mask_ptr[slot];
         if (slot != active_slot) {
-            mask[CHAINENV_NOOP_ACTION] = 1;
+            mask[NOOP_ACTION] = 1;
             continue;
         }
 
         for (int action = 0; action < env->rows * env->cols; action++) {
-            if (chainenv_is_legal_move(env, action, env->current_player)) {
+            int owner = env->owner[env->action_cell[action]];
+            if (owner == 0 || owner == env->current_player) {
                 mask[action] = 1;
             }
         }
     }
 }
 
-static inline bool chainenv_is_legal_move(const ChainEnv* env, int action, int player) {
-    int idx = chainenv_action_to_board_idx(env, action);
-    if (idx < 0) {
-        return false;
-    }
-
-    return env->owner[idx] == 0 || env->owner[idx] == player;
-}
-
-static inline void chainenv_apply_single_orb(ChainEnv* env, int board_idx, int player) {
-    if (env->owner[board_idx] != player) {
-        env->owner[board_idx] = player;
-    }
+static void place_orb(ChainEnv* env, int board_idx, int player) {
+    env->owner[board_idx] = player;
     env->orbs[board_idx] += 1;
 }
 
-static inline ResolveStats chainenv_resolve_chain(ChainEnv* env, int player, float start_delay) {
-    ResolveStats stats = {0};
-    stats.end_time = start_delay;
-    int recorded_waves = 0;
-    bool truncated_render = false;
-
-    for (int wave = 0;; wave++) {
-        int unstable[CHAINENV_MAX_CELLS];
-        int unstable_count = 0;
-
-        for (int r = 0; r < env->rows; r++) {
-            for (int c = 0; c < env->cols; c++) {
-                int idx = chainenv_slot(r, c);
-                if (env->owner[idx] != player) {
-                    continue;
-                }
-
-                int critical = chainenv_critical_mass(env, r, c);
-                if (env->orbs[idx] >= critical) {
-                    unstable[unstable_count++] = idx;
-                }
-            }
-        }
-
-        if (unstable_count == 0) {
-            break;
-        }
-
-        bool record_wave = wave < CHAINENV_MAX_RENDER_WAVES;
-        float delay = start_delay + recorded_waves * CHAINENV_WAVE_DELAY;
-        for (int i = 0; i < unstable_count; i++) {
-            int idx = unstable[i];
-            int burst_row = idx / CHAINENV_MAX_COLS;
-            int burst_col = idx % CHAINENV_MAX_COLS;
-            int critical = chainenv_critical_mass(env, burst_row, burst_col);
-
-            env->orbs[idx] -= critical;
-            if (env->orbs[idx] <= 0) {
-                env->orbs[idx] = 0;
-                env->owner[idx] = 0;
-            } else {
-                env->owner[idx] = player;
-            }
-
-            stats.bursts += 1;
-            if (record_wave) {
-                chainenv_record_burst(env, burst_row, burst_col, player, delay);
-            }
-        }
-
-        for (int i = 0; i < unstable_count; i++) {
-            int idx = unstable[i];
-            int src_row = idx / CHAINENV_MAX_COLS;
-            int src_col = idx % CHAINENV_MAX_COLS;
-            static const int dr[4] = {-1, 1, 0, 0};
-            static const int dc[4] = {0, 0, -1, 1};
-
-            for (int d = 0; d < 4; d++) {
-                int nr = src_row + dr[d];
-                int nc = src_col + dc[d];
-                if (!chainenv_cell_active(env, nr, nc)) {
-                    continue;
-                }
-
-                int nidx = chainenv_slot(nr, nc);
-                chainenv_apply_single_orb(env, nidx, player);
-                if (record_wave) {
-                    chainenv_record_transfer(env, src_row, src_col, nr, nc, player, delay);
-                }
-            }
-        }
-
-        if (record_wave) {
-            float reveal_time = delay + fmaxf(CHAINENV_BURST_DURATION, CHAINENV_TRANSFER_DURATION);
-            chainenv_record_snapshot(env, reveal_time);
-            stats.end_time = reveal_time;
-            recorded_waves += 1;
-        } else {
-            truncated_render = true;
-        }
-
-        // Match the mobile game: once a player has been wiped out after both
-        // sides have taken at least one turn, the move ends immediately instead
-        // of continuing a single-color avalanche.
-        if (chainenv_check_winner(env) != 0) {
-            break;
-        }
-    }
-
-    if (truncated_render) {
-        float final_time = start_delay
-            + recorded_waves * CHAINENV_WAVE_DELAY
-            + fmaxf(CHAINENV_BURST_DURATION, CHAINENV_TRANSFER_DURATION);
-        chainenv_record_snapshot(env, final_time);
-        stats.end_time = final_time;
-    }
-
-    return stats;
-}
-
-static inline bool chainenv_player_eliminated(const ChainEnv* env, int player) {
-    for (int row = 0; row < env->rows; row++) {
-        for (int col = 0; col < env->cols; col++) {
-            int idx = chainenv_slot(row, col);
-            if (env->owner[idx] == player && env->orbs[idx] > 0) {
-                return false;
-            }
-        }
-    }
-
-    return true;
-}
-
-static inline int chainenv_check_winner(const ChainEnv* env) {
-    if (env->turns_taken[0] == 0 || env->turns_taken[1] == 0) {
-        return 0;
-    }
-
-    bool red_out = chainenv_player_eliminated(env, CHAINENV_PLAYER_RED);
-    bool green_out = chainenv_player_eliminated(env, CHAINENV_PLAYER_GREEN);
-    if (!red_out && green_out) {
-        return CHAINENV_PLAYER_RED;
-    }
-    if (red_out && !green_out) {
-        return CHAINENV_PLAYER_GREEN;
-    }
-
-    return 0;
-}
-
-static inline int chainenv_timeout_winner(const ChainEnv* env) {
+static int timeout_winner(ChainEnv* env) {
     int red_total = 0;
     int green_total = 0;
-    chainenv_recount(env, &red_total, &green_total);
+    count_orbs(env, &red_total, &green_total);
 
     if (red_total > green_total) {
-        return CHAINENV_PLAYER_RED;
+        return RED_PLAYER;
     }
     if (green_total > red_total) {
-        return CHAINENV_PLAYER_GREEN;
+        return GREEN_PLAYER;
     }
     return 0;
 }
 
-static inline float chainenv_move_score(const ChainEnv* env, int action, int player) {
-    int idx = chainenv_action_to_board_idx(env, action);
-    int row = idx / CHAINENV_MAX_COLS;
-    int col = idx % CHAINENV_MAX_COLS;
-    int critical = chainenv_critical_mass(env, row, col);
-    int existing = env->orbs[idx];
-    int owner = env->owner[idx];
-    float score = 0.0f;
-    int friendly_neighbors = 0;
-    int enemy_neighbors = 0;
-
-    score += owner == player ? 3.1f : 1.0f;
-    score += (5 - critical) * 0.35f;
-    score += (existing + 1 >= critical) ? 4.0f : (1.2f / (float)(critical - existing));
-
-    static const int dr[4] = {-1, 1, 0, 0};
-    static const int dc[4] = {0, 0, -1, 1};
-    for (int d = 0; d < 4; d++) {
-        int nr = row + dr[d];
-        int nc = col + dc[d];
-        if (!chainenv_cell_active(env, nr, nc)) {
-            continue;
-        }
-
-        int nidx = chainenv_slot(nr, nc);
-        int nowner = env->owner[nidx];
-        int norbs = env->orbs[nidx];
-        int ncritical = chainenv_critical_mass(env, nr, nc);
-
-        if (nowner == player) {
-            friendly_neighbors += 1;
-            score += norbs == ncritical - 1 ? 1.1f : 0.32f * norbs;
-        } else if (nowner == -player) {
-            enemy_neighbors += 1;
-            score += norbs == ncritical - 1 ? 2.2f : 0.15f * norbs;
-            if (owner == 0 && env->move_count < 10) {
-                score -= 0.35f;
-            }
-        }
-    }
-
-    if (owner == 0) {
-        if (env->move_count < 8) {
-            score += 0.18f * friendly_neighbors;
-            score -= 0.20f * enemy_neighbors;
-        } else {
-            score += 0.10f * friendly_neighbors;
-        }
-    }
-
-    return score;
-}
-
-static inline int chainenv_choose_env_action(ChainEnv* env) {
-    int legal_actions[CHAINENV_MAX_CELLS];
+static int choose_opponent_action(ChainEnv* env) {
+    int legal_actions[MAX_CELLS];
     int legal_count = 0;
     for (int action = 0; action < env->rows * env->cols; action++) {
-        int idx = chainenv_action_to_board_idx(env, action);
-        if (env->owner[idx] == 0 || env->owner[idx] == CHAINENV_PLAYER_GREEN) {
+        int idx = env->action_cell[action];
+        if (env->owner[idx] == 0 || env->owner[idx] == GREEN_PLAYER) {
             legal_actions[legal_count++] = action;
         }
     }
 
-    if (legal_count == 0) {
-        return -1;
-    }
-
-    if (env->opponent_policy == CHAINENV_OPPONENT_RANDOM) {
+    if (env->opponent_policy == RANDOM_OPPONENT) {
         return legal_actions[rand_r(&env->rng) % legal_count];
     }
 
-    float scores[CHAINENV_MAX_CELLS];
+    float scores[MAX_CELLS];
     float best_score = -1.0e9f;
     for (int i = 0; i < legal_count; i++) {
         int action = legal_actions[i];
-        float score = chainenv_move_score(env, action, CHAINENV_PLAYER_GREEN);
+        int idx = env->action_cell[action];
+        int critical = env->critical_mass[idx];
+        int existing = env->orbs[idx];
+        int owner = env->owner[idx];
+        float score = owner == GREEN_PLAYER ? 3.1f : 1.0f;
+        int friendly_neighbors = 0;
+        int enemy_neighbors = 0;
+
+        score += (5 - critical) * 0.35f;
+        score += existing + 1 >= critical ? 4.0f : 1.2f / (critical - existing);
+        for (int n = 0; n < env->neighbor_count[idx]; n++) {
+            int neighbor = env->neighbors[idx][n];
+            int neighbor_owner = env->owner[neighbor];
+            int neighbor_orbs = env->orbs[neighbor];
+            int neighbor_mass = env->critical_mass[neighbor];
+            if (neighbor_owner == GREEN_PLAYER) {
+                friendly_neighbors += 1;
+                score += neighbor_orbs == neighbor_mass - 1 ? 1.1f : 0.32f * neighbor_orbs;
+            } else if (neighbor_owner == RED_PLAYER) {
+                enemy_neighbors += 1;
+                score += neighbor_orbs == neighbor_mass - 1 ? 2.2f : 0.15f * neighbor_orbs;
+                if (owner == 0 && env->move_count < 10) {
+                    score -= 0.35f;
+                }
+            }
+        }
+        if (owner == 0 && env->move_count < 8) {
+            score += 0.18f * friendly_neighbors;
+            score -= 0.20f * enemy_neighbors;
+        } else if (owner == 0) {
+            score += 0.10f * friendly_neighbors;
+        }
+
         scores[i] = score;
         if (score > best_score) {
             best_score = score;
@@ -717,126 +422,262 @@ static inline int chainenv_choose_env_action(ChainEnv* env) {
     float margin = env->move_count < 8 ? 0.95f : 0.55f;
     float threshold = best_score - margin;
     float total_weight = 0.0f;
-    int candidate_count = 0;
-    int candidates[CHAINENV_MAX_CELLS];
-    float weights[CHAINENV_MAX_CELLS];
+    for (int i = 0; i < legal_count; i++) {
+        if (scores[i] >= threshold) {
+            total_weight += 0.15f + (scores[i] - threshold);
+        }
+    }
 
+    float sample = ((float)(rand_r(&env->rng) % 100000) / 100000.0f) * total_weight;
+    int last_candidate = legal_actions[0];
     for (int i = 0; i < legal_count; i++) {
         if (scores[i] < threshold) {
             continue;
         }
-
-        float weight = 0.15f + (scores[i] - threshold);
-        candidates[candidate_count] = legal_actions[i];
-        weights[candidate_count] = weight;
-        total_weight += weight;
-        candidate_count += 1;
-    }
-
-    float sample = ((float)(rand_r(&env->rng) % 100000) / 100000.0f) * total_weight;
-    for (int i = 0; i < candidate_count; i++) {
-        sample -= weights[i];
+        last_candidate = legal_actions[i];
+        sample -= 0.15f + (scores[i] - threshold);
         if (sample <= 0.0f) {
-            return candidates[i];
+            return last_candidate;
         }
     }
 
-    return candidates[candidate_count - 1];
+    return last_candidate;
 }
 
-static inline float chainenv_reward_for_player(
-        const ChainEnv* env, int player, int winner, int invalid_player) {
-    if (winner == 0) {
-        return 0.0f;
-    }
-    if (player == winner) {
-        return env->win_reward;
-    }
-    if (invalid_player != 0 && player == invalid_player) {
-        return env->invalid_move_reward;
-    }
-    return env->loss_reward;
-}
-
-static inline void chainenv_finish_game(ChainEnv* env, int winner, int invalid_player) {
+static void finish_game(ChainEnv* env, int winner, int invalid_player) {
     for (int slot = 0; slot < env->num_agents; slot++) {
-        int player = chainenv_player_for_slot(env, slot);
-        *env->reward_ptr[slot] = chainenv_reward_for_player(
-            env, player, winner, invalid_player);
+        int player = player_for_slot(env, slot);
+        float reward = env->loss_reward;
+        if (winner == 0) {
+            reward = 0.0f;
+        } else if (player == winner) {
+            reward = env->win_reward;
+        } else if (player == invalid_player) {
+            reward = env->invalid_move_reward;
+        }
+        *env->reward_ptr[slot] = reward;
         *env->terminal_ptr[slot] = 1.0f;
     }
 
     env->winner = winner;
-    chainenv_add_historical_log(env);
-    env->end_game = 1;
-    chainenv_update_action_mask(env);
-    chainenv_add_log(env, invalid_player != 0);
-}
-
-static inline void chainenv_reset_slot_mapping(ChainEnv* env) {
-    if (chainenv_is_selfplay(env) && (rand_r(&env->rng) & 1) != 0) {
-        chainenv_set_slot_players(env, CHAINENV_PLAYER_GREEN, CHAINENV_PLAYER_RED);
-        return;
+    if (env->num_agents == 2 && env->tag > 0 && env->tag <= MAX_BANKS) {
+        float primary_score = 0.0f;
+        if (winner == 0) {
+            primary_score = 0.5f;
+        } else if (player_for_slot(env, 0) == winner) {
+            primary_score = 1.0f;
+        }
+        int bank = env->tag - 1;
+        env->log.hist_score_bank[bank] += primary_score;
+        env->log.hist_n_bank[bank] += 1.0f;
+        env->log.hist_score += primary_score;
+        env->log.hist_n += 1.0f;
+        env->boundary_reached = 1;
     }
 
-    chainenv_set_slot_players(env, CHAINENV_PLAYER_RED, CHAINENV_PLAYER_GREEN);
+    env->end_game = 1;
+    compute_action_masks(env);
+
+    float reward = *env->reward_ptr[0];
+    env->log.perf += reward > 0.0f ? 1.0f : (reward == 0.0f ? 0.5f : 0.0f);
+    env->log.score += reward;
+    env->log.episode_return += reward;
+    env->log.episode_length += (float)env->tick;
+    env->log.chain_bursts += (float)env->last_chain_bursts;
+    env->log.invalid_rate += invalid_player != 0 ? 1.0f : 0.0f;
+    if (env->num_agents == 2) {
+        if (winner == 0) {
+            env->log.slot_0_score += 0.5f;
+            env->log.slot_1_score += 0.5f;
+            env->log.draw_rate += 1.0f;
+        } else if (slot_for_player(env, winner) == 0) {
+            env->log.slot_0_score += 1.0f;
+        } else {
+            env->log.slot_1_score += 1.0f;
+        }
+    }
+    env->log.n += 1.0f;
 }
 
-static inline ResolveStats chainenv_execute_turn(
+static ResolveStats execute_turn(
         ChainEnv* env, int player, int action, float start_delay) {
-    int board_idx = chainenv_action_to_board_idx(env, action);
-    env->turns_taken[chainenv_player_index(player)] += 1;
+    int board_idx = env->action_cell[action];
+    env->turns_taken[player_index(player)] += 1;
     env->move_count += 1;
-    if (player == CHAINENV_PLAYER_RED) {
+    if (player == RED_PLAYER) {
         env->last_player_action = action;
     } else {
         env->last_env_action = action;
     }
 
-    chainenv_apply_single_orb(env, board_idx, player);
-    chainenv_record_snapshot(env, start_delay + CHAINENV_PLACEMENT_DURATION);
-    return chainenv_resolve_chain(env, player, start_delay + CHAINENV_PLACEMENT_DURATION);
+    place_orb(env, board_idx, player);
+    if (env->client != NULL) {
+        record_snapshot(env, start_delay + PLACEMENT_DURATION);
+    }
+    start_delay += PLACEMENT_DURATION;
+    ResolveStats stats = {.end_time = start_delay};
+    bool render = env->client != NULL;
+    int recorded_waves = 0;
+    bool truncated_render = false;
+
+    for (int wave = 0;; wave++) {
+        uint8_t unstable[MAX_CELLS];
+        int unstable_count = 0;
+
+        for (int action = 0; action < env->rows * env->cols; action++) {
+            int idx = env->action_cell[action];
+            if (env->owner[idx] == player && env->orbs[idx] >= env->critical_mass[idx]) {
+                unstable[unstable_count++] = idx;
+            }
+        }
+
+        if (unstable_count == 0) {
+            break;
+        }
+
+        bool record_wave = render && wave < MAX_RENDER_WAVES;
+        float delay = start_delay + recorded_waves * WAVE_DELAY;
+        for (int i = 0; i < unstable_count; i++) {
+            int idx = unstable[i];
+            env->orbs[idx] -= env->critical_mass[idx];
+            if (env->orbs[idx] == 0) {
+                env->owner[idx] = 0;
+            }
+
+            stats.bursts += 1;
+            if (record_wave) {
+                Client* client = env->client;
+                if (client->burst_count < MAX_RENDER_BURSTS) {
+                    client->bursts[client->burst_count++] = (BurstAnim) {
+                        .row = idx / MAX_COLS,
+                        .col = idx % MAX_COLS,
+                        .color = player,
+                        .delay = delay,
+                        .duration = BURST_DURATION,
+                    };
+                }
+                float end_time = delay + BURST_DURATION;
+                if (end_time > client->animation_total) {
+                    client->animation_total = end_time;
+                }
+            }
+        }
+
+        for (int i = 0; i < unstable_count; i++) {
+            int idx = unstable[i];
+            for (int n = 0; n < env->neighbor_count[idx]; n++) {
+                int neighbor = env->neighbors[idx][n];
+                place_orb(env, neighbor, player);
+                if (record_wave) {
+                    Client* client = env->client;
+                    if (client->transfer_count < MAX_RENDER_TRANSFERS) {
+                        client->transfers[client->transfer_count++] = (OrbTransferAnim) {
+                            .src_row = idx / MAX_COLS,
+                            .src_col = idx % MAX_COLS,
+                            .dst_row = neighbor / MAX_COLS,
+                            .dst_col = neighbor % MAX_COLS,
+                            .color = player,
+                            .delay = delay,
+                            .duration = TRANSFER_DURATION,
+                        };
+                    }
+                    float end_time = delay + TRANSFER_DURATION;
+                    if (end_time > client->animation_total) {
+                        client->animation_total = end_time;
+                    }
+                }
+            }
+        }
+
+        if (record_wave) {
+            float reveal_time = delay + fmaxf(BURST_DURATION, TRANSFER_DURATION);
+            record_snapshot(env, reveal_time);
+            stats.end_time = reveal_time;
+            recorded_waves += 1;
+        } else if (render) {
+            truncated_render = true;
+        }
+
+        // Match the mobile game: once a player has been wiped out after both
+        // sides have taken at least one turn, the move ends immediately instead
+        // of continuing a single-color avalanche.
+        if (env->turns_taken[0] > 0 && env->turns_taken[1] > 0) {
+            bool red_present = false;
+            bool green_present = false;
+            for (int action = 0; action < env->rows * env->cols; action++) {
+                int owner = env->owner[env->action_cell[action]];
+                red_present |= owner == RED_PLAYER;
+                green_present |= owner == GREEN_PLAYER;
+                if (red_present && green_present) {
+                    break;
+                }
+            }
+            if (red_present && !green_present) {
+                stats.winner = RED_PLAYER;
+            } else if (green_present && !red_present) {
+                stats.winner = GREEN_PLAYER;
+            }
+            if (stats.winner != 0) {
+                break;
+            }
+        }
+    }
+
+    if (truncated_render) {
+        float final_time = start_delay
+            + recorded_waves * WAVE_DELAY
+            + fmaxf(BURST_DURATION, TRANSFER_DURATION);
+        record_snapshot(env, final_time);
+        stats.end_time = final_time;
+    }
+
+    return stats;
 }
 
-static inline void chainenv_maybe_open_scripted_duel(ChainEnv* env) {
-    if (chainenv_is_selfplay(env)) {
-        return;
+static void init(ChainEnv* env) {
+    for (int action = 0; action < env->rows * env->cols; action++) {
+        int row = action / env->cols;
+        int col = action % env->cols;
+        int idx = board_index(row, col);
+        env->action_cell[action] = idx;
+
+        uint8_t* neighbors = env->neighbors[idx];
+        int count = 0;
+        if (row > 0) {
+            neighbors[count++] = board_index(row - 1, col);
+        }
+        if (row + 1 < env->rows) {
+            neighbors[count++] = board_index(row + 1, col);
+        }
+        if (col > 0) {
+            neighbors[count++] = board_index(row, col - 1);
+        }
+        if (col + 1 < env->cols) {
+            neighbors[count++] = board_index(row, col + 1);
+        }
+        env->neighbor_count[idx] = count;
+        env->critical_mass[idx] = count;
     }
 
-    env->current_player = CHAINENV_PLAYER_RED;
-    if ((rand_r(&env->rng) & 1u) == 0u) {
-        return;
+    // Stable cells hold at most critical_mass - 1 orbs.
+    int stable_capacity = 3 * env->rows * env->cols - 2 * env->rows - 2 * env->cols;
+    if (env->max_steps > stable_capacity) {
+        env->max_steps = stable_capacity;
     }
-
-    int env_action = chainenv_choose_env_action(env);
-    if (env_action < 0) {
-        return;
-    }
-
-    chainenv_begin_animation(env);
-    ResolveStats env_stats = chainenv_execute_turn(env, CHAINENV_PLAYER_GREEN, env_action, 0.0f);
-    env->last_chain_bursts = env_stats.bursts;
-    env->current_player = CHAINENV_PLAYER_RED;
-}
-
-static inline void init_chainenv(ChainEnv* env) {
-    int stable_capacity = chainenv_stable_capacity(env);
-    if (env->max_steps > stable_capacity) env->max_steps = stable_capacity;
     env->tick = 0;
     env->move_count = 0;
     env->end_game = 0;
     env->turns_taken[0] = 0;
     env->turns_taken[1] = 0;
-    env->current_player = CHAINENV_PLAYER_RED;
+    env->current_player = RED_PLAYER;
     env->last_player_action = -1;
     env->last_env_action = -1;
     env->last_chain_bursts = 0;
     env->winner = 0;
-    chainenv_set_slot_players(env, CHAINENV_PLAYER_RED, CHAINENV_PLAYER_GREEN);
-    chainenv_reset_render_animations(env);
+    set_slot_players(env, RED_PLAYER, GREEN_PLAYER);
 }
 
-static inline void c_close(ChainEnv* env) {
+static void c_close(ChainEnv* env) {
     if (env->client != NULL) {
         if (IsWindowReady()) {
             CloseWindow();
@@ -846,7 +687,7 @@ static inline void c_close(ChainEnv* env) {
     }
 }
 
-static inline void c_reset(ChainEnv* env) {
+static void c_reset(ChainEnv* env) {
     memset(env->owner, 0, sizeof(env->owner));
     memset(env->orbs, 0, sizeof(env->orbs));
     env->tick = 0;
@@ -854,23 +695,40 @@ static inline void c_reset(ChainEnv* env) {
     env->end_game = 0;
     env->turns_taken[0] = 0;
     env->turns_taken[1] = 0;
-    env->current_player = CHAINENV_PLAYER_RED;
+    env->current_player = RED_PLAYER;
     env->last_player_action = -1;
     env->last_env_action = -1;
     env->last_chain_bursts = 0;
     env->winner = 0;
-    chainenv_reset_slot_mapping(env);
-    chainenv_zero_outputs(env);
-    chainenv_reset_render_animations(env);
-    chainenv_clear_invalid_hint(env);
-    chainenv_maybe_open_scripted_duel(env);
-    chainenv_compute_observations(env);
-    chainenv_update_action_mask(env);
+    if (is_selfplay(env) && (rand_r(&env->rng) & 1) != 0) {
+        set_slot_players(env, GREEN_PLAYER, RED_PLAYER);
+    } else {
+        set_slot_players(env, RED_PLAYER, GREEN_PLAYER);
+    }
+    zero_outputs(env);
+    if (env->client != NULL) {
+        reset_animations(env->client);
+        clear_invalid_hint(env->client);
+    }
+
+    if (!is_selfplay(env) && (rand_r(&env->rng) & 1u) != 0u) {
+        int opponent_action = choose_opponent_action(env);
+        if (env->client != NULL) {
+            begin_animation(env);
+        }
+        ResolveStats stats = execute_turn(
+            env, GREEN_PLAYER, opponent_action, 0.0f);
+        env->last_chain_bursts = stats.bursts;
+        env->current_player = RED_PLAYER;
+    }
+
+    compute_observations(env);
+    compute_action_masks(env);
 }
 
-static inline void c_step(ChainEnv* env) {
+static void c_step(ChainEnv* env) {
     env->tick += 1;
-    chainenv_zero_outputs(env);
+    zero_outputs(env);
 
     if (env->end_game) {
         c_reset(env);
@@ -879,93 +737,91 @@ static inline void c_step(ChainEnv* env) {
 
     env->last_chain_bursts = 0;
 
-    if (chainenv_is_selfplay(env)) {
-        int active_slot = chainenv_slot_for_player(env, env->current_player);
+    if (is_selfplay(env)) {
+        int active_slot = slot_for_player(env, env->current_player);
         int action = (int)*env->action_ptr[active_slot];
-        if (env->current_player == CHAINENV_PLAYER_RED) {
+        if (env->current_player == RED_PLAYER) {
             env->last_player_action = action;
         } else {
             env->last_env_action = action;
         }
 
-        if (!chainenv_is_legal_move(env, action, env->current_player)) {
-            chainenv_compute_observations(env);
-            chainenv_finish_game(env, -env->current_player, env->current_player);
+        if (!is_legal_move(env, action, env->current_player)) {
+            compute_observations(env);
+            finish_game(env, -env->current_player, env->current_player);
             return;
         }
 
-        chainenv_begin_animation(env);
-        ResolveStats stats = chainenv_execute_turn(env, env->current_player, action, 0.0f);
+        if (env->client != NULL) {
+            begin_animation(env);
+        }
+        ResolveStats stats = execute_turn(env, env->current_player, action, 0.0f);
         env->last_chain_bursts = stats.bursts;
 
-        int winner = chainenv_check_winner(env);
+        int winner = stats.winner;
         if (winner == 0 && env->move_count >= env->max_steps) {
-            winner = chainenv_timeout_winner(env);
+            winner = timeout_winner(env);
         }
 
         if (winner != 0 || env->move_count >= env->max_steps) {
-            chainenv_compute_observations(env);
-            chainenv_finish_game(env, winner, 0);
+            compute_observations(env);
+            finish_game(env, winner, 0);
             return;
         }
 
         env->current_player = -env->current_player;
-        chainenv_compute_observations(env);
-        chainenv_update_action_mask(env);
+        compute_observations(env);
+        compute_action_masks(env);
         return;
     }
 
     int action = (int)*env->action_ptr[0];
     env->last_env_action = -1;
-    if (!chainenv_is_legal_move(env, action, CHAINENV_PLAYER_RED)) {
+    if (!is_legal_move(env, action, RED_PLAYER)) {
         env->last_player_action = action;
-        chainenv_compute_observations(env);
-        chainenv_finish_game(env, CHAINENV_PLAYER_GREEN, CHAINENV_PLAYER_RED);
+        compute_observations(env);
+        finish_game(env, GREEN_PLAYER, RED_PLAYER);
         return;
     }
 
-    chainenv_begin_animation(env);
-    ResolveStats player_stats = chainenv_execute_turn(env, CHAINENV_PLAYER_RED, action, 0.0f);
+    if (env->client != NULL) {
+        begin_animation(env);
+    }
+    ResolveStats player_stats = execute_turn(env, RED_PLAYER, action, 0.0f);
     env->last_chain_bursts = player_stats.bursts;
 
-    int winner = chainenv_check_winner(env);
+    int winner = player_stats.winner;
     if (winner == 0 && env->move_count >= env->max_steps) {
-        winner = chainenv_timeout_winner(env);
+        winner = timeout_winner(env);
     }
     if (winner != 0 || env->move_count >= env->max_steps) {
-        chainenv_compute_observations(env);
-        chainenv_finish_game(env, winner, 0);
+        compute_observations(env);
+        finish_game(env, winner, 0);
         return;
     }
 
-    int env_action = chainenv_choose_env_action(env);
-    if (env_action < 0) {
-        chainenv_compute_observations(env);
-        chainenv_finish_game(env, CHAINENV_PLAYER_RED, 0);
-        return;
-    }
-
-    float env_start = player_stats.end_time + CHAINENV_TURN_GAP;
-    ResolveStats env_stats = chainenv_execute_turn(
-        env, CHAINENV_PLAYER_GREEN, env_action, env_start);
+    int env_action = choose_opponent_action(env);
+    float env_start = player_stats.end_time + TURN_GAP;
+    ResolveStats env_stats = execute_turn(
+        env, GREEN_PLAYER, env_action, env_start);
     env->last_chain_bursts += env_stats.bursts;
 
-    winner = chainenv_check_winner(env);
+    winner = env_stats.winner;
     if (winner == 0 && env->move_count >= env->max_steps) {
-        winner = chainenv_timeout_winner(env);
+        winner = timeout_winner(env);
     }
-    env->current_player = CHAINENV_PLAYER_RED;
-    chainenv_compute_observations(env);
+    env->current_player = RED_PLAYER;
+    compute_observations(env);
     if (winner != 0 || env->move_count >= env->max_steps) {
-        chainenv_finish_game(env, winner, 0);
+        finish_game(env, winner, 0);
         return;
     }
 
-    chainenv_update_action_mask(env);
+    compute_action_masks(env);
 }
 
-static inline Client* make_client(void) {
-    Client* client = (Client*)calloc(1, sizeof(Client));
+static Client* make_client(void) {
+    Client* client = calloc(1, sizeof(Client));
     client->screen_width = 980;
     client->screen_height = 860;
 
@@ -975,31 +831,27 @@ static inline Client* make_client(void) {
     return client;
 }
 
-static inline Color chainenv_player_color(int player) {
-    return player == CHAINENV_PLAYER_RED
+static Color player_color(int player) {
+    return player == RED_PLAYER
         ? (Color){255, 80, 88, 255}
         : (Color){77, 231, 125, 255};
 }
 
-static inline Color chainenv_dim_color(Color color, float factor) {
-    return (Color) {
-        (unsigned char)fminf(255.0f, color.r * factor),
-        (unsigned char)fminf(255.0f, color.g * factor),
-        (unsigned char)fminf(255.0f, color.b * factor),
-        color.a,
-    };
-}
-
-static inline float chainenv_ease_out(float t) {
+static float ease_out(float t) {
     float inv = 1.0f - t;
     return 1.0f - inv * inv * inv;
 }
 
-static inline void chainenv_draw_glossy_orb(Vector2 center, float radius, Color color, float alpha) {
+static void draw_orb(Vector2 center, float radius, Color color, float alpha) {
     Color shadow = (Color){0, 0, 0, (unsigned char)(100.0f * alpha)};
     Color base = color;
     base.a = (unsigned char)(255.0f * alpha);
-    Color dark = chainenv_dim_color(color, 0.60f);
+    Color dark = (Color) {
+        (unsigned char)(color.r * 0.60f),
+        (unsigned char)(color.g * 0.60f),
+        (unsigned char)(color.b * 0.60f),
+        color.a,
+    };
     dark.a = (unsigned char)(220.0f * alpha);
     Color highlight = (Color){255, 255, 255, (unsigned char)(180.0f * alpha)};
 
@@ -1009,267 +861,7 @@ static inline void chainenv_draw_glossy_orb(Vector2 center, float radius, Color 
     DrawCircleV((Vector2){center.x - radius * 0.30f, center.y - radius * 0.34f}, radius * 0.32f, highlight);
 }
 
-static inline void chainenv_draw_stack(
-        Client* client, int row, int col, int owner, int count, float time) {
-    if (owner == 0 || count <= 0) {
-        return;
-    }
-
-    float cx = client->board_x + (col + 0.5f) * client->cell_size;
-    float cy = client->board_y + (row + 0.5f) * client->cell_size;
-    float orbit = client->cell_size * 0.12f;
-    float radius = client->cell_size * 0.18f;
-    Color color = chainenv_player_color(owner);
-
-    if (count == 1) {
-        chainenv_draw_glossy_orb((Vector2){cx, cy}, radius, color, 1.0f);
-        return;
-    }
-
-    float speed = owner == CHAINENV_PLAYER_RED ? CHAINENV_RED_ORBIT_SPEED : CHAINENV_GREEN_ORBIT_SPEED;
-    for (int i = 0; i < count; i++) {
-        float angle = time * speed + ((2.0f * PI) * i) / (float)count;
-        float ox = cosf(angle) * orbit;
-        float oy = sinf(angle) * orbit * 0.65f;
-        chainenv_draw_glossy_orb((Vector2){cx + ox, cy + oy}, radius * 0.92f, color, 1.0f);
-    }
-}
-
-static inline void chainenv_get_display_board(
-        const ChainEnv* env, const Client* client, int* display_owner, int* display_orbs) {
-    chainenv_copy_board(display_owner, display_orbs, env->owner, env->orbs);
-    if (client == NULL || client->snapshot_count == 0) {
-        return;
-    }
-
-    chainenv_copy_board(display_owner, display_orbs, client->base_owner, client->base_orbs);
-    for (int i = 0; i < client->snapshot_count; i++) {
-        if (client->snapshot_time[i] > client->animation_clock + 1.0e-4f) {
-            break;
-        }
-
-        chainenv_copy_board(
-            display_owner,
-            display_orbs,
-            client->snapshot_owner[i],
-            client->snapshot_orbs[i]);
-    }
-}
-
-static inline void chainenv_draw_board(ChainEnv* env, Client* client) {
-    Color bg = (Color){7, 20, 25, 255};
-    Color frame = (Color){16, 47, 57, 255};
-    Color inner = (Color){18, 69, 84, 255};
-    Color grid_line = (Color){111, 214, 232, 55};
-    int display_owner[CHAINENV_MAX_CELLS];
-    int display_orbs[CHAINENV_MAX_CELLS];
-
-    DrawRectangleGradientV(0, 0, client->screen_width, client->screen_height,
-        (Color){4, 12, 18, 255}, bg);
-
-    float board_w = client->cell_size * env->cols;
-    float board_h = client->cell_size * env->rows;
-    DrawRectangleRounded(
-        (Rectangle){client->board_x - 22, client->board_y - 22, board_w + 44, board_h + 44},
-        0.08f, 24, frame);
-    DrawRectangleRounded(
-        (Rectangle){client->board_x - 8, client->board_y - 8, board_w + 16, board_h + 16},
-        0.05f, 24, inner);
-
-    float time = (float)GetTime();
-    chainenv_get_display_board(env, client, display_owner, display_orbs);
-    for (int row = 0; row < env->rows; row++) {
-        for (int col = 0; col < env->cols; col++) {
-            float x = client->board_x + col * client->cell_size;
-            float y = client->board_y + row * client->cell_size;
-            Rectangle cell = {x, y, client->cell_size, client->cell_size};
-            DrawRectangleRounded(cell, 0.14f, 12, (Color){14, 44, 55, 255});
-            DrawRectangleRounded(
-                (Rectangle){x + 3, y + 3, client->cell_size - 6, client->cell_size - 6},
-                0.14f, 12, (Color){11, 33, 42, 255});
-            DrawRectangleLinesEx(
-                (Rectangle){x + 1, y + 1, client->cell_size - 2, client->cell_size - 2},
-                1.0f, grid_line);
-
-            int idx = chainenv_slot(row, col);
-            int critical = chainenv_critical_mass(env, row, col);
-            char label[8];
-            snprintf(label, sizeof(label), "%d", critical);
-            DrawText(
-                label,
-                (int)(x + client->cell_size - 16),
-                (int)(y + 8),
-                (int)(client->cell_size * 0.16f),
-                (Color){176, 228, 233, 135});
-
-            chainenv_draw_stack(client, row, col, display_owner[idx], display_orbs[idx], time);
-        }
-    }
-}
-
-static inline void chainenv_draw_effects(ChainEnv* env, Client* client) {
-    float t = client->animation_clock;
-    for (int i = 0; i < client->burst_count; i++) {
-        BurstAnim* burst = &client->bursts[i];
-        float local = t - burst->delay;
-        if (local < 0.0f || local > burst->duration) {
-            continue;
-        }
-
-        float p = local / burst->duration;
-        float eased = chainenv_ease_out(p);
-        float cx = client->board_x + (burst->col + 0.5f) * client->cell_size;
-        float cy = client->board_y + (burst->row + 0.5f) * client->cell_size;
-        Color color = chainenv_player_color(burst->color);
-        color.a = (unsigned char)(150.0f * (1.0f - p));
-        DrawRing((Vector2){cx, cy},
-            client->cell_size * (0.10f + eased * 0.02f),
-            client->cell_size * (0.24f + eased * 0.30f),
-            0.0f, 360.0f, 32, color);
-    }
-
-    for (int i = 0; i < client->transfer_count; i++) {
-        OrbTransferAnim* anim = &client->transfers[i];
-        float local = t - anim->delay;
-        if (local < 0.0f || local > anim->duration) {
-            continue;
-        }
-
-        float p = chainenv_ease_out(local / anim->duration);
-        float src_x = client->board_x + (anim->src_col + 0.5f) * client->cell_size;
-        float src_y = client->board_y + (anim->src_row + 0.5f) * client->cell_size;
-        float dst_x = client->board_x + (anim->dst_col + 0.5f) * client->cell_size;
-        float dst_y = client->board_y + (anim->dst_row + 0.5f) * client->cell_size;
-        Vector2 pos = {
-            src_x + (dst_x - src_x) * p,
-            src_y + (dst_y - src_y) * p,
-        };
-        float arc = sinf(p * PI) * client->cell_size * 0.07f;
-        pos.y -= arc;
-        chainenv_draw_glossy_orb(pos, client->cell_size * 0.10f, chainenv_player_color(anim->color), 0.95f);
-    }
-}
-
-static inline void chainenv_draw_hud(ChainEnv* env, Client* client) {
-    int red_total = 0;
-    int green_total = 0;
-    chainenv_recount(env, &red_total, &green_total);
-    const char* mode_label = chainenv_is_selfplay(env) ? "Self-play" : "Scripted duel";
-    const char* red_label = chainenv_is_selfplay(env) ? "Red" : "Red (you)";
-    const char* green_label = chainenv_is_selfplay(env) ? "Green" : "Green (scripted)";
-    float sidebar_x = 32.0f;
-    float sidebar_y = 26.0f;
-    float header_h = 124.0f;
-    float stats_y = sidebar_y + header_h + 8.0f;
-    int stat_label_x = (int)(sidebar_x + 20.0f);
-    int stat_value_x = (int)(sidebar_x + 20.0f);
-    int stat_y = (int)(stats_y + 12.0f);
-    int stat_gap = 42;
-
-    DrawText("Chain Reaction", (int)(sidebar_x + 20.0f), (int)(sidebar_y + 18.0f), 33,
-        (Color){236, 248, 250, 255});
-    DrawText(red_label, (int)(sidebar_x + 22.0f), (int)(sidebar_y + 64.0f), 22,
-        chainenv_player_color(CHAINENV_PLAYER_RED));
-    DrawText(green_label, (int)(sidebar_x + 22.0f), (int)(sidebar_y + 92.0f), 22,
-        chainenv_player_color(CHAINENV_PLAYER_GREEN));
-
-    DrawText("Mode", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
-    DrawText(mode_label, stat_value_x, stat_y + 16, 23, (Color){236, 248, 250, 255});
-    stat_y += stat_gap;
-
-    char board_text[32];
-    snprintf(board_text, sizeof(board_text), "%dx%d", env->rows, env->cols);
-    DrawText("Board", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
-    DrawText(board_text, stat_value_x, stat_y + 16, 23, (Color){236, 248, 250, 255});
-    stat_y += stat_gap;
-
-    char red_text[32];
-    char green_text[32];
-    char burst_text[32];
-    snprintf(red_text, sizeof(red_text), "%d", red_total);
-    snprintf(green_text, sizeof(green_text), "%d", green_total);
-    snprintf(burst_text, sizeof(burst_text), "%d", env->last_chain_bursts);
-
-    DrawText("Red Orbs", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
-    DrawText(red_text, stat_value_x, stat_y + 16, 23, chainenv_player_color(CHAINENV_PLAYER_RED));
-    stat_y += stat_gap;
-
-    DrawText("Green Orbs", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
-    DrawText(green_text, stat_value_x, stat_y + 16, 23, chainenv_player_color(CHAINENV_PLAYER_GREEN));
-    stat_y += stat_gap;
-
-    DrawText("Last Chain Bursts", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
-    DrawText(burst_text, stat_value_x, stat_y + 16, 23, (Color){236, 248, 250, 255});
-    stat_y += stat_gap;
-
-    DrawText("Cell Labels", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
-    DrawText("Critical mass", stat_value_x, stat_y + 16, 22, (Color){210, 233, 239, 255});
-    stat_y += stat_gap;
-
-    if (!chainenv_is_selfplay(env) && client->invalid_hint_time > 0.0f) {
-        DrawText("Invalid Move", stat_label_x, stat_y, 15, (Color){236, 183, 120, 240});
-        DrawText("Place on empty or red cells", stat_value_x, stat_y + 16, 22,
-            (Color){255, 216, 164, 255});
-    }
-
-    if (!env->end_game) {
-        return;
-    }
-
-    const char* result = "Draw";
-    Color result_color = (Color){235, 235, 235, 255};
-    if (env->winner == CHAINENV_PLAYER_RED) {
-        result = "Red Wins";
-        result_color = chainenv_player_color(CHAINENV_PLAYER_RED);
-    } else if (env->winner == CHAINENV_PLAYER_GREEN) {
-        result = "Green Wins";
-        result_color = chainenv_player_color(CHAINENV_PLAYER_GREEN);
-    }
-
-    float board_w = client->cell_size * env->cols;
-    float board_h = client->cell_size * env->rows;
-    int center_x = (int)(client->board_x + board_w * 0.5f);
-    int center_y = (int)(client->board_y + board_h * 0.5f);
-    int font_size = 52;
-    int msg_width = MeasureText(result, font_size);
-    DrawText(result,
-        center_x - msg_width / 2,
-        center_y - 48,
-        font_size, result_color);
-    const char* reset_text = "Click anywhere to reset";
-    int reset_width = MeasureText(reset_text, 24);
-    DrawText(reset_text,
-        center_x - reset_width / 2,
-        center_y + 18,
-        24, (Color){240, 240, 240, 230});
-}
-
-static inline int chainenv_pick_action(const ChainEnv* env, const Client* client, Vector2 mouse) {
-    float board_w = client->cell_size * env->cols;
-    float board_h = client->cell_size * env->rows;
-    if (mouse.x < client->board_x || mouse.x >= client->board_x + board_w ||
-            mouse.y < client->board_y || mouse.y >= client->board_y + board_h) {
-        return -1;
-    }
-
-    int col = (int)((mouse.x - client->board_x) / client->cell_size);
-    int row = (int)((mouse.y - client->board_y) / client->cell_size);
-    if (!chainenv_cell_active(env, row, col)) {
-        return -1;
-    }
-
-    return row * env->cols + col;
-}
-
-static inline bool chainenv_animation_active(const ChainEnv* env) {
-    if (env->client == NULL) {
-        return false;
-    }
-
-    return env->client->animation_clock < env->client->animation_total - 1.0e-4f;
-}
-
-static inline void c_render(ChainEnv* env) {
+static void c_render(ChainEnv* env) {
     if (env->client == NULL) {
         env->client = make_client();
     }
@@ -1284,7 +876,7 @@ static inline void c_render(ChainEnv* env) {
         exit(0);
     }
 
-    chainenv_layout_board(env->client, env);
+    layout_board(env);
     float dt = GetFrameTime();
     env->client->invalid_hint_time = fmaxf(0.0f, env->client->invalid_hint_time - dt);
     env->client->animation_clock = fminf(
@@ -1292,8 +884,230 @@ static inline void c_render(ChainEnv* env) {
         env->client->animation_clock + dt);
 
     BeginDrawing();
-    chainenv_draw_board(env, env->client);
-    chainenv_draw_effects(env, env->client);
-    chainenv_draw_hud(env, env->client);
+    {
+        Client* client = env->client;
+        Color bg = (Color){7, 20, 25, 255};
+        Color frame = (Color){16, 47, 57, 255};
+        Color inner = (Color){18, 69, 84, 255};
+        Color grid_line = (Color){111, 214, 232, 55};
+        int8_t display_owner[MAX_CELLS];
+        uint16_t display_orbs[MAX_CELLS];
+
+        DrawRectangleGradientV(0, 0, client->screen_width, client->screen_height,
+            (Color){4, 12, 18, 255}, bg);
+
+        float board_w = client->cell_size * env->cols;
+        float board_h = client->cell_size * env->rows;
+        DrawRectangleRounded(
+            (Rectangle){client->board_x - 22, client->board_y - 22, board_w + 44, board_h + 44},
+            0.08f, 24, frame);
+        DrawRectangleRounded(
+            (Rectangle){client->board_x - 8, client->board_y - 8, board_w + 16, board_h + 16},
+            0.05f, 24, inner);
+
+        float time = (float)GetTime();
+        copy_render_board(display_owner, display_orbs, env->owner, env->orbs);
+        if (client->snapshot_count > 0) {
+            copy_render_board(display_owner, display_orbs, client->base_owner, client->base_orbs);
+            for (int i = 0; i < client->snapshot_count; i++) {
+                if (client->snapshot_time[i] > client->animation_clock + 1.0e-4f) {
+                    break;
+                }
+                copy_render_board(
+                    display_owner,
+                    display_orbs,
+                    client->snapshot_owner[i],
+                    client->snapshot_orbs[i]);
+            }
+        }
+
+        for (int row = 0; row < env->rows; row++) {
+            for (int col = 0; col < env->cols; col++) {
+                float x = client->board_x + col * client->cell_size;
+                float y = client->board_y + row * client->cell_size;
+                Rectangle cell = {x, y, client->cell_size, client->cell_size};
+                DrawRectangleRounded(cell, 0.14f, 12, (Color){14, 44, 55, 255});
+                DrawRectangleRounded(
+                    (Rectangle){x + 3, y + 3, client->cell_size - 6, client->cell_size - 6},
+                    0.14f, 12, (Color){11, 33, 42, 255});
+                DrawRectangleLinesEx(
+                    (Rectangle){x + 1, y + 1, client->cell_size - 2, client->cell_size - 2},
+                    1.0f, grid_line);
+
+                int idx = board_index(row, col);
+                int critical = env->critical_mass[idx];
+                char label[8];
+                snprintf(label, sizeof(label), "%d", critical);
+                DrawText(
+                    label,
+                    (int)(x + client->cell_size - 16),
+                    (int)(y + 8),
+                    (int)(client->cell_size * 0.16f),
+                    (Color){176, 228, 233, 135});
+
+                int owner = display_owner[idx];
+                int count = display_orbs[idx];
+                if (owner != 0) {
+                    float cx = client->board_x + (col + 0.5f) * client->cell_size;
+                    float cy = client->board_y + (row + 0.5f) * client->cell_size;
+                    float radius = client->cell_size * 0.18f;
+                    Color color = player_color(owner);
+                    if (count == 1) {
+                        draw_orb((Vector2){cx, cy}, radius, color, 1.0f);
+                    } else {
+                        float orbit = client->cell_size * 0.12f;
+                        float speed = owner == RED_PLAYER
+                            ? RED_ORBIT_SPEED
+                            : GREEN_ORBIT_SPEED;
+                        for (int i = 0; i < count; i++) {
+                            float angle = time * speed + 2.0f * PI * i / count;
+                            float ox = cosf(angle) * orbit;
+                            float oy = sinf(angle) * orbit * 0.65f;
+                            draw_orb(
+                                (Vector2){cx + ox, cy + oy},
+                                radius * 0.92f,
+                                color,
+                                1.0f);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    {
+        Client* client = env->client;
+        float t = client->animation_clock;
+        for (int i = 0; i < client->burst_count; i++) {
+            BurstAnim* burst = &client->bursts[i];
+            float local = t - burst->delay;
+            if (local < 0.0f || local > burst->duration) {
+                continue;
+            }
+
+            float p = local / burst->duration;
+            float eased = ease_out(p);
+            float cx = client->board_x + (burst->col + 0.5f) * client->cell_size;
+            float cy = client->board_y + (burst->row + 0.5f) * client->cell_size;
+            Color color = player_color(burst->color);
+            color.a = (unsigned char)(150.0f * (1.0f - p));
+            DrawRing((Vector2){cx, cy},
+                client->cell_size * (0.10f + eased * 0.02f),
+                client->cell_size * (0.24f + eased * 0.30f),
+                0.0f, 360.0f, 32, color);
+        }
+
+        for (int i = 0; i < client->transfer_count; i++) {
+            OrbTransferAnim* anim = &client->transfers[i];
+            float local = t - anim->delay;
+            if (local < 0.0f || local > anim->duration) {
+                continue;
+            }
+
+            float p = ease_out(local / anim->duration);
+            float src_x = client->board_x + (anim->src_col + 0.5f) * client->cell_size;
+            float src_y = client->board_y + (anim->src_row + 0.5f) * client->cell_size;
+            float dst_x = client->board_x + (anim->dst_col + 0.5f) * client->cell_size;
+            float dst_y = client->board_y + (anim->dst_row + 0.5f) * client->cell_size;
+            Vector2 pos = {
+                src_x + (dst_x - src_x) * p,
+                src_y + (dst_y - src_y) * p,
+            };
+            float arc = sinf(p * PI) * client->cell_size * 0.07f;
+            pos.y -= arc;
+            draw_orb(pos, client->cell_size * 0.10f, player_color(anim->color), 0.95f);
+        }
+    }
+    {
+        Client* client = env->client;
+        int red_total = 0;
+        int green_total = 0;
+        count_orbs(env, &red_total, &green_total);
+        const char* mode_label = is_selfplay(env) ? "Self-play" : "Scripted duel";
+        const char* red_label = is_selfplay(env) ? "Red" : "Red (you)";
+        const char* green_label = is_selfplay(env) ? "Green" : "Green (scripted)";
+        float sidebar_x = 32.0f;
+        float sidebar_y = 26.0f;
+        float header_h = 124.0f;
+        float stats_y = sidebar_y + header_h + 8.0f;
+        int stat_label_x = (int)(sidebar_x + 20.0f);
+        int stat_value_x = (int)(sidebar_x + 20.0f);
+        int stat_y = (int)(stats_y + 12.0f);
+        int stat_gap = 42;
+
+        DrawText("Chain Reaction", (int)(sidebar_x + 20.0f), (int)(sidebar_y + 18.0f), 33,
+            (Color){236, 248, 250, 255});
+        DrawText(red_label, (int)(sidebar_x + 22.0f), (int)(sidebar_y + 64.0f), 22,
+            player_color(RED_PLAYER));
+        DrawText(green_label, (int)(sidebar_x + 22.0f), (int)(sidebar_y + 92.0f), 22,
+            player_color(GREEN_PLAYER));
+
+        DrawText("Mode", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
+        DrawText(mode_label, stat_value_x, stat_y + 16, 23, (Color){236, 248, 250, 255});
+        stat_y += stat_gap;
+
+        char board_text[32];
+        snprintf(board_text, sizeof(board_text), "%dx%d", env->rows, env->cols);
+        DrawText("Board", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
+        DrawText(board_text, stat_value_x, stat_y + 16, 23, (Color){236, 248, 250, 255});
+        stat_y += stat_gap;
+
+        char red_text[32];
+        char green_text[32];
+        char burst_text[32];
+        snprintf(red_text, sizeof(red_text), "%d", red_total);
+        snprintf(green_text, sizeof(green_text), "%d", green_total);
+        snprintf(burst_text, sizeof(burst_text), "%d", env->last_chain_bursts);
+
+        DrawText("Red Orbs", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
+        DrawText(red_text, stat_value_x, stat_y + 16, 23, player_color(RED_PLAYER));
+        stat_y += stat_gap;
+
+        DrawText("Green Orbs", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
+        DrawText(green_text, stat_value_x, stat_y + 16, 23, player_color(GREEN_PLAYER));
+        stat_y += stat_gap;
+
+        DrawText("Last Chain Bursts", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
+        DrawText(burst_text, stat_value_x, stat_y + 16, 23, (Color){236, 248, 250, 255});
+        stat_y += stat_gap;
+
+        DrawText("Cell Labels", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
+        DrawText("Critical mass", stat_value_x, stat_y + 16, 22, (Color){210, 233, 239, 255});
+        stat_y += stat_gap;
+
+        if (!is_selfplay(env) && client->invalid_hint_time > 0.0f) {
+            DrawText("Invalid Move", stat_label_x, stat_y, 15, (Color){236, 183, 120, 240});
+            DrawText("Place on empty or red cells", stat_value_x, stat_y + 16, 22,
+                (Color){255, 216, 164, 255});
+        }
+
+        if (env->end_game) {
+            const char* result = "Draw";
+            Color result_color = (Color){235, 235, 235, 255};
+            if (env->winner == RED_PLAYER) {
+                result = "Red Wins";
+                result_color = player_color(RED_PLAYER);
+            } else if (env->winner == GREEN_PLAYER) {
+                result = "Green Wins";
+                result_color = player_color(GREEN_PLAYER);
+            }
+
+            float board_w = client->cell_size * env->cols;
+            float board_h = client->cell_size * env->rows;
+            int center_x = (int)(client->board_x + board_w * 0.5f);
+            int center_y = (int)(client->board_y + board_h * 0.5f);
+            int font_size = 52;
+            int msg_width = MeasureText(result, font_size);
+            DrawText(result,
+                center_x - msg_width / 2,
+                center_y - 48,
+                font_size, result_color);
+            const char* reset_text = "Click anywhere to reset";
+            int reset_width = MeasureText(reset_text, 24);
+            DrawText(reset_text,
+                center_x - reset_width / 2,
+                center_y + 18,
+                24, (Color){240, 240, 240, 230});
+        }
+    }
     EndDrawing();
 }

--- a/ocean/chain_reaction/chain_reaction.h
+++ b/ocean/chain_reaction/chain_reaction.h
@@ -133,9 +133,6 @@ typedef struct {
     int turns_taken[2];
     int current_player;
     int player_for_slot[MAX_SLOTS];
-    int slot_for_player[MAX_SLOTS];
-    int last_player_action;
-    int last_env_action;
     int last_chain_bursts;
     int winner;
     // Selfplay-pool tagging. tag = 0 means pure selfplay; tag = 1..N means
@@ -159,21 +156,6 @@ static bool is_selfplay(ChainEnv* env) {
     return env->num_agents > 1;
 }
 
-static int slot_for_player(ChainEnv* env, int player) {
-    return env->slot_for_player[player_index(player)];
-}
-
-static int player_for_slot(ChainEnv* env, int slot) {
-    return env->player_for_slot[slot];
-}
-
-static void set_slot_players(ChainEnv* env, int slot0_player, int slot1_player) {
-    env->player_for_slot[0] = slot0_player;
-    env->player_for_slot[1] = slot1_player;
-    env->slot_for_player[player_index(slot0_player)] = 0;
-    env->slot_for_player[player_index(slot1_player)] = 1;
-}
-
 // Rendering snapshots whole board states so chain waves can be replayed visually.
 static void copy_render_board(
         int8_t* dst_owner, uint16_t* dst_orbs,
@@ -182,31 +164,12 @@ static void copy_render_board(
     memcpy(dst_orbs, src_orbs, sizeof(uint16_t) * MAX_CELLS);
 }
 
-static void layout_board(ChainEnv* env) {
-    Client* client = env->client;
-    float sidebar_w = fminf(250.0f, (float)client->screen_width * 0.26f);
-    float gutter = fmaxf(30.0f, (float)client->screen_width * 0.04f);
-    float board_area_x = sidebar_w + gutter;
-    float board_area_w = fmaxf(260.0f, (float)client->screen_width - board_area_x - gutter);
-    float available_h = (float)client->screen_height - 150.0f;
-    float cell_size = fminf((board_area_w - 8.0f) / (float)env->cols, available_h / (float)env->rows);
-    cell_size = fmaxf(cell_size, 48.0f);
-
-    client->cell_size = cell_size;
-    client->board_x = board_area_x + fmaxf(0.0f, (board_area_w - cell_size * env->cols) * 0.5f);
-    client->board_y = ((float)client->screen_height - cell_size * env->rows) * 0.5f + 6.0f;
-}
-
 static void reset_animations(Client* client) {
     client->animation_clock = 0.0f;
     client->animation_total = 0.0f;
     client->snapshot_count = 0;
     client->transfer_count = 0;
     client->burst_count = 0;
-}
-
-static void clear_invalid_hint(Client* client) {
-    client->invalid_hint_time = 0.0f;
 }
 
 static void begin_animation(ChainEnv* env) {
@@ -251,13 +214,6 @@ static void count_orbs(ChainEnv* env, int* red_total, int* green_total) {
     *green_total = green;
 }
 
-static void zero_outputs(ChainEnv* env) {
-    for (int slot = 0; slot < env->num_agents; slot++) {
-        *env->reward_ptr[slot] = 0.0f;
-        *env->terminal_ptr[slot] = 0.0f;
-    }
-}
-
 static bool is_legal_move(ChainEnv* env, int action, int player) {
     if (action < 0 || action >= env->rows * env->cols) {
         return false;
@@ -267,34 +223,54 @@ static bool is_legal_move(ChainEnv* env, int action, int player) {
 }
 
 static void compute_observations(ChainEnv* env) {
+    float* obs0 = env->obs_ptr[0];
+    memset(obs0, 0, OBS_SIZE * sizeof(float));
+    float* obs1 = NULL;
+    if (env->num_agents == 2) {
+        obs1 = env->obs_ptr[1];
+        memset(obs1, 0, OBS_SIZE * sizeof(float));
+    }
+
     int red_total = 0;
     int green_total = 0;
-    count_orbs(env, &red_total, &green_total);
+    int player0 = env->player_for_slot[0];
+    for (int row = 0; row < env->rows; row++) {
+        for (int col = 0; col < env->cols; col++) {
+            int idx = board_index(row, col);
+            int obs_idx = idx * OBS_CHANNELS;
+            int owner = env->owner[idx];
+            int orbs = env->orbs[idx];
+            float mass = env->critical_mass[idx] / 4.0f;
+            red_total += owner == RED_PLAYER ? orbs : 0;
+            green_total += owner == GREEN_PLAYER ? orbs : 0;
 
-    float area = (float)(env->rows * env->cols);
-    for (int slot = 0; slot < env->num_agents; slot++) {
-        float* obs = env->obs_ptr[slot];
-        memset(obs, 0, OBS_SIZE * sizeof(float));
-        int player = player_for_slot(env, slot);
-
-        for (int row = 0; row < env->rows; row++) {
-            for (int col = 0; col < env->cols; col++) {
-                int idx = board_index(row, col);
-                int obs_idx = idx * OBS_CHANNELS;
-                obs[obs_idx + 0] = 1.0f;
-                obs[obs_idx + 1] = env->critical_mass[idx] / 4.0f;
-
-                if (env->owner[idx] == player) {
-                    obs[obs_idx + 2] = env->orbs[idx] / 4.0f;
-                } else if (env->owner[idx] == -player) {
-                    obs[obs_idx + 3] = env->orbs[idx] / 4.0f;
+            obs0[obs_idx + 0] = 1.0f;
+            obs0[obs_idx + 1] = mass;
+            if (obs1 != NULL) {
+                obs1[obs_idx + 0] = 1.0f;
+                obs1[obs_idx + 1] = mass;
+            }
+            if (owner == player0) {
+                obs0[obs_idx + 2] = orbs / 4.0f;
+                if (obs1 != NULL) {
+                    obs1[obs_idx + 3] = orbs / 4.0f;
+                }
+            } else if (owner == -player0) {
+                obs0[obs_idx + 3] = orbs / 4.0f;
+                if (obs1 != NULL) {
+                    obs1[obs_idx + 2] = orbs / 4.0f;
                 }
             }
         }
+    }
 
+    float area = (float)(env->rows * env->cols);
+    int base = MAX_CELLS * OBS_CHANNELS;
+    for (int slot = 0; slot < env->num_agents; slot++) {
+        float* obs = env->obs_ptr[slot];
+        int player = env->player_for_slot[slot];
         int self_total = player == RED_PLAYER ? red_total : green_total;
         int opp_total = player == RED_PLAYER ? green_total : red_total;
-        int base = MAX_CELLS * OBS_CHANNELS;
         obs[base + 0] = env->rows / (float)MAX_ROWS;
         obs[base + 1] = env->cols / (float)MAX_COLS;
         obs[base + 2] = self_total / (area * 4.0f);
@@ -326,7 +302,7 @@ static void compute_action_masks(ChainEnv* env) {
         return;
     }
 
-    int active_slot = slot_for_player(env, env->current_player);
+    int active_slot = env->player_for_slot[0] == env->current_player ? 0 : 1;
     for (int slot = 0; slot < env->num_agents; slot++) {
         unsigned char* mask = env->action_mask_ptr[slot];
         if (slot != active_slot) {
@@ -446,7 +422,7 @@ static int choose_opponent_action(ChainEnv* env) {
 
 static void finish_game(ChainEnv* env, int winner, int invalid_player) {
     for (int slot = 0; slot < env->num_agents; slot++) {
-        int player = player_for_slot(env, slot);
+        int player = env->player_for_slot[slot];
         float reward = env->loss_reward;
         if (winner == 0) {
             reward = 0.0f;
@@ -464,7 +440,7 @@ static void finish_game(ChainEnv* env, int winner, int invalid_player) {
         float primary_score = 0.0f;
         if (winner == 0) {
             primary_score = 0.5f;
-        } else if (player_for_slot(env, 0) == winner) {
+        } else if (env->player_for_slot[0] == winner) {
             primary_score = 1.0f;
         }
         int bank = env->tag - 1;
@@ -490,7 +466,7 @@ static void finish_game(ChainEnv* env, int winner, int invalid_player) {
             env->log.slot_0_score += 0.5f;
             env->log.slot_1_score += 0.5f;
             env->log.draw_rate += 1.0f;
-        } else if (slot_for_player(env, winner) == 0) {
+        } else if (env->player_for_slot[0] == winner) {
             env->log.slot_0_score += 1.0f;
         } else {
             env->log.slot_1_score += 1.0f;
@@ -504,12 +480,6 @@ static ResolveStats execute_turn(
     int board_idx = env->action_cell[action];
     env->turns_taken[player_index(player)] += 1;
     env->move_count += 1;
-    if (player == RED_PLAYER) {
-        env->last_player_action = action;
-    } else {
-        env->last_env_action = action;
-    }
-
     place_orb(env, board_idx, player);
     if (env->client != NULL) {
         record_snapshot(env, start_delay + PLACEMENT_DURATION);
@@ -664,17 +634,6 @@ static void init(ChainEnv* env) {
     if (env->max_steps > stable_capacity) {
         env->max_steps = stable_capacity;
     }
-    env->tick = 0;
-    env->move_count = 0;
-    env->end_game = 0;
-    env->turns_taken[0] = 0;
-    env->turns_taken[1] = 0;
-    env->current_player = RED_PLAYER;
-    env->last_player_action = -1;
-    env->last_env_action = -1;
-    env->last_chain_bursts = 0;
-    env->winner = 0;
-    set_slot_players(env, RED_PLAYER, GREEN_PLAYER);
 }
 
 static void c_close(ChainEnv* env) {
@@ -696,19 +655,22 @@ static void c_reset(ChainEnv* env) {
     env->turns_taken[0] = 0;
     env->turns_taken[1] = 0;
     env->current_player = RED_PLAYER;
-    env->last_player_action = -1;
-    env->last_env_action = -1;
     env->last_chain_bursts = 0;
     env->winner = 0;
     if (is_selfplay(env) && (rand_r(&env->rng) & 1) != 0) {
-        set_slot_players(env, GREEN_PLAYER, RED_PLAYER);
+        env->player_for_slot[0] = GREEN_PLAYER;
+        env->player_for_slot[1] = RED_PLAYER;
     } else {
-        set_slot_players(env, RED_PLAYER, GREEN_PLAYER);
+        env->player_for_slot[0] = RED_PLAYER;
+        env->player_for_slot[1] = GREEN_PLAYER;
     }
-    zero_outputs(env);
+    for (int slot = 0; slot < env->num_agents; slot++) {
+        *env->reward_ptr[slot] = 0.0f;
+        *env->terminal_ptr[slot] = 0.0f;
+    }
     if (env->client != NULL) {
         reset_animations(env->client);
-        clear_invalid_hint(env->client);
+        env->client->invalid_hint_time = 0.0f;
     }
 
     if (!is_selfplay(env) && (rand_r(&env->rng) & 1u) != 0u) {
@@ -728,7 +690,10 @@ static void c_reset(ChainEnv* env) {
 
 static void c_step(ChainEnv* env) {
     env->tick += 1;
-    zero_outputs(env);
+    for (int slot = 0; slot < env->num_agents; slot++) {
+        *env->reward_ptr[slot] = 0.0f;
+        *env->terminal_ptr[slot] = 0.0f;
+    }
 
     if (env->end_game) {
         c_reset(env);
@@ -738,14 +703,8 @@ static void c_step(ChainEnv* env) {
     env->last_chain_bursts = 0;
 
     if (is_selfplay(env)) {
-        int active_slot = slot_for_player(env, env->current_player);
+        int active_slot = env->player_for_slot[0] == env->current_player ? 0 : 1;
         int action = (int)*env->action_ptr[active_slot];
-        if (env->current_player == RED_PLAYER) {
-            env->last_player_action = action;
-        } else {
-            env->last_env_action = action;
-        }
-
         if (!is_legal_move(env, action, env->current_player)) {
             compute_observations(env);
             finish_game(env, -env->current_player, env->current_player);
@@ -776,9 +735,7 @@ static void c_step(ChainEnv* env) {
     }
 
     int action = (int)*env->action_ptr[0];
-    env->last_env_action = -1;
     if (!is_legal_move(env, action, RED_PLAYER)) {
-        env->last_player_action = action;
         compute_observations(env);
         finish_game(env, GREEN_PLAYER, RED_PLAYER);
         return;
@@ -820,17 +777,6 @@ static void c_step(ChainEnv* env) {
     compute_action_masks(env);
 }
 
-static Client* make_client(void) {
-    Client* client = calloc(1, sizeof(Client));
-    client->screen_width = 980;
-    client->screen_height = 860;
-
-    SetConfigFlags(FLAG_MSAA_4X_HINT | FLAG_WINDOW_RESIZABLE);
-    InitWindow(client->screen_width, client->screen_height, "PufferLib Chain Reaction");
-    SetTargetFPS(60);
-    return client;
-}
-
 static Color player_color(int player) {
     return player == RED_PLAYER
         ? (Color){255, 80, 88, 255}
@@ -863,7 +809,15 @@ static void draw_orb(Vector2 center, float radius, Color color, float alpha) {
 
 static void c_render(ChainEnv* env) {
     if (env->client == NULL) {
-        env->client = make_client();
+        env->client = calloc(1, sizeof(Client));
+        env->client->screen_width = 980;
+        env->client->screen_height = 860;
+        SetConfigFlags(FLAG_MSAA_4X_HINT | FLAG_WINDOW_RESIZABLE);
+        InitWindow(
+            env->client->screen_width,
+            env->client->screen_height,
+            "PufferLib Chain Reaction");
+        SetTargetFPS(60);
     }
 
     if (IsWindowReady()) {
@@ -876,7 +830,22 @@ static void c_render(ChainEnv* env) {
         exit(0);
     }
 
-    layout_board(env);
+    Client* client = env->client;
+    float sidebar_w = fminf(250.0f, (float)client->screen_width * 0.26f);
+    float gutter = fmaxf(30.0f, (float)client->screen_width * 0.04f);
+    float board_area_x = sidebar_w + gutter;
+    float board_area_w = fmaxf(
+        260.0f, (float)client->screen_width - board_area_x - gutter);
+    float available_h = (float)client->screen_height - 150.0f;
+    float cell_size = fminf(
+        (board_area_w - 8.0f) / (float)env->cols,
+        available_h / (float)env->rows);
+    client->cell_size = fmaxf(cell_size, 48.0f);
+    client->board_x = board_area_x + fmaxf(
+        0.0f, (board_area_w - client->cell_size * env->cols) * 0.5f);
+    client->board_y = (
+        (float)client->screen_height - client->cell_size * env->rows) * 0.5f + 6.0f;
+
     float dt = GetFrameTime();
     env->client->invalid_hint_time = fmaxf(0.0f, env->client->invalid_hint_time - dt);
     env->client->animation_clock = fminf(

--- a/ocean/chain_reaction/chain_reaction.h
+++ b/ocean/chain_reaction/chain_reaction.h
@@ -1,0 +1,1334 @@
+/* Chain Reaction env core */
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "raylib.h"
+
+#define CHAINENV_MAX_ROWS 9
+#define CHAINENV_MAX_COLS 9
+#define CHAINENV_MAX_CELLS (CHAINENV_MAX_ROWS * CHAINENV_MAX_COLS)
+#define CHAINENV_MAX_ACTIONS (CHAINENV_MAX_CELLS + 1)
+#define CHAINENV_NOOP_ACTION CHAINENV_MAX_CELLS
+#define CHAINENV_MAX_SLOTS 2
+#define CHAINENV_OBS_CHANNELS 4
+#define CHAINENV_GLOBAL_OBS 5
+#define CHAINENV_OBS_SIZE (CHAINENV_MAX_CELLS * CHAINENV_OBS_CHANNELS + CHAINENV_GLOBAL_OBS)
+#define CHAINENV_MAX_RENDER_WAVES 256
+#define CHAINENV_PLAYER_RED 1
+#define CHAINENV_PLAYER_GREEN -1
+#define CHAINENV_OPPONENT_RANDOM 0
+#define CHAINENV_OPPONENT_HEURISTIC 1
+#define CHAINENV_MAX_RENDER_TRANSFERS 768
+#define CHAINENV_MAX_RENDER_BURSTS 256
+#define CHAINENV_MAX_SNAPSHOTS (2 * CHAINENV_MAX_RENDER_WAVES + 8)
+#define CHAINENV_BURST_DURATION 0.36f
+#define CHAINENV_TRANSFER_DURATION 0.28f
+#define CHAINENV_WAVE_DELAY 0.10f
+#define CHAINENV_PLACEMENT_DURATION 0.11f
+#define CHAINENV_TURN_GAP 0.08f
+#define CHAINENV_RED_ORBIT_SPEED 0.90f
+#define CHAINENV_GREEN_ORBIT_SPEED -0.78f
+
+typedef struct Log Log;
+struct Log {
+    float perf;
+    float score;
+    float episode_return;
+    float episode_length;
+    float chain_bursts;
+    float invalid_rate;
+    float slot_0_score;
+    float slot_1_score;
+    float draw_rate;
+    float n;
+};
+
+typedef struct OrbTransferAnim OrbTransferAnim;
+struct OrbTransferAnim {
+    int src_row;
+    int src_col;
+    int dst_row;
+    int dst_col;
+    int color;
+    float delay;
+    float duration;
+};
+
+typedef struct BurstAnim BurstAnim;
+struct BurstAnim {
+    int row;
+    int col;
+    int color;
+    float delay;
+    float duration;
+};
+
+typedef struct Client Client;
+struct Client {
+    int screen_width;
+    int screen_height;
+    float board_x;
+    float board_y;
+    float cell_size;
+    float animation_clock;
+    float animation_total;
+    float invalid_hint_time;
+    OrbTransferAnim transfers[CHAINENV_MAX_RENDER_TRANSFERS];
+    BurstAnim bursts[CHAINENV_MAX_RENDER_BURSTS];
+    int base_owner[CHAINENV_MAX_CELLS];
+    int base_orbs[CHAINENV_MAX_CELLS];
+    int snapshot_owner[CHAINENV_MAX_SNAPSHOTS][CHAINENV_MAX_CELLS];
+    int snapshot_orbs[CHAINENV_MAX_SNAPSHOTS][CHAINENV_MAX_CELLS];
+    float snapshot_time[CHAINENV_MAX_SNAPSHOTS];
+    int snapshot_count;
+    int transfer_count;
+    int burst_count;
+};
+
+typedef struct ResolveStats ResolveStats;
+struct ResolveStats {
+    int bursts;
+    int waves;
+    int transfers;
+    float end_time;
+};
+
+typedef struct ChainEnv ChainEnv;
+struct ChainEnv {
+    float* observations;
+    float* actions;
+    float* rewards;
+    float* terminals;
+    unsigned char* action_mask;
+    int num_agents;
+    Log log;
+    Client* client;
+
+    int rows;
+    int cols;
+    int max_steps;
+    int opponent_policy;
+    float win_reward;
+    float loss_reward;
+    float invalid_move_reward;
+
+    int owner[CHAINENV_MAX_CELLS];
+    int orbs[CHAINENV_MAX_CELLS];
+    int move_count;
+    int tick;
+    int end_game;
+    int turns_taken[2];
+    int current_player;
+    int player_for_slot[CHAINENV_MAX_SLOTS];
+    int slot_for_player[CHAINENV_MAX_SLOTS];
+    int last_player_action;
+    int last_env_action;
+    int last_chain_bursts;
+    int last_chain_waves;
+    int winner;
+    unsigned int rng;
+};
+
+static inline int chainenv_slot(int row, int col) {
+    return row * CHAINENV_MAX_COLS + col;
+}
+
+static inline int chainenv_player_index(int player) {
+    return (player == CHAINENV_PLAYER_RED) ? 0 : 1;
+}
+
+static inline bool chainenv_is_selfplay(const ChainEnv* env) {
+    return env->num_agents > 1;
+}
+
+static inline int chainenv_slot_for_player(const ChainEnv* env, int player) {
+    return env->slot_for_player[chainenv_player_index(player)];
+}
+
+static inline int chainenv_player_for_slot(const ChainEnv* env, int slot) {
+    return env->player_for_slot[slot];
+}
+
+static inline void chainenv_set_slot_players(ChainEnv* env, int slot0_player, int slot1_player) {
+    env->player_for_slot[0] = slot0_player;
+    env->player_for_slot[1] = slot1_player;
+    env->slot_for_player[chainenv_player_index(slot0_player)] = 0;
+    env->slot_for_player[chainenv_player_index(slot1_player)] = 1;
+}
+
+static inline void chainenv_copy_board(
+        int* dst_owner, int* dst_orbs, const int* src_owner, const int* src_orbs) {
+    memcpy(dst_owner, src_owner, sizeof(int) * CHAINENV_MAX_CELLS);
+    memcpy(dst_orbs, src_orbs, sizeof(int) * CHAINENV_MAX_CELLS);
+}
+
+static inline bool chainenv_cell_active(const ChainEnv* env, int row, int col) {
+    return row >= 0 && row < env->rows && col >= 0 && col < env->cols;
+}
+
+static inline bool chainenv_board_idx_active(const ChainEnv* env, int idx) {
+    int row = idx / CHAINENV_MAX_COLS;
+    int col = idx % CHAINENV_MAX_COLS;
+    return chainenv_cell_active(env, row, col);
+}
+
+static inline int chainenv_action_to_board_idx(const ChainEnv* env, int action) {
+    if (action < 0 || action >= env->rows * env->cols) {
+        return -1;
+    }
+
+    int row = action / env->cols;
+    int col = action % env->cols;
+    return chainenv_slot(row, col);
+}
+
+static inline int chainenv_board_idx_to_action(const ChainEnv* env, int board_idx) {
+    int row = board_idx / CHAINENV_MAX_COLS;
+    int col = board_idx % CHAINENV_MAX_COLS;
+    if (!chainenv_cell_active(env, row, col)) {
+        return -1;
+    }
+
+    return row * env->cols + col;
+}
+
+static inline int chainenv_critical_mass(const ChainEnv* env, int row, int col) {
+    int mass = 0;
+    mass += chainenv_cell_active(env, row - 1, col) ? 1 : 0;
+    mass += chainenv_cell_active(env, row + 1, col) ? 1 : 0;
+    mass += chainenv_cell_active(env, row, col - 1) ? 1 : 0;
+    mass += chainenv_cell_active(env, row, col + 1) ? 1 : 0;
+    return mass;
+}
+
+static inline int chainenv_stable_capacity(const ChainEnv* env) {
+    // Stable cells hold at most (critical_mass - 1) orbs, so this is the
+    // largest turn count that can still admit a stable board on the chosen grid.
+    return 3 * env->rows * env->cols - 2 * env->rows - 2 * env->cols;
+}
+
+static inline void chainenv_add_log(ChainEnv* env, int invalid) {
+    float reward = env->rewards[0];
+    env->log.perf += reward > 0.0f ? 1.0f : (reward == 0.0f ? 0.5f : 0.0f);
+    env->log.score += reward;
+    env->log.episode_return += reward;
+    env->log.episode_length += (float)env->tick;
+    env->log.chain_bursts += (float)env->last_chain_bursts;
+    env->log.invalid_rate += invalid ? 1.0f : 0.0f;
+    if (env->num_agents > 1) {
+        float slot0_reward = env->rewards[0];
+        float slot1_reward = env->rewards[1];
+        if (fabsf(slot0_reward - slot1_reward) <= 1.0e-6f) {
+            env->log.slot_0_score += 0.5f;
+            env->log.slot_1_score += 0.5f;
+            env->log.draw_rate += 1.0f;
+        } else if (slot0_reward > slot1_reward) {
+            env->log.slot_0_score += 1.0f;
+        } else {
+            env->log.slot_1_score += 1.0f;
+        }
+    }
+    env->log.n += 1.0f;
+}
+
+static inline void chainenv_layout_board(Client* client, const ChainEnv* env) {
+    float sidebar_w = fminf(250.0f, (float)client->screen_width * 0.26f);
+    float gutter = fmaxf(30.0f, (float)client->screen_width * 0.04f);
+    float board_area_x = sidebar_w + gutter;
+    float board_area_w = fmaxf(260.0f, (float)client->screen_width - board_area_x - gutter);
+    float available_h = (float)client->screen_height - 150.0f;
+    float cell_size = fminf((board_area_w - 8.0f) / (float)env->cols, available_h / (float)env->rows);
+    cell_size = fmaxf(cell_size, 48.0f);
+
+    client->cell_size = cell_size;
+    client->board_x = board_area_x + fmaxf(0.0f, (board_area_w - cell_size * env->cols) * 0.5f);
+    client->board_y = ((float)client->screen_height - cell_size * env->rows) * 0.5f + 6.0f;
+}
+
+static inline void chainenv_reset_render_animations(ChainEnv* env) {
+    if (env->client == NULL) {
+        return;
+    }
+
+    env->client->animation_clock = 0.0f;
+    env->client->animation_total = 0.0f;
+    env->client->snapshot_count = 0;
+    env->client->transfer_count = 0;
+    env->client->burst_count = 0;
+}
+
+static inline void chainenv_clear_invalid_hint(ChainEnv* env) {
+    if (env->client == NULL) {
+        return;
+    }
+
+    env->client->invalid_hint_time = 0.0f;
+}
+
+static inline void chainenv_show_invalid_hint(ChainEnv* env) {
+    if (env->client == NULL) {
+        return;
+    }
+
+    env->client->invalid_hint_time = 1.9f;
+}
+
+static inline void chainenv_begin_animation(ChainEnv* env) {
+    if (env->client == NULL) {
+        return;
+    }
+
+    chainenv_reset_render_animations(env);
+    chainenv_copy_board(
+        env->client->base_owner,
+        env->client->base_orbs,
+        env->owner,
+        env->orbs);
+}
+
+static inline void chainenv_record_snapshot(ChainEnv* env, float reveal_time) {
+    if (env->client == NULL) {
+        return;
+    }
+
+    Client* client = env->client;
+    int snapshot_idx = client->snapshot_count;
+    if (snapshot_idx >= CHAINENV_MAX_SNAPSHOTS) {
+        snapshot_idx = CHAINENV_MAX_SNAPSHOTS - 1;
+    } else {
+        client->snapshot_count += 1;
+    }
+
+    chainenv_copy_board(
+        client->snapshot_owner[snapshot_idx],
+        client->snapshot_orbs[snapshot_idx],
+        env->owner,
+        env->orbs);
+    client->snapshot_time[snapshot_idx] = reveal_time;
+
+    if (reveal_time > client->animation_total) {
+        client->animation_total = reveal_time;
+    }
+}
+
+static inline void chainenv_record_burst(ChainEnv* env, int row, int col, int color, float delay) {
+    if (env->client == NULL) {
+        return;
+    }
+
+    Client* client = env->client;
+    if (client->burst_count < CHAINENV_MAX_RENDER_BURSTS) {
+        client->bursts[client->burst_count++] = (BurstAnim) {
+            .row = row,
+            .col = col,
+            .color = color,
+            .delay = delay,
+            .duration = CHAINENV_BURST_DURATION,
+        };
+    }
+
+    float end_time = delay + CHAINENV_BURST_DURATION;
+    if (end_time > client->animation_total) {
+        client->animation_total = end_time;
+    }
+}
+
+static inline void chainenv_record_transfer(
+        ChainEnv* env, int src_row, int src_col, int dst_row, int dst_col, int color, float delay) {
+    if (env->client == NULL) {
+        return;
+    }
+
+    Client* client = env->client;
+    if (client->transfer_count < CHAINENV_MAX_RENDER_TRANSFERS) {
+        client->transfers[client->transfer_count++] = (OrbTransferAnim) {
+            .src_row = src_row,
+            .src_col = src_col,
+            .dst_row = dst_row,
+            .dst_col = dst_col,
+            .color = color,
+            .delay = delay,
+            .duration = CHAINENV_TRANSFER_DURATION,
+        };
+    }
+
+    float end_time = delay + CHAINENV_TRANSFER_DURATION;
+    if (end_time > client->animation_total) {
+        client->animation_total = end_time;
+    }
+}
+
+static inline void chainenv_recount(const ChainEnv* env, int* red_total, int* green_total) {
+    int red = 0;
+    int green = 0;
+    for (int row = 0; row < env->rows; row++) {
+        for (int col = 0; col < env->cols; col++) {
+            int idx = chainenv_slot(row, col);
+            if (env->owner[idx] == CHAINENV_PLAYER_RED) {
+                red += env->orbs[idx];
+            } else if (env->owner[idx] == CHAINENV_PLAYER_GREEN) {
+                green += env->orbs[idx];
+            }
+        }
+    }
+
+    *red_total = red;
+    *green_total = green;
+}
+
+static inline void chainenv_zero_outputs(ChainEnv* env) {
+    for (int slot = 0; slot < env->num_agents; slot++) {
+        env->rewards[slot] = 0.0f;
+        env->terminals[slot] = 0.0f;
+    }
+}
+
+static inline bool chainenv_is_legal_move(const ChainEnv* env, int action, int player);
+static inline int chainenv_check_winner(const ChainEnv* env);
+
+static inline void chainenv_compute_observations(ChainEnv* env) {
+    int red_total = 0;
+    int green_total = 0;
+    chainenv_recount(env, &red_total, &green_total);
+    memset(env->observations, 0, env->num_agents * CHAINENV_OBS_SIZE * sizeof(float));
+
+    float area = (float)(env->rows * env->cols);
+    for (int slot = 0; slot < env->num_agents; slot++) {
+        int player = chainenv_player_for_slot(env, slot);
+        float* obs = env->observations + slot * CHAINENV_OBS_SIZE;
+
+        for (int row = 0; row < env->rows; row++) {
+            for (int col = 0; col < env->cols; col++) {
+                int idx = chainenv_slot(row, col);
+                int obs_idx = idx * CHAINENV_OBS_CHANNELS;
+                obs[obs_idx + 0] = 1.0f;
+                obs[obs_idx + 1] = chainenv_critical_mass(env, row, col) / 4.0f;
+
+                if (env->owner[idx] == player) {
+                    obs[obs_idx + 2] = env->orbs[idx] / 4.0f;
+                } else if (env->owner[idx] == -player) {
+                    obs[obs_idx + 3] = env->orbs[idx] / 4.0f;
+                }
+            }
+        }
+
+        int self_total = player == CHAINENV_PLAYER_RED ? red_total : green_total;
+        int opp_total = player == CHAINENV_PLAYER_RED ? green_total : red_total;
+        int base = CHAINENV_MAX_CELLS * CHAINENV_OBS_CHANNELS;
+        obs[base + 0] = env->rows / (float)CHAINENV_MAX_ROWS;
+        obs[base + 1] = env->cols / (float)CHAINENV_MAX_COLS;
+        obs[base + 2] = area > 0.0f ? self_total / (area * 4.0f) : 0.0f;
+        obs[base + 3] = area > 0.0f ? opp_total / (area * 4.0f) : 0.0f;
+        obs[base + 4] = env->current_player == player ? 1.0f : 0.0f;
+    }
+}
+
+static inline void chainenv_update_action_mask(ChainEnv* env) {
+    if (env->action_mask == NULL) {
+        return;
+    }
+
+    memset(env->action_mask, 0, env->num_agents * CHAINENV_MAX_ACTIONS * sizeof(unsigned char));
+    if (env->end_game) {
+        for (int slot = 0; slot < env->num_agents; slot++) {
+            env->action_mask[slot * CHAINENV_MAX_ACTIONS + CHAINENV_NOOP_ACTION] = 1;
+        }
+        return;
+    }
+
+    if (!chainenv_is_selfplay(env)) {
+        for (int action = 0; action < env->rows * env->cols; action++) {
+            int idx = chainenv_action_to_board_idx(env, action);
+            if (idx < 0) {
+                continue;
+            }
+
+            if (env->owner[idx] == 0 || env->owner[idx] == CHAINENV_PLAYER_RED) {
+                env->action_mask[action] = 1;
+            }
+        }
+        return;
+    }
+
+    int active_slot = chainenv_slot_for_player(env, env->current_player);
+    for (int slot = 0; slot < env->num_agents; slot++) {
+        unsigned char* mask = env->action_mask + slot * CHAINENV_MAX_ACTIONS;
+        if (slot != active_slot) {
+            mask[CHAINENV_NOOP_ACTION] = 1;
+            continue;
+        }
+
+        for (int action = 0; action < env->rows * env->cols; action++) {
+            if (chainenv_is_legal_move(env, action, env->current_player)) {
+                mask[action] = 1;
+            }
+        }
+    }
+}
+
+static inline bool chainenv_is_legal_move(const ChainEnv* env, int action, int player) {
+    int idx = chainenv_action_to_board_idx(env, action);
+    if (idx < 0) {
+        return false;
+    }
+
+    return env->owner[idx] == 0 || env->owner[idx] == player;
+}
+
+static inline void chainenv_apply_single_orb(ChainEnv* env, int board_idx, int player) {
+    if (env->owner[board_idx] != player) {
+        env->owner[board_idx] = player;
+    }
+    env->orbs[board_idx] += 1;
+}
+
+static inline ResolveStats chainenv_resolve_chain(ChainEnv* env, int player, float start_delay) {
+    ResolveStats stats = {0};
+    stats.end_time = start_delay;
+    int recorded_waves = 0;
+    bool truncated_render = false;
+
+    for (int wave = 0;; wave++) {
+        int unstable[CHAINENV_MAX_CELLS];
+        int unstable_count = 0;
+
+        for (int r = 0; r < env->rows; r++) {
+            for (int c = 0; c < env->cols; c++) {
+                int idx = chainenv_slot(r, c);
+                if (env->owner[idx] != player) {
+                    continue;
+                }
+
+                int critical = chainenv_critical_mass(env, r, c);
+                if (env->orbs[idx] >= critical) {
+                    unstable[unstable_count++] = idx;
+                }
+            }
+        }
+
+        if (unstable_count == 0) {
+            break;
+        }
+
+        stats.waves += 1;
+        bool record_wave = wave < CHAINENV_MAX_RENDER_WAVES;
+        float delay = start_delay + recorded_waves * CHAINENV_WAVE_DELAY;
+        for (int i = 0; i < unstable_count; i++) {
+            int idx = unstable[i];
+            int burst_row = idx / CHAINENV_MAX_COLS;
+            int burst_col = idx % CHAINENV_MAX_COLS;
+            int critical = chainenv_critical_mass(env, burst_row, burst_col);
+
+            env->orbs[idx] -= critical;
+            if (env->orbs[idx] <= 0) {
+                env->orbs[idx] = 0;
+                env->owner[idx] = 0;
+            } else {
+                env->owner[idx] = player;
+            }
+
+            stats.bursts += 1;
+            if (record_wave) {
+                chainenv_record_burst(env, burst_row, burst_col, player, delay);
+            }
+        }
+
+        for (int i = 0; i < unstable_count; i++) {
+            int idx = unstable[i];
+            int src_row = idx / CHAINENV_MAX_COLS;
+            int src_col = idx % CHAINENV_MAX_COLS;
+            static const int dr[4] = {-1, 1, 0, 0};
+            static const int dc[4] = {0, 0, -1, 1};
+
+            for (int d = 0; d < 4; d++) {
+                int nr = src_row + dr[d];
+                int nc = src_col + dc[d];
+                if (!chainenv_cell_active(env, nr, nc)) {
+                    continue;
+                }
+
+                int nidx = chainenv_slot(nr, nc);
+                chainenv_apply_single_orb(env, nidx, player);
+                stats.transfers += 1;
+                if (record_wave) {
+                    chainenv_record_transfer(env, src_row, src_col, nr, nc, player, delay);
+                }
+            }
+        }
+
+        if (record_wave) {
+            float reveal_time = delay + fmaxf(CHAINENV_BURST_DURATION, CHAINENV_TRANSFER_DURATION);
+            chainenv_record_snapshot(env, reveal_time);
+            stats.end_time = reveal_time;
+            recorded_waves += 1;
+        } else {
+            truncated_render = true;
+        }
+
+        // Match the mobile game: once a player has been wiped out after both
+        // sides have taken at least one turn, the move ends immediately instead
+        // of continuing a single-color avalanche.
+        if (chainenv_check_winner(env) != 0) {
+            break;
+        }
+    }
+
+    if (truncated_render) {
+        float final_time = start_delay
+            + recorded_waves * CHAINENV_WAVE_DELAY
+            + fmaxf(CHAINENV_BURST_DURATION, CHAINENV_TRANSFER_DURATION);
+        chainenv_record_snapshot(env, final_time);
+        stats.end_time = final_time;
+    }
+
+    return stats;
+}
+
+static inline bool chainenv_player_eliminated(const ChainEnv* env, int player) {
+    for (int row = 0; row < env->rows; row++) {
+        for (int col = 0; col < env->cols; col++) {
+            int idx = chainenv_slot(row, col);
+            if (env->owner[idx] == player && env->orbs[idx] > 0) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+static inline int chainenv_check_winner(const ChainEnv* env) {
+    if (env->turns_taken[0] == 0 || env->turns_taken[1] == 0) {
+        return 0;
+    }
+
+    bool red_out = chainenv_player_eliminated(env, CHAINENV_PLAYER_RED);
+    bool green_out = chainenv_player_eliminated(env, CHAINENV_PLAYER_GREEN);
+    if (!red_out && green_out) {
+        return CHAINENV_PLAYER_RED;
+    }
+    if (red_out && !green_out) {
+        return CHAINENV_PLAYER_GREEN;
+    }
+
+    return 0;
+}
+
+static inline int chainenv_timeout_winner(const ChainEnv* env) {
+    int red_total = 0;
+    int green_total = 0;
+    chainenv_recount(env, &red_total, &green_total);
+
+    if (red_total > green_total) {
+        return CHAINENV_PLAYER_RED;
+    }
+    if (green_total > red_total) {
+        return CHAINENV_PLAYER_GREEN;
+    }
+    return 0;
+}
+
+static inline float chainenv_move_score(const ChainEnv* env, int action, int player) {
+    int idx = chainenv_action_to_board_idx(env, action);
+    if (idx < 0) {
+        return -1.0e9f;
+    }
+
+    int row = idx / CHAINENV_MAX_COLS;
+    int col = idx % CHAINENV_MAX_COLS;
+    int critical = chainenv_critical_mass(env, row, col);
+    int existing = env->orbs[idx];
+    int owner = env->owner[idx];
+    float score = 0.0f;
+    int friendly_neighbors = 0;
+    int enemy_neighbors = 0;
+
+    score += owner == player ? 3.1f : 1.0f;
+    score += (5 - critical) * 0.35f;
+    score += (existing + 1 >= critical) ? 4.0f : (1.2f / (float)(critical - existing));
+
+    static const int dr[4] = {-1, 1, 0, 0};
+    static const int dc[4] = {0, 0, -1, 1};
+    for (int d = 0; d < 4; d++) {
+        int nr = row + dr[d];
+        int nc = col + dc[d];
+        if (!chainenv_cell_active(env, nr, nc)) {
+            continue;
+        }
+
+        int nidx = chainenv_slot(nr, nc);
+        int nowner = env->owner[nidx];
+        int norbs = env->orbs[nidx];
+        int ncritical = chainenv_critical_mass(env, nr, nc);
+
+        if (nowner == player) {
+            friendly_neighbors += 1;
+            score += norbs == ncritical - 1 ? 1.1f : 0.32f * norbs;
+        } else if (nowner == -player) {
+            enemy_neighbors += 1;
+            score += norbs == ncritical - 1 ? 2.2f : 0.15f * norbs;
+            if (owner == 0 && env->move_count < 10) {
+                score -= 0.35f;
+            }
+        }
+    }
+
+    if (owner == 0) {
+        if (env->move_count < 8) {
+            score += 0.18f * friendly_neighbors;
+            score -= 0.20f * enemy_neighbors;
+        } else {
+            score += 0.10f * friendly_neighbors;
+        }
+    }
+
+    return score;
+}
+
+static inline int chainenv_choose_env_action(ChainEnv* env) {
+    int legal_actions[CHAINENV_MAX_CELLS];
+    int legal_count = 0;
+    for (int action = 0; action < env->rows * env->cols; action++) {
+        int idx = chainenv_action_to_board_idx(env, action);
+        if (idx < 0) {
+            continue;
+        }
+
+        if (env->owner[idx] == 0 || env->owner[idx] == CHAINENV_PLAYER_GREEN) {
+            legal_actions[legal_count++] = action;
+        }
+    }
+
+    if (legal_count == 0) {
+        return -1;
+    }
+
+    if (env->opponent_policy == CHAINENV_OPPONENT_RANDOM) {
+        return legal_actions[rand_r(&env->rng) % legal_count];
+    }
+
+    float scores[CHAINENV_MAX_CELLS];
+    float best_score = -1.0e9f;
+    int best_action = legal_actions[0];
+    for (int i = 0; i < legal_count; i++) {
+        int action = legal_actions[i];
+        float score = chainenv_move_score(env, action, CHAINENV_PLAYER_GREEN);
+        scores[i] = score;
+        if (score > best_score + 1.0e-6f) {
+            best_score = score;
+            best_action = action;
+        }
+    }
+
+    float margin = env->move_count < 8 ? 0.95f : 0.55f;
+    float threshold = best_score - margin;
+    float total_weight = 0.0f;
+    int candidate_count = 0;
+    int candidates[CHAINENV_MAX_CELLS];
+    float weights[CHAINENV_MAX_CELLS];
+
+    for (int i = 0; i < legal_count; i++) {
+        if (scores[i] + 1.0e-6f < threshold) {
+            continue;
+        }
+
+        float weight = 0.15f + (scores[i] - threshold);
+        candidates[candidate_count] = legal_actions[i];
+        weights[candidate_count] = weight;
+        total_weight += weight;
+        candidate_count += 1;
+    }
+
+    if (candidate_count == 0 || total_weight <= 1.0e-6f) {
+        return best_action;
+    }
+
+    float sample = ((float)(rand_r(&env->rng) % 100000) / 100000.0f) * total_weight;
+    for (int i = 0; i < candidate_count; i++) {
+        sample -= weights[i];
+        if (sample <= 0.0f) {
+            return candidates[i];
+        }
+    }
+
+    return candidates[candidate_count - 1];
+}
+
+static inline float chainenv_reward_for_player(
+        const ChainEnv* env, int player, int winner, int invalid_player) {
+    if (winner == 0) {
+        return 0.0f;
+    }
+    if (player == winner) {
+        return env->win_reward;
+    }
+    if (invalid_player != 0 && player == invalid_player) {
+        return env->invalid_move_reward;
+    }
+    return env->loss_reward;
+}
+
+static inline void chainenv_finish_game(ChainEnv* env, int winner, int invalid_player) {
+    if (env->num_agents == 1) {
+        env->rewards[0] = chainenv_reward_for_player(
+            env, CHAINENV_PLAYER_RED, winner, invalid_player);
+        env->terminals[0] = 1.0f;
+    } else {
+        for (int slot = 0; slot < env->num_agents; slot++) {
+            int player = chainenv_player_for_slot(env, slot);
+            env->rewards[slot] = chainenv_reward_for_player(
+                env, player, winner, invalid_player);
+            env->terminals[slot] = 1.0f;
+        }
+    }
+
+    env->end_game = 1;
+    env->winner = winner;
+    chainenv_update_action_mask(env);
+    chainenv_add_log(env, invalid_player != 0);
+}
+
+static inline void chainenv_reset_slot_mapping(ChainEnv* env) {
+    if (chainenv_is_selfplay(env) && (rand_r(&env->rng) & 1) != 0) {
+        chainenv_set_slot_players(env, CHAINENV_PLAYER_GREEN, CHAINENV_PLAYER_RED);
+        return;
+    }
+
+    chainenv_set_slot_players(env, CHAINENV_PLAYER_RED, CHAINENV_PLAYER_GREEN);
+}
+
+static inline ResolveStats chainenv_execute_turn(
+        ChainEnv* env, int player, int action, float start_delay) {
+    ResolveStats stats = {0};
+    int board_idx = chainenv_action_to_board_idx(env, action);
+    if (board_idx < 0) {
+        return stats;
+    }
+
+    env->turns_taken[chainenv_player_index(player)] += 1;
+    env->move_count += 1;
+    if (player == CHAINENV_PLAYER_RED) {
+        env->last_player_action = action;
+    } else {
+        env->last_env_action = action;
+    }
+
+    chainenv_apply_single_orb(env, board_idx, player);
+    chainenv_record_snapshot(env, start_delay + CHAINENV_PLACEMENT_DURATION);
+    return chainenv_resolve_chain(env, player, start_delay + CHAINENV_PLACEMENT_DURATION);
+}
+
+static inline void chainenv_maybe_open_scripted_duel(ChainEnv* env) {
+    if (chainenv_is_selfplay(env)) {
+        return;
+    }
+
+    env->current_player = CHAINENV_PLAYER_RED;
+    if ((rand_r(&env->rng) & 1u) == 0u) {
+        return;
+    }
+
+    int env_action = chainenv_choose_env_action(env);
+    if (env_action < 0) {
+        return;
+    }
+
+    chainenv_begin_animation(env);
+    ResolveStats env_stats = chainenv_execute_turn(env, CHAINENV_PLAYER_GREEN, env_action, 0.0f);
+    env->last_chain_bursts = env_stats.bursts;
+    env->last_chain_waves = env_stats.waves;
+    env->current_player = CHAINENV_PLAYER_RED;
+}
+
+static inline void init_chainenv(ChainEnv* env) {
+    if (env->num_agents < 1) env->num_agents = 1;
+    if (env->num_agents > CHAINENV_MAX_SLOTS) env->num_agents = CHAINENV_MAX_SLOTS;
+    if (env->max_steps < 1) env->max_steps = 1;
+    int stable_capacity = chainenv_stable_capacity(env);
+    if (env->max_steps > stable_capacity) env->max_steps = stable_capacity;
+    env->tick = 0;
+    env->move_count = 0;
+    env->end_game = 0;
+    env->turns_taken[0] = 0;
+    env->turns_taken[1] = 0;
+    env->current_player = CHAINENV_PLAYER_RED;
+    env->last_player_action = -1;
+    env->last_env_action = -1;
+    env->last_chain_bursts = 0;
+    env->last_chain_waves = 0;
+    env->winner = 0;
+    chainenv_set_slot_players(env, CHAINENV_PLAYER_RED, CHAINENV_PLAYER_GREEN);
+    chainenv_reset_render_animations(env);
+}
+
+static inline void c_close(ChainEnv* env) {
+    if (env->client != NULL) {
+        if (IsWindowReady()) {
+            CloseWindow();
+        }
+        free(env->client);
+        env->client = NULL;
+    }
+}
+
+static inline void c_reset(ChainEnv* env) {
+    memset(env->owner, 0, sizeof(env->owner));
+    memset(env->orbs, 0, sizeof(env->orbs));
+    env->tick = 0;
+    env->move_count = 0;
+    env->end_game = 0;
+    env->turns_taken[0] = 0;
+    env->turns_taken[1] = 0;
+    env->current_player = CHAINENV_PLAYER_RED;
+    env->last_player_action = -1;
+    env->last_env_action = -1;
+    env->last_chain_bursts = 0;
+    env->last_chain_waves = 0;
+    env->winner = 0;
+    chainenv_reset_slot_mapping(env);
+    chainenv_zero_outputs(env);
+    chainenv_reset_render_animations(env);
+    chainenv_clear_invalid_hint(env);
+    chainenv_maybe_open_scripted_duel(env);
+    chainenv_compute_observations(env);
+    chainenv_update_action_mask(env);
+}
+
+static inline void c_step(ChainEnv* env) {
+    env->tick += 1;
+    chainenv_zero_outputs(env);
+
+    if (env->end_game) {
+        c_reset(env);
+        return;
+    }
+
+    env->last_chain_bursts = 0;
+    env->last_chain_waves = 0;
+
+    if (chainenv_is_selfplay(env)) {
+        int active_slot = chainenv_slot_for_player(env, env->current_player);
+        int action = (int)env->actions[active_slot];
+        if (env->current_player == CHAINENV_PLAYER_RED) {
+            env->last_player_action = action;
+        } else {
+            env->last_env_action = action;
+        }
+
+        if (action == CHAINENV_NOOP_ACTION ||
+                !chainenv_is_legal_move(env, action, env->current_player)) {
+            chainenv_compute_observations(env);
+            chainenv_finish_game(env, -env->current_player, env->current_player);
+            return;
+        }
+
+        chainenv_begin_animation(env);
+        ResolveStats stats = chainenv_execute_turn(env, env->current_player, action, 0.0f);
+        env->last_chain_bursts = stats.bursts;
+        env->last_chain_waves = stats.waves;
+
+        int winner = chainenv_check_winner(env);
+        if (winner == 0 && env->move_count >= env->max_steps) {
+            winner = chainenv_timeout_winner(env);
+        }
+
+        if (winner != 0 || env->move_count >= env->max_steps) {
+            chainenv_compute_observations(env);
+            chainenv_finish_game(env, winner, 0);
+            return;
+        }
+
+        env->current_player = -env->current_player;
+        chainenv_compute_observations(env);
+        chainenv_update_action_mask(env);
+        return;
+    }
+
+    int action = (int)env->actions[0];
+    env->last_env_action = -1;
+    if (!chainenv_is_legal_move(env, action, CHAINENV_PLAYER_RED)) {
+        env->last_player_action = action;
+        chainenv_compute_observations(env);
+        chainenv_finish_game(env, CHAINENV_PLAYER_GREEN, CHAINENV_PLAYER_RED);
+        return;
+    }
+
+    chainenv_begin_animation(env);
+    ResolveStats player_stats = chainenv_execute_turn(env, CHAINENV_PLAYER_RED, action, 0.0f);
+    env->last_chain_bursts = player_stats.bursts;
+    env->last_chain_waves = player_stats.waves;
+
+    int winner = chainenv_check_winner(env);
+    if (winner == 0 && env->move_count >= env->max_steps) {
+        winner = chainenv_timeout_winner(env);
+    }
+    if (winner != 0 || env->move_count >= env->max_steps) {
+        chainenv_compute_observations(env);
+        chainenv_finish_game(env, winner, 0);
+        return;
+    }
+
+    int env_action = chainenv_choose_env_action(env);
+    if (env_action < 0) {
+        chainenv_compute_observations(env);
+        chainenv_finish_game(env, CHAINENV_PLAYER_RED, 0);
+        return;
+    }
+
+    float env_start = player_stats.end_time + CHAINENV_TURN_GAP;
+    ResolveStats env_stats = chainenv_execute_turn(
+        env, CHAINENV_PLAYER_GREEN, env_action, env_start);
+    env->last_chain_bursts += env_stats.bursts;
+    env->last_chain_waves += env_stats.waves;
+
+    winner = chainenv_check_winner(env);
+    if (winner == 0 && env->move_count >= env->max_steps) {
+        winner = chainenv_timeout_winner(env);
+    }
+    env->current_player = CHAINENV_PLAYER_RED;
+    chainenv_compute_observations(env);
+    if (winner != 0 || env->move_count >= env->max_steps) {
+        chainenv_finish_game(env, winner, 0);
+        return;
+    }
+
+    chainenv_update_action_mask(env);
+}
+
+static inline Client* make_client(void) {
+    Client* client = (Client*)calloc(1, sizeof(Client));
+    client->screen_width = 980;
+    client->screen_height = 860;
+
+    SetConfigFlags(FLAG_MSAA_4X_HINT | FLAG_WINDOW_RESIZABLE);
+    InitWindow(client->screen_width, client->screen_height, "PufferLib Chain Reaction");
+    SetTargetFPS(60);
+    return client;
+}
+
+static inline Color chainenv_player_color(int player) {
+    return player == CHAINENV_PLAYER_RED
+        ? (Color){255, 80, 88, 255}
+        : (Color){77, 231, 125, 255};
+}
+
+static inline Color chainenv_dim_color(Color color, float factor) {
+    return (Color) {
+        (unsigned char)fminf(255.0f, color.r * factor),
+        (unsigned char)fminf(255.0f, color.g * factor),
+        (unsigned char)fminf(255.0f, color.b * factor),
+        color.a,
+    };
+}
+
+static inline float chainenv_ease_out(float t) {
+    float inv = 1.0f - t;
+    return 1.0f - inv * inv * inv;
+}
+
+static inline void chainenv_draw_glossy_orb(Vector2 center, float radius, Color color, float alpha) {
+    Color shadow = (Color){0, 0, 0, (unsigned char)(100.0f * alpha)};
+    Color base = color;
+    base.a = (unsigned char)(255.0f * alpha);
+    Color dark = chainenv_dim_color(color, 0.60f);
+    dark.a = (unsigned char)(220.0f * alpha);
+    Color highlight = (Color){255, 255, 255, (unsigned char)(180.0f * alpha)};
+
+    DrawCircleV((Vector2){center.x + radius * 0.14f, center.y + radius * 0.18f}, radius * 1.05f, shadow);
+    DrawCircleV(center, radius, dark);
+    DrawCircleV((Vector2){center.x - radius * 0.08f, center.y - radius * 0.08f}, radius * 0.88f, base);
+    DrawCircleV((Vector2){center.x - radius * 0.30f, center.y - radius * 0.34f}, radius * 0.32f, highlight);
+}
+
+static inline void chainenv_draw_stack(
+        Client* client, int row, int col, int owner, int count, float time) {
+    if (owner == 0 || count <= 0) {
+        return;
+    }
+
+    float cx = client->board_x + (col + 0.5f) * client->cell_size;
+    float cy = client->board_y + (row + 0.5f) * client->cell_size;
+    float orbit = client->cell_size * 0.12f;
+    float radius = client->cell_size * 0.18f;
+    Color color = chainenv_player_color(owner);
+
+    if (count == 1) {
+        chainenv_draw_glossy_orb((Vector2){cx, cy}, radius, color, 1.0f);
+        return;
+    }
+
+    float speed = owner == CHAINENV_PLAYER_RED ? CHAINENV_RED_ORBIT_SPEED : CHAINENV_GREEN_ORBIT_SPEED;
+    for (int i = 0; i < count; i++) {
+        float angle = time * speed + ((2.0f * PI) * i) / (float)count;
+        float ox = cosf(angle) * orbit;
+        float oy = sinf(angle) * orbit * 0.65f;
+        chainenv_draw_glossy_orb((Vector2){cx + ox, cy + oy}, radius * 0.92f, color, 1.0f);
+    }
+}
+
+static inline void chainenv_get_display_board(
+        const ChainEnv* env, const Client* client, int* display_owner, int* display_orbs) {
+    chainenv_copy_board(display_owner, display_orbs, env->owner, env->orbs);
+    if (client == NULL || client->snapshot_count == 0) {
+        return;
+    }
+
+    chainenv_copy_board(display_owner, display_orbs, client->base_owner, client->base_orbs);
+    for (int i = 0; i < client->snapshot_count; i++) {
+        if (client->snapshot_time[i] > client->animation_clock + 1.0e-4f) {
+            break;
+        }
+
+        chainenv_copy_board(
+            display_owner,
+            display_orbs,
+            client->snapshot_owner[i],
+            client->snapshot_orbs[i]);
+    }
+}
+
+static inline void chainenv_draw_board(ChainEnv* env, Client* client) {
+    Color bg = (Color){7, 20, 25, 255};
+    Color frame = (Color){16, 47, 57, 255};
+    Color inner = (Color){18, 69, 84, 255};
+    Color grid_line = (Color){111, 214, 232, 55};
+    int display_owner[CHAINENV_MAX_CELLS];
+    int display_orbs[CHAINENV_MAX_CELLS];
+
+    DrawRectangleGradientV(0, 0, client->screen_width, client->screen_height,
+        (Color){4, 12, 18, 255}, bg);
+
+    float board_w = client->cell_size * env->cols;
+    float board_h = client->cell_size * env->rows;
+    DrawRectangleRounded(
+        (Rectangle){client->board_x - 22, client->board_y - 22, board_w + 44, board_h + 44},
+        0.08f, 24, frame);
+    DrawRectangleRounded(
+        (Rectangle){client->board_x - 8, client->board_y - 8, board_w + 16, board_h + 16},
+        0.05f, 24, inner);
+
+    float time = (float)GetTime();
+    chainenv_get_display_board(env, client, display_owner, display_orbs);
+    for (int row = 0; row < env->rows; row++) {
+        for (int col = 0; col < env->cols; col++) {
+            float x = client->board_x + col * client->cell_size;
+            float y = client->board_y + row * client->cell_size;
+            Rectangle cell = {x, y, client->cell_size, client->cell_size};
+            DrawRectangleRounded(cell, 0.14f, 12, (Color){14, 44, 55, 255});
+            DrawRectangleRounded(
+                (Rectangle){x + 3, y + 3, client->cell_size - 6, client->cell_size - 6},
+                0.14f, 12, (Color){11, 33, 42, 255});
+            DrawRectangleLinesEx(
+                (Rectangle){x + 1, y + 1, client->cell_size - 2, client->cell_size - 2},
+                1.0f, grid_line);
+
+            int idx = chainenv_slot(row, col);
+            int critical = chainenv_critical_mass(env, row, col);
+            char label[8];
+            snprintf(label, sizeof(label), "%d", critical);
+            DrawText(
+                label,
+                (int)(x + client->cell_size - 16),
+                (int)(y + 8),
+                (int)(client->cell_size * 0.16f),
+                (Color){176, 228, 233, 135});
+
+            chainenv_draw_stack(client, row, col, display_owner[idx], display_orbs[idx], time);
+        }
+    }
+}
+
+static inline void chainenv_draw_effects(ChainEnv* env, Client* client) {
+    float t = client->animation_clock;
+    for (int i = 0; i < client->burst_count; i++) {
+        BurstAnim* burst = &client->bursts[i];
+        float local = t - burst->delay;
+        if (local < 0.0f || local > burst->duration) {
+            continue;
+        }
+
+        float p = local / burst->duration;
+        float eased = chainenv_ease_out(p);
+        float cx = client->board_x + (burst->col + 0.5f) * client->cell_size;
+        float cy = client->board_y + (burst->row + 0.5f) * client->cell_size;
+        Color color = chainenv_player_color(burst->color);
+        color.a = (unsigned char)(150.0f * (1.0f - p));
+        DrawRing((Vector2){cx, cy},
+            client->cell_size * (0.10f + eased * 0.02f),
+            client->cell_size * (0.24f + eased * 0.30f),
+            0.0f, 360.0f, 32, color);
+    }
+
+    for (int i = 0; i < client->transfer_count; i++) {
+        OrbTransferAnim* anim = &client->transfers[i];
+        float local = t - anim->delay;
+        if (local < 0.0f || local > anim->duration) {
+            continue;
+        }
+
+        float p = chainenv_ease_out(local / anim->duration);
+        float src_x = client->board_x + (anim->src_col + 0.5f) * client->cell_size;
+        float src_y = client->board_y + (anim->src_row + 0.5f) * client->cell_size;
+        float dst_x = client->board_x + (anim->dst_col + 0.5f) * client->cell_size;
+        float dst_y = client->board_y + (anim->dst_row + 0.5f) * client->cell_size;
+        Vector2 pos = {
+            src_x + (dst_x - src_x) * p,
+            src_y + (dst_y - src_y) * p,
+        };
+        float arc = sinf(p * PI) * client->cell_size * 0.07f;
+        pos.y -= arc;
+        chainenv_draw_glossy_orb(pos, client->cell_size * 0.10f, chainenv_player_color(anim->color), 0.95f);
+    }
+}
+
+static inline void chainenv_draw_hud(ChainEnv* env, Client* client) {
+    int red_total = 0;
+    int green_total = 0;
+    chainenv_recount(env, &red_total, &green_total);
+    const char* mode_label = chainenv_is_selfplay(env) ? "Self-play" : "Scripted duel";
+    const char* red_label = chainenv_is_selfplay(env) ? "Red" : "Red (you)";
+    const char* green_label = chainenv_is_selfplay(env) ? "Green" : "Green (scripted)";
+    float sidebar_x = 32.0f;
+    float sidebar_y = 26.0f;
+    float header_h = 124.0f;
+    float stats_y = sidebar_y + header_h + 8.0f;
+    int stat_label_x = (int)(sidebar_x + 20.0f);
+    int stat_value_x = (int)(sidebar_x + 20.0f);
+    int stat_y = (int)(stats_y + 12.0f);
+    int stat_gap = 42;
+
+    DrawText("Chain Reaction", (int)(sidebar_x + 20.0f), (int)(sidebar_y + 18.0f), 33,
+        (Color){236, 248, 250, 255});
+    DrawText(red_label, (int)(sidebar_x + 22.0f), (int)(sidebar_y + 64.0f), 22,
+        chainenv_player_color(CHAINENV_PLAYER_RED));
+    DrawText(green_label, (int)(sidebar_x + 22.0f), (int)(sidebar_y + 92.0f), 22,
+        chainenv_player_color(CHAINENV_PLAYER_GREEN));
+
+    DrawText("Mode", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
+    DrawText(mode_label, stat_value_x, stat_y + 16, 23, (Color){236, 248, 250, 255});
+    stat_y += stat_gap;
+
+    char board_text[32];
+    snprintf(board_text, sizeof(board_text), "%dx%d", env->rows, env->cols);
+    DrawText("Board", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
+    DrawText(board_text, stat_value_x, stat_y + 16, 23, (Color){236, 248, 250, 255});
+    stat_y += stat_gap;
+
+    char red_text[32];
+    char green_text[32];
+    char burst_text[32];
+    snprintf(red_text, sizeof(red_text), "%d", red_total);
+    snprintf(green_text, sizeof(green_text), "%d", green_total);
+    snprintf(burst_text, sizeof(burst_text), "%d", env->last_chain_bursts);
+
+    DrawText("Red Orbs", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
+    DrawText(red_text, stat_value_x, stat_y + 16, 23, chainenv_player_color(CHAINENV_PLAYER_RED));
+    stat_y += stat_gap;
+
+    DrawText("Green Orbs", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
+    DrawText(green_text, stat_value_x, stat_y + 16, 23, chainenv_player_color(CHAINENV_PLAYER_GREEN));
+    stat_y += stat_gap;
+
+    DrawText("Last Chain Bursts", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
+    DrawText(burst_text, stat_value_x, stat_y + 16, 23, (Color){236, 248, 250, 255});
+    stat_y += stat_gap;
+
+    DrawText("Cell Labels", stat_label_x, stat_y, 15, (Color){151, 194, 205, 230});
+    DrawText("Critical mass", stat_value_x, stat_y + 16, 22, (Color){210, 233, 239, 255});
+    stat_y += stat_gap;
+
+    if (!chainenv_is_selfplay(env) && client->invalid_hint_time > 0.0f) {
+        DrawText("Invalid Move", stat_label_x, stat_y, 15, (Color){236, 183, 120, 240});
+        DrawText("Place on empty or red cells", stat_value_x, stat_y + 16, 22,
+            (Color){255, 216, 164, 255});
+    }
+
+    if (!env->end_game) {
+        return;
+    }
+
+    const char* result = "Draw";
+    Color result_color = (Color){235, 235, 235, 255};
+    if (env->winner == CHAINENV_PLAYER_RED) {
+        result = "Red Wins";
+        result_color = chainenv_player_color(CHAINENV_PLAYER_RED);
+    } else if (env->winner == CHAINENV_PLAYER_GREEN) {
+        result = "Green Wins";
+        result_color = chainenv_player_color(CHAINENV_PLAYER_GREEN);
+    }
+
+    float board_w = client->cell_size * env->cols;
+    float board_h = client->cell_size * env->rows;
+    int center_x = (int)(client->board_x + board_w * 0.5f);
+    int center_y = (int)(client->board_y + board_h * 0.5f);
+    int font_size = 52;
+    int msg_width = MeasureText(result, font_size);
+    DrawText(result,
+        center_x - msg_width / 2,
+        center_y - 48,
+        font_size, result_color);
+    const char* reset_text = "Click anywhere to reset";
+    int reset_width = MeasureText(reset_text, 24);
+    DrawText(reset_text,
+        center_x - reset_width / 2,
+        center_y + 18,
+        24, (Color){240, 240, 240, 230});
+}
+
+static inline int chainenv_pick_action(const ChainEnv* env, const Client* client, Vector2 mouse) {
+    float board_w = client->cell_size * env->cols;
+    float board_h = client->cell_size * env->rows;
+    if (mouse.x < client->board_x || mouse.x >= client->board_x + board_w ||
+            mouse.y < client->board_y || mouse.y >= client->board_y + board_h) {
+        return -1;
+    }
+
+    int col = (int)((mouse.x - client->board_x) / client->cell_size);
+    int row = (int)((mouse.y - client->board_y) / client->cell_size);
+    if (!chainenv_cell_active(env, row, col)) {
+        return -1;
+    }
+
+    return row * env->cols + col;
+}
+
+static inline bool chainenv_animation_active(const ChainEnv* env) {
+    if (env->client == NULL) {
+        return false;
+    }
+
+    return env->client->animation_clock < env->client->animation_total - 1.0e-4f;
+}
+
+static inline void c_render(ChainEnv* env) {
+    if (env->client == NULL) {
+        env->client = make_client();
+    }
+
+    if (IsWindowReady()) {
+        env->client->screen_width = GetScreenWidth();
+        env->client->screen_height = GetScreenHeight();
+    }
+
+    if (WindowShouldClose() || IsKeyPressed(KEY_ESCAPE)) {
+        c_close(env);
+        exit(0);
+    }
+
+    chainenv_layout_board(env->client, env);
+    float dt = GetFrameTime();
+    env->client->invalid_hint_time = fmaxf(0.0f, env->client->invalid_hint_time - dt);
+    env->client->animation_clock = fminf(
+        env->client->animation_total,
+        env->client->animation_clock + dt);
+
+    BeginDrawing();
+    chainenv_draw_board(env, env->client);
+    chainenv_draw_effects(env, env->client);
+    chainenv_draw_hud(env, env->client);
+    EndDrawing();
+}


### PR DESCRIPTION
Adds `chain_reaction` to ocean envs for self-play based on the classic Chain Reaction game.

Implemented:
- Per-cell observations and legal action masks over the board.
- Critical-mass explosion mechanics with cascading chain reactions.
- Ownership conversion and elimination-based win conditions.
- Renderer/demo support for visualizing board state and gameplay.

Demo:

![Chain Reaction demo](https://github.com/vyomakesh0728/PufferLib/releases/download/chainenv-pr-assets/chain_reaction_demo.gif)
