### PR TITLE
Optimize CUDA Breakout rollout and training

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,8 @@ set -e
 #   ./build.sh breakout --fast       # Standalone executable (optimized)
 #   ./build.sh breakout --web        # Emscripten web build
 #   ./build.sh breakout --profile    # Kernel profiling binary
+#   ./build.sh breakout --cuda-env-test # CUDA environment parity test
+#   ./build.sh breakout --cpu-env    # Force the legacy CPU environment path
 #   ./build.sh all                   # Build all envs native and native float32
 
 if [ -z "$1" ]; then
@@ -27,6 +29,8 @@ for arg in "$@"; do
         --fast)  MODE=fast ;;
         --web)   MODE=web ;;
         --profile) MODE=profile ;;
+        --cuda-env-test) MODE=cuda_env_test ;;
+        --cpu-env) CPU_ENV="-DPUFFER_CPU_ENV" ;;
         --cpu)   MODE=cpu ;;
         *) echo "Error: unknown argument '$arg'" && exit 1 ;;
     esac
@@ -220,7 +224,15 @@ elif [ "$MODE" = "cpu" ]; then
     exit 0
 fi
 
-CUDA_HOME=${CUDA_HOME:-${CUDA_PATH:-$(dirname "$(dirname "$(which nvcc)")")}}
+if [ -n "$CUDA_HOME" ]; then
+    :
+elif [ -n "$CUDA_PATH" ]; then
+    CUDA_HOME="$CUDA_PATH"
+elif [ -x /usr/local/cuda/bin/nvcc ]; then
+    CUDA_HOME=/usr/local/cuda
+else
+    CUDA_HOME=$(dirname "$(dirname "$(readlink -f "$(command -v nvcc)")")")
+fi
 # NCCL include/lib fallback.
 # Needed when NCCL is provided by the nvidia-nccl-cu12 wheel in the active venv.
 NCCL_IFLAG=""
@@ -231,11 +243,26 @@ done
 for dir in /usr/lib/x86_64-linux-gnu /usr/local/cuda/lib64; do
     if [ -f "$dir/libnccl.so" ] || [ -f "$dir/libnccl.so.2" ]; then NCCL_LFLAG="-L$dir"; break; fi
 done
-if [ -z "$NCCL_IFLAG" ]; then
-    NCCL_IFLAG=$(python -c "import nvidia.nccl, os; print('-I' + os.path.join(nvidia.nccl.__path__[0], 'include'))" 2>/dev/null || echo "")
+NCCL_PY_ROOT=""
+if [ -z "$NCCL_IFLAG" ] || [ -z "$NCCL_LFLAG" ]; then
+    # The training interpreter is not necessarily named `python` (for example,
+    # the CUDA wheels may be installed only for Python 3.12).
+    for python_bin in "${PYTHON:-python}" python3 python3.12; do
+        command -v "$python_bin" >/dev/null 2>&1 || continue
+        NCCL_PY_ROOT=$($python_bin -c \
+            "import nvidia.nccl; print(nvidia.nccl.__path__[0])" 2>/dev/null || true)
+        [ -n "$NCCL_PY_ROOT" ] && break
+    done
 fi
-if [ -z "$NCCL_LFLAG" ]; then
-    NCCL_LFLAG=$(python -c "import nvidia.nccl, os; print('-L' + os.path.join(nvidia.nccl.__path__[0], 'lib'))" 2>/dev/null || echo "")
+if [ -z "$NCCL_IFLAG" ] && [ -f "$NCCL_PY_ROOT/include/nccl.h" ]; then
+    NCCL_IFLAG="-I$NCCL_PY_ROOT/include"
+fi
+if [ -z "$NCCL_LFLAG" ] && [ -d "$NCCL_PY_ROOT/lib" ]; then
+    NCCL_LFLAG="-L$NCCL_PY_ROOT/lib"
+fi
+if [ -z "$NCCL_IFLAG" ]; then
+    echo "Error: nccl.h not found. Install NCCL or the nvidia-nccl-cu12 Python package."
+    exit 1
 fi
 
 export CCACHE_DIR="${CCACHE_DIR:-$HOME/.ccache}"
@@ -244,6 +271,14 @@ export CCACHE_COMPILERCHECK=content
 NVCC="ccache $CUDA_HOME/bin/nvcc"
 CC="${CC:-$(command -v ccache >/dev/null && echo 'ccache clang' || echo 'clang')}"
 ARCH=${NVCC_ARCH:-native}
+CUDA_HOST_COMPAT=()
+NVCC_MAJOR=$($CUDA_HOME/bin/nvcc --version | sed -n 's/.*release \([0-9][0-9]*\).*/\1/p' | head -1)
+if [ "${NVCC_MAJOR:-0}" -ge 13 ]; then
+    # CUDA 13.1 declares rsqrt before current glibc's GNU/C23 declaration.
+    # Default-source mode retains ulong/usleep without enabling the conflicting
+    # GNU math extension declarations.
+    CUDA_HOST_COMPAT+=(-U_GNU_SOURCE -D_DEFAULT_SOURCE)
+fi
 
 ENV_HEADER="$SRC_DIR/$ENV.h"
 mkdir -p build
@@ -267,6 +302,8 @@ if [ "$MODE" = "native" ]; then
 	    -Xcompiler=-DPLATFORM_DESKTOP \
 	    -Xcompiler=-fopenmp \
 	    $PRECISION \
+	    $CPU_ENV \
+	    "${CUDA_HOST_COMPAT[@]}" \
 	    src/pufferl.cu \
         "$RAYLIB_A" \
         -L$CUDA_HOME/lib64 $NCCL_LFLAG \
@@ -285,6 +322,8 @@ elif [ "$MODE" = "profile" ]; then
         -DENV_NAME=$ENV \
         -Xcompiler=-DPLATFORM_DESKTOP \
         $PRECISION \
+        $CPU_ENV \
+        "${CUDA_HOST_COMPAT[@]}" \
         -Xcompiler=-fopenmp \
         tests/profile_kernels.cu \
         "$RAYLIB_A" \
@@ -292,4 +331,26 @@ elif [ "$MODE" = "profile" ]; then
         -lGL -lm -lpthread $OMP_LIB \
         -o profile
     echo "Built: ./profile"
+elif [ "$MODE" = "cuda_env_test" ]; then
+    if [ "$ENV" != "breakout" ]; then
+        echo "Error: --cuda-env-test currently supports breakout only"
+        exit 1
+    fi
+    echo "Compiling CUDA environment parity test ($ARCH)..."
+    $NVCC $NVCC_OPT -arch=$ARCH -std=c++17 \
+        -I. -Isrc -I$SRC_DIR -Ivendor \
+        -I$CUDA_HOME/include $NCCL_IFLAG -I$RAYLIB_NAME/include \
+        "${ENV_COMPILE_FLAGS[@]}" \
+        -DENV_NAME=$ENV \
+        $PRECISION \
+        "${CUDA_HOST_COMPAT[@]}" \
+        -Xcompiler=-DPLATFORM_DESKTOP \
+        -Xcompiler=-fopenmp \
+        tests/test_breakout_cuda.cu \
+        "$RAYLIB_A" \
+        -L$CUDA_HOME/lib64 $NCCL_LFLAG \
+        -lnccl -lnvidia-ml -lcublas -lcurand \
+        -lGL -lm -lpthread $OMP_LIB \
+        -o test_cuda_env
+    echo "Built: ./test_cuda_env"
 fi

--- a/config/breakout.ini
+++ b/config/breakout.ini
@@ -3,7 +3,8 @@ env_name = breakout
 
 [vec]
 total_agents = 4096
-num_buffers = 8
+# fbr: Two full-horizon graphs provide the best verified rollout throughput.
+num_buffers = 2
 num_threads = 8
 
 [policy]

--- a/ocean/breakout/breakout.h
+++ b/ocean/breakout/breakout.h
@@ -20,6 +20,13 @@ typedef float obs_t;
 #define OBS_SIZE 118
 #define NUM_ATNS 1
 
+// fbr: Breakout uses the device-resident environment unless explicitly disabled.
+#ifndef PUFFER_CPU_ENV
+#define PUFFER_CUDA_ENV
+#define PUFFER_BREAKOUT_CUDA
+#define PUFFER_CUDA_ENV_IMPL "ocean/breakout/breakout_cuda.cuh"
+#endif
+
 #define BRICK_INDEX_NO_COLLISION -4
 #define BRICK_INDEX_SIDEWALL_COLLISION -3
 #define BRICK_INDEX_BACKWALL_COLLISION -2

--- a/ocean/breakout/breakout_cuda.cuh
+++ b/ocean/breakout/breakout_cuda.cuh
@@ -1,0 +1,528 @@
+#pragma once
+
+// fbr: Breakout's host Env contains pointers to brick and Agent buffers. Rollouts
+// instead keep one pointer-free state per environment on the GPU. A CUDA graph
+// step writes observations/rewards/terminals directly into the next BF16
+// rollout slice, avoiding both the host step and the float H2D conversion.
+static constexpr int BC_MAX_BRICKS = OBS_SIZE - 10;
+static constexpr int BC_BRICK_WORDS = (BC_MAX_BRICKS + 31) / 32;
+static constexpr float BC_PI = 3.14159265358979323846f;
+
+struct BreakoutCudaState {
+    Log log;
+    float paddle_x, paddle_y;
+    float ball_x, ball_y, ball_vx, ball_vy;
+    float initial_paddle_width, paddle_width, paddle_height, paddle_speed;
+    float ball_speed, initial_ball_speed, max_ball_speed;
+    // fbr: Pack 108 brick flags into four words to keep each environment state compact.
+    unsigned int brick_bits[BC_BRICK_WORDS];
+    int score, balls_fired, hits;
+    int width, height, num_bricks, brick_rows, brick_cols;
+    int ball_width, ball_height, brick_width, brick_height;
+    int num_balls, max_score, half_max_score, tick, frameskip, continuous;
+    unsigned int rng;
+    unsigned char hit_brick;
+};
+
+struct BreakoutCudaCollision {
+    float t, overlap, x, y, vx, vy;
+    int brick_index;
+};
+
+static_assert(sizeof(BreakoutCudaState) % sizeof(unsigned int) == 0,
+    "Breakout CUDA state must remain naturally word-aligned");
+
+__host__ __device__ __forceinline__ bool bc_brick_destroyed(
+        const BreakoutCudaState& state, int brick_idx) {
+    return (state.brick_bits[brick_idx >> 5] >> (brick_idx & 31)) & 1u;
+}
+
+__host__ __device__ __forceinline__ void bc_destroy_brick_bit(
+        BreakoutCudaState& state, int brick_idx) {
+    state.brick_bits[brick_idx >> 5] |= 1u << (brick_idx & 31);
+}
+
+__host__ __device__ __forceinline__ void bc_clear_bricks(
+        BreakoutCudaState& state) {
+    for (int i = 0; i < BC_BRICK_WORDS; ++i) state.brick_bits[i] = 0;
+}
+
+template <typename T>
+__device__ __forceinline__ void bc_store(T* dst, int idx, float value) {
+    dst[idx] = value;
+}
+
+template <>
+__device__ __forceinline__ void bc_store<precision_t>(
+        precision_t* dst, int idx, float value) {
+    dst[idx] = from_float(value);
+}
+
+// fbr: Match glibc rand_r so a CPU and CUDA environment initialized from the same
+// state choose the same launch direction.
+__device__ __forceinline__ int bc_rand_r(unsigned int* seed) {
+    unsigned int next = *seed;
+    int result;
+    next = next * 1103515245u + 12345u;
+    result = (int)((next / 65536u) % 2048u);
+    next = next * 1103515245u + 12345u;
+    result = (result << 10) ^ (int)((next / 65536u) % 1024u);
+    next = next * 1103515245u + 12345u;
+    result = (result << 10) ^ (int)((next / 65536u) % 1024u);
+    *seed = next;
+    return result;
+}
+
+template <typename T>
+__device__ __forceinline__ void bc_observe(
+        const BreakoutCudaState& state, int env_idx, T* observations) {
+    int idx = env_idx * OBS_SIZE;
+    bc_store(observations, idx++, state.paddle_x / state.width);
+    bc_store(observations, idx++, state.paddle_y / state.height);
+    bc_store(observations, idx++, state.ball_x / state.width);
+    bc_store(observations, idx++, state.ball_y / state.height);
+    bc_store(observations, idx++, state.ball_vx / 512.0f);
+    bc_store(observations, idx++, state.ball_vy / 512.0f);
+    bc_store(observations, idx++, state.balls_fired / 5.0f);
+    bc_store(observations, idx++, state.score / 864.0f);
+    bc_store(observations, idx++, state.num_balls / 5.0f);
+    bc_store(observations, idx++, state.paddle_width / (2.0f * HALF_PADDLE_WIDTH));
+    for (int i = 0; i < state.num_bricks; ++i) {
+        bc_store(observations, idx++, bc_brick_destroyed(state, i) ? 1.0f : 0.0f);
+    }
+}
+
+__device__ __forceinline__ bool bc_vline_collision(float xw, float yw, float hw,
+        float x, float y, float vx, float vy, float h, BreakoutCudaCollision* col) {
+    float t = (xw - x) / vx;
+    float top = fminf(yw + hw, y + h + vy * t);
+    float bottom = fmaxf(yw, y + vy * t);
+    float overlap = top - bottom;
+    if (overlap > 0.0f && t > 0.0f && t <= 1.0f
+            && (t < col->t || (t == col->t && overlap > col->overlap))) {
+        col->t = t;
+        col->overlap = overlap;
+        col->x = xw;
+        col->y = y + vy * t;
+        col->vx = -vx;
+        col->vy = vy;
+        return true;
+    }
+    return false;
+}
+
+__device__ __forceinline__ bool bc_hline_collision(float xw, float yw, float ww,
+        float x, float y, float vx, float vy, float w, BreakoutCudaCollision* col) {
+    float t = (yw - y) / vy;
+    float right = fminf(xw + ww, x + w + vx * t);
+    float left = fmaxf(xw, x + vx * t);
+    float overlap = right - left;
+    if (overlap > 0.0f && t > 0.0f && t <= 1.0f
+            && (t < col->t || (t == col->t && overlap > col->overlap))) {
+        col->t = t;
+        col->overlap = overlap;
+        col->x = x + vx * t;
+        col->y = yw;
+        col->vx = vx;
+        col->vy = -vy;
+        return true;
+    }
+    return false;
+}
+
+__device__ __forceinline__ void bc_brick_collision(
+        BreakoutCudaState& state, int brick_idx, BreakoutCudaCollision* col) {
+    int row = brick_idx / state.brick_cols;
+    int column = brick_idx - row * state.brick_cols;
+    float brick_x = column * state.brick_width;
+    float brick_y = row * state.brick_height + Y_OFFSET;
+    bool collision = false;
+    if (state.ball_vx > 0.0f && bc_vline_collision(
+            brick_x, brick_y, state.brick_height,
+            state.ball_x + state.ball_width, state.ball_y,
+            state.ball_vx, state.ball_vy, state.ball_height, col)) {
+        collision = true;
+        col->x -= state.ball_width;
+    }
+    if (state.ball_vx < 0.0f && bc_vline_collision(
+            brick_x + state.brick_width, brick_y, state.brick_height,
+            state.ball_x, state.ball_y, state.ball_vx, state.ball_vy,
+            state.ball_height, col)) {
+        collision = true;
+    }
+    if (state.ball_vy > 0.0f && bc_hline_collision(
+            brick_x, brick_y, state.brick_width,
+            state.ball_x, state.ball_y + state.ball_height,
+            state.ball_vx, state.ball_vy, state.ball_width, col)) {
+        collision = true;
+        col->y -= state.ball_height;
+    }
+    if (state.ball_vy < 0.0f && bc_hline_collision(
+            brick_x, brick_y + state.brick_height, state.brick_width,
+            state.ball_x, state.ball_y, state.ball_vx, state.ball_vy,
+            state.ball_width, col)) {
+        collision = true;
+    }
+    if (collision) col->brick_index = brick_idx;
+}
+
+__device__ __forceinline__ int bc_column(const BreakoutCudaState& state, float x) {
+    return (int)(x / state.brick_width);
+}
+
+__device__ __forceinline__ int bc_row(const BreakoutCudaState& state, float y) {
+    return (int)((y - Y_OFFSET) / state.brick_height);
+}
+
+__device__ __forceinline__ void bc_all_brick_collisions(
+        BreakoutCudaState& state, BreakoutCudaCollision* col) {
+    float ball_x_dst = state.ball_x + state.ball_vx;
+    float ball_y_dst = state.ball_y + state.ball_vy;
+    int row_from = bc_row(state, fminf(state.ball_y, ball_y_dst));
+    row_from = max(row_from, 0);
+    if (row_from > state.brick_rows) return;
+    int column_from = max(bc_column(state, fminf(state.ball_x, ball_x_dst)), 0);
+    int column_to = bc_column(state,
+        fmaxf(ball_x_dst + state.ball_width, state.ball_x + state.ball_width));
+    column_to = min(column_to, state.brick_cols - 1);
+    int row_to = bc_row(state,
+        fmaxf(ball_y_dst + state.ball_height, state.ball_y + state.ball_height));
+    row_to = min(row_to, state.brick_rows - 1);
+    for (int row = row_from; row <= row_to; ++row) {
+        for (int column = column_from; column <= column_to; ++column) {
+            int idx = row * state.brick_cols + column;
+            if (!bc_brick_destroyed(state, idx)) bc_brick_collision(state, idx, col);
+        }
+    }
+}
+
+__device__ __forceinline__ bool bc_paddle_collision(
+        BreakoutCudaState& state, BreakoutCudaCollision* col) {
+    if (state.ball_y + state.ball_height + state.ball_vy < state.paddle_y) return false;
+    if (!bc_hline_collision(state.paddle_x, state.paddle_y, state.paddle_width,
+            state.ball_x, state.ball_y + state.ball_height,
+            state.ball_vx, state.ball_vy, state.ball_width, col)
+            || col->t > 1.0f) return false;
+    col->y -= state.ball_height;
+    col->brick_index = BRICK_INDEX_PADDLE_COLLISION;
+    state.hit_brick = false;
+    float relative = ((state.ball_x + state.ball_width / 2.0f) - state.paddle_x)
+        / state.paddle_width;
+    float angle = -BC_PI / 4.0f + relative * BC_PI / 2.0f;
+    state.ball_vx = sinf(angle) * state.ball_speed * TICK_RATE;
+    state.ball_vy = -cosf(angle) * state.ball_speed * TICK_RATE;
+    state.hits++;
+    if (state.hits % 4 == 0 && state.ball_speed < state.max_ball_speed) {
+        state.ball_speed += 64.0f;
+    }
+    if (state.score == state.half_max_score) {
+        bc_clear_bricks(state);
+    }
+    return true;
+}
+
+__device__ __forceinline__ void bc_wall_collisions(
+        BreakoutCudaState& state, BreakoutCudaCollision* col) {
+    if (state.ball_vx < 0.0f && bc_vline_collision(0, 0, state.height,
+            state.ball_x, state.ball_y, state.ball_vx, state.ball_vy,
+            state.ball_height, col)) {
+        col->brick_index = BRICK_INDEX_SIDEWALL_COLLISION;
+    }
+    if (state.ball_vx > 0.0f && bc_vline_collision(state.width, 0, state.height,
+            state.ball_x + state.ball_width, state.ball_y,
+            state.ball_vx, state.ball_vy, state.ball_height, col)) {
+        col->x -= state.ball_width;
+        col->brick_index = BRICK_INDEX_SIDEWALL_COLLISION;
+    }
+    if (state.ball_vy < 0.0f && bc_hline_collision(0, 0, state.width,
+            state.ball_x, state.ball_y, state.ball_vx, state.ball_vy,
+            state.ball_width, col)) {
+        col->brick_index = BRICK_INDEX_BACKWALL_COLLISION;
+    }
+}
+
+__device__ __forceinline__ void bc_destroy_brick(
+        BreakoutCudaState& state, int brick_idx, float* reward) {
+    int points = 7 - 3 * ((brick_idx / state.brick_cols) / 2);
+    state.score += points;
+    bc_destroy_brick_bit(state, brick_idx);
+    *reward += points;
+    if (brick_idx / state.brick_cols < 3) state.ball_speed = state.max_ball_speed;
+}
+
+__device__ __forceinline__ bool bc_handle_collisions(
+        BreakoutCudaState& state, float* reward) {
+    BreakoutCudaCollision col = {
+        2.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f, BRICK_INDEX_NO_COLLISION
+    };
+    float offset = state.max_ball_speed * 1.1f * TICK_RATE;
+    if (state.ball_x < 0.0f) state.ball_x += offset;
+    if (state.ball_x > state.width) state.ball_x -= offset;
+    if (state.ball_y < 0.0f) state.ball_y += offset;
+    bc_all_brick_collisions(state, &col);
+    bc_wall_collisions(state, &col);
+    bc_paddle_collision(state, &col);
+    if (col.brick_index != BRICK_INDEX_PADDLE_COLLISION && col.t <= 1.0f) {
+        state.ball_x = col.x;
+        state.ball_y = col.y;
+        state.ball_vx = col.vx;
+        state.ball_vy = col.vy;
+        if (col.brick_index >= 0) bc_destroy_brick(state, col.brick_index, reward);
+        if (col.brick_index == BRICK_INDEX_BACKWALL_COLLISION) {
+            state.paddle_width = HALF_PADDLE_WIDTH;
+        }
+    }
+    return col.brick_index != BRICK_INDEX_NO_COLLISION;
+}
+
+__device__ __forceinline__ void bc_reset_round(BreakoutCudaState& state) {
+    state.balls_fired = 0;
+    state.hit_brick = false;
+    state.hits = 0;
+    state.ball_speed = state.initial_ball_speed;
+    state.paddle_width = state.initial_paddle_width;
+    state.paddle_x = state.width / 2.0f - state.paddle_width / 2.0f;
+    state.paddle_y = state.height - state.paddle_height - 10.0f;
+    state.ball_x = state.paddle_x
+        + (state.paddle_width / 2.0f - state.ball_width / 2.0f);
+    state.ball_y = state.height / 2.0f - 30.0f;
+    state.ball_vx = 0.0f;
+    state.ball_vy = 0.0f;
+}
+
+__device__ __forceinline__ void bc_reset(BreakoutCudaState& state) {
+    state.score = 0;
+    state.num_balls = 5;
+    bc_clear_bricks(state);
+    bc_reset_round(state);
+    state.tick = 0;
+}
+
+__device__ __forceinline__ void bc_add_log(BreakoutCudaState& state) {
+    state.log.episode_length += state.tick;
+    state.log.episode_return += state.score;
+    state.log.score += state.score;
+    state.log.perf += state.score / (float)state.max_score;
+    state.log.n += 1.0f;
+}
+
+__device__ __forceinline__ void bc_step_frame(
+        BreakoutCudaState& state, float action, float* reward, float* terminal) {
+    float act = 0.0f;
+    if (state.balls_fired == 0) {
+        state.balls_fired = 1;
+        float direction = BC_PI / 3.25f;
+        state.ball_vy = cosf(direction) * state.ball_speed * TICK_RATE;
+        state.ball_vx = sinf(direction) * state.ball_speed * TICK_RATE;
+        if (bc_rand_r(&state.rng) % 2 == 0) state.ball_vx = -state.ball_vx;
+    } else if (action == LEFT) {
+        act = -1.0f;
+    } else if (action == RIGHT) {
+        act = 1.0f;
+    }
+    if (state.continuous) act = action;
+    state.paddle_x += act * state.paddle_speed * TICK_RATE;
+    state.paddle_x = fminf(fmaxf(state.paddle_x, 0.0f),
+        state.width - state.paddle_width);
+    if (!bc_handle_collisions(state, reward)) {
+        state.ball_x += state.ball_vx;
+        state.ball_y += state.ball_vy;
+    }
+    if (state.ball_y >= state.paddle_y + state.paddle_height) {
+        state.num_balls--;
+        bc_reset_round(state);
+    }
+    if (state.num_balls < 0 || state.score == state.max_score) {
+        *terminal = 1.0f;
+        bc_add_log(state);
+        bc_reset(state);
+    }
+}
+
+template <typename T>
+__global__ void bc_init_output(
+        const BreakoutCudaState* states, int count, T* obs, T* rewards, T* terminals) {
+    int env_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (env_idx >= count) return;
+    bc_observe(states[env_idx], env_idx, obs);
+    bc_store(rewards, env_idx, 0.0f);
+    bc_store(terminals, env_idx, 0.0f);
+}
+
+template <typename T>
+__global__ void bc_step(BreakoutCudaState* states, int count,
+        const precision_t* actions,
+        T* observations, T* rewards, T* terminals) {
+    int env_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    bool valid = env_idx < count;
+    extern __shared__ unsigned int shared_words[];
+    BreakoutCudaState* local_states = (BreakoutCudaState*)shared_words;
+    BreakoutCudaState* local = &local_states[threadIdx.x];
+    if (valid) *local = states[env_idx];
+    __syncthreads();
+
+    if (valid) {
+        float reward = 0.0f;
+        float terminal = 0.0f;
+        float action = to_float(actions[env_idx * NUM_ATNS]);
+        for (int frame = 0; frame < local->frameskip; ++frame) {
+            local->tick++;
+            bc_step_frame(*local, action, &reward, &terminal);
+        }
+        (void)observations;
+        bc_store(rewards, env_idx, reward);
+        bc_store(terminals, env_idx, terminal);
+    }
+    if (valid) states[env_idx] = *local;
+}
+
+// fbr: Physics is most efficient with one lane per independent environment. The
+// observation has the opposite layout: one warp per environment makes its 118
+// contiguous feature stores coalesced and supplies enough warps to fill every
+// SM. A separate graph node avoids running scalar physics on only one lane.
+static constexpr int BC_OBSERVE_WARPS_PER_BLOCK = 4;
+static constexpr int BC_OBSERVE_BLOCK_SIZE = 32 * BC_OBSERVE_WARPS_PER_BLOCK;
+
+template <typename T>
+__global__ void bc_observe_warp(const BreakoutCudaState* states, int count,
+        T* observations) {
+    int warp_in_block = threadIdx.x >> 5;
+    int lane = threadIdx.x & 31;
+    int env_idx = blockIdx.x * BC_OBSERVE_WARPS_PER_BLOCK + warp_in_block;
+    if (env_idx >= count) return;
+
+    const BreakoutCudaState& state = states[env_idx];
+    int base = env_idx * OBS_SIZE;
+    if (lane < 10) {
+        float value;
+        switch (lane) {
+            case 0: value = state.paddle_x / state.width; break;
+            case 1: value = state.paddle_y / state.height; break;
+            case 2: value = state.ball_x / state.width; break;
+            case 3: value = state.ball_y / state.height; break;
+            case 4: value = state.ball_vx / 512.0f; break;
+            case 5: value = state.ball_vy / 512.0f; break;
+            case 6: value = state.balls_fired / 5.0f; break;
+            case 7: value = state.score / 864.0f; break;
+            case 8: value = state.num_balls / 5.0f; break;
+            default:
+                value = state.paddle_width / (2.0f * HALF_PADDLE_WIDTH);
+                break;
+        }
+        bc_store(observations, base + lane, value);
+    }
+    for (int brick = lane; brick < state.num_bricks; brick += 32) {
+        bc_store(observations, base + 10 + brick,
+            bc_brick_destroyed(state, brick) ? 1.0f : 0.0f);
+    }
+}
+
+__global__ void bc_clear_logs(BreakoutCudaState* states, int count) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < count) states[idx].log = {};
+}
+
+static int bc_block_size = 32;
+
+static BreakoutCudaState bc_from_host(const Breakout& env) {
+    BreakoutCudaState state = {};
+    state.log = env.log;
+    state.paddle_x = env.paddle_x; state.paddle_y = env.paddle_y;
+    state.ball_x = env.ball_x; state.ball_y = env.ball_y;
+    state.ball_vx = env.ball_vx; state.ball_vy = env.ball_vy;
+    state.initial_paddle_width = env.initial_paddle_width;
+    state.paddle_width = env.paddle_width; state.paddle_height = env.paddle_height;
+    state.paddle_speed = env.paddle_speed; state.ball_speed = env.ball_speed;
+    state.initial_ball_speed = env.initial_ball_speed;
+    state.max_ball_speed = env.max_ball_speed;
+    for (int i = 0; i < env.num_bricks; ++i) {
+        if (env.brick_states[i] != 0.0f) bc_destroy_brick_bit(state, i);
+    }
+    state.score = env.score; state.balls_fired = env.balls_fired; state.hits = env.hits;
+    state.width = env.width; state.height = env.height; state.num_bricks = env.num_bricks;
+    state.brick_rows = env.brick_rows; state.brick_cols = env.brick_cols;
+    state.ball_width = env.ball_width; state.ball_height = env.ball_height;
+    state.brick_width = env.brick_width; state.brick_height = env.brick_height;
+    state.num_balls = env.num_balls; state.max_score = env.max_score;
+    state.half_max_score = env.half_max_score; state.tick = env.tick;
+    state.frameskip = env.frameskip; state.continuous = env.continuous;
+    state.rng = env.rng; state.hit_brick = env.hit_brick;
+    return state;
+}
+
+static void puf_cuda_env_init(VecEnv* vec, cudaStream_t stream) {
+    int count = vec->size;
+    if (!vec->gpu_env_state) {
+        cudaMalloc(&vec->gpu_env_state, (size_t)count * sizeof(BreakoutCudaState));
+    }
+    BreakoutCudaState* host = (BreakoutCudaState*)calloc(count, sizeof(*host));
+    for (int i = 0; i < count; ++i) {
+        Breakout& env = ((Breakout*)vec->envs)[i];
+        assert(env.num_bricks <= BC_MAX_BRICKS);
+        host[i] = bc_from_host(env);
+    }
+    cudaMemcpyAsync(vec->gpu_env_state, host, (size_t)count * sizeof(*host),
+        cudaMemcpyHostToDevice, stream);
+    cudaStreamSynchronize(stream);
+    free(host);
+
+    size_t shared_bytes = (size_t)bc_block_size * sizeof(BreakoutCudaState);
+    cudaFuncSetAttribute(bc_step<float>, cudaFuncAttributeMaxDynamicSharedMemorySize,
+        (int)shared_bytes);
+    cudaFuncSetAttribute(bc_step<precision_t>, cudaFuncAttributeMaxDynamicSharedMemorySize,
+        (int)shared_bytes);
+    bc_init_output<float><<<grid_size(count), BLOCK_SIZE, 0, stream>>>(
+        (BreakoutCudaState*)vec->gpu_env_state, count,
+        vec->gpu_observations, vec->gpu_rewards, vec->gpu_terminals);
+}
+
+template <typename T>
+static void bc_launch_step(VecEnv* vec, int env_start, int env_count,
+        const precision_t* actions, T* observations, T* rewards, T* terminals,
+        cudaStream_t stream) {
+    size_t shared_bytes = (size_t)bc_block_size * sizeof(BreakoutCudaState);
+    bc_step<T><<<(env_count + bc_block_size - 1) / bc_block_size,
+        bc_block_size, shared_bytes, stream>>>(
+        (BreakoutCudaState*)vec->gpu_env_state + env_start, env_count,
+        actions, observations, rewards, terminals);
+    bc_observe_warp<T><<<(env_count + BC_OBSERVE_WARPS_PER_BLOCK - 1)
+            / BC_OBSERVE_WARPS_PER_BLOCK,
+        BC_OBSERVE_BLOCK_SIZE, 0, stream>>>(
+        (BreakoutCudaState*)vec->gpu_env_state + env_start, env_count,
+        observations);
+}
+
+static void puf_cuda_env_step(VecEnv* vec, int env_start, int env_count,
+        int agent_start, int agent_count, const precision_t* actions,
+        float* observations, float* rewards, float* terminals, cudaStream_t stream) {
+    (void)agent_start; (void)agent_count;
+    bc_launch_step(vec, env_start, env_count, actions,
+        observations, rewards, terminals, stream);
+}
+
+static void puf_cuda_env_step_direct(VecEnv* vec, int env_start, int env_count,
+        int agent_start, int agent_count, const precision_t* actions,
+        precision_t* observations, precision_t* rewards, precision_t* terminals,
+        cudaStream_t stream) {
+    (void)agent_start; (void)agent_count;
+    bc_launch_step(vec, env_start, env_count, actions,
+        observations, rewards, terminals, stream);
+}
+
+static void puf_cuda_env_sync_logs(VecEnv* vec, int clear, cudaStream_t stream) {
+    int count = vec->size;
+    BreakoutCudaState* host = (BreakoutCudaState*)malloc((size_t)count * sizeof(*host));
+    cudaMemcpy(host, vec->gpu_env_state, (size_t)count * sizeof(*host),
+        cudaMemcpyDeviceToHost);
+    for (int i = 0; i < count; ++i) ((Breakout*)vec->envs)[i].log = host[i].log;
+    free(host);
+    if (clear) {
+        bc_clear_logs<<<grid_size(count), BLOCK_SIZE, 0, stream>>>(
+            (BreakoutCudaState*)vec->gpu_env_state, count);
+    }
+}
+
+static void puf_cuda_env_close(VecEnv* vec) {
+    if (vec->gpu_env_state) cudaFree(vec->gpu_env_state);
+    vec->gpu_env_state = nullptr;
+}

--- a/src/algo.cu
+++ b/src/algo.cu
@@ -276,9 +276,15 @@ __global__ void mingru_scan_forward(PrefixScan scan) {
 
 // Reads sparse checkpoints from forward pass
 // Recomputes intermediate values in chunks (faster on benchmarks)
-__global__ void mingru_scan_backward(PrefixScan scan,
-        const precision_t* __restrict__ grad_out,
-        const precision_t* __restrict__ grad_next_state) {
+__global__ __launch_bounds__(BLOCK_SIZE, 4) void mingru_scan_backward(PrefixScan scan,
+        const precision_t* __restrict__ grad_out) {
+    // fbr: Per-thread checkpoint arrays spill to local memory. Give each thread
+    // a four-value shared-memory slot to retain the recomputed scan chunk.
+    __shared__ float sm_chunk_a_star[BLOCK_SIZE * CHECKPOINT_INTERVAL];
+    __shared__ float sm_chunk_s[BLOCK_SIZE * CHECKPOINT_INTERVAL];
+    __shared__ float sm_chunk_log_values[BLOCK_SIZE * CHECKPOINT_INTERVAL];
+    __shared__ float sm_chunk_hidden[BLOCK_SIZE * CHECKPOINT_INTERVAL];
+    __shared__ float sm_chunk_gate[BLOCK_SIZE * CHECKPOINT_INTERVAL];
     int T_seq = scan.T, H = scan.H, B = scan.B;
     precision_t* __restrict__ grad_combined = scan.grad_combined.data;
     precision_t* __restrict__ grad_state = scan.grad_state.data;
@@ -304,6 +310,7 @@ __global__ void mingru_scan_backward(PrefixScan scan,
     int H2 = 2 * H;
     const int state_idx = b * H + h;
     const int out_base = bHT + h;
+    int shared_base = threadIdx.x * CHECKPOINT_INTERVAL;
 
     const precision_t* combined_h_base = &combined[cbase + h];
     const precision_t* combined_g_base = &combined[cbase + H + h];
@@ -323,13 +330,6 @@ __global__ void mingru_scan_backward(PrefixScan scan,
     for (int chunk_end = T_seq; chunk_end > 0; chunk_end -= CHECKPOINT_INTERVAL) {
         int chunk_start = (chunk_end > CHECKPOINT_INTERVAL) ? (chunk_end - CHECKPOINT_INTERVAL) : 0;
         int chunk_len = chunk_end - chunk_start;
-
-        // Chunk storage in registers
-        float chunk_a_star[CHECKPOINT_INTERVAL];
-        float chunk_s[CHECKPOINT_INTERVAL];
-        float chunk_log_values[CHECKPOINT_INTERVAL];
-        float chunk_hidden[CHECKPOINT_INTERVAL];
-        float chunk_gate[CHECKPOINT_INTERVAL];
 
         // Load checkpoint from global memory
         int ckpt_buf_idx = buf_base + chunk_start * H;
@@ -351,22 +351,22 @@ __global__ void mingru_scan_backward(PrefixScan scan,
             float z = recomp_log_value - recomp_a_star;
             recomp_s = logaddexp(recomp_s, z);
 
-            chunk_a_star[i] = recomp_a_star;
-            chunk_s[i] = recomp_s;
-            chunk_log_values[i] = recomp_log_value;
-            chunk_hidden[i] = hv;
-            chunk_gate[i] = gv;
+            sm_chunk_a_star[shared_base + i] = recomp_a_star;
+            sm_chunk_s[shared_base + i] = recomp_s;
+            sm_chunk_log_values[shared_base + i] = recomp_log_value;
+            sm_chunk_hidden[shared_base + i] = hv;
+            sm_chunk_gate[shared_base + i] = gv;
         }
 
         for (int i = chunk_len - 1; i >= 0; --i) {
             int t = chunk_start + 1 + i;
             int t_offset = (t - 1) * H3;
 
-            float a_star_t = chunk_a_star[i];
-            float s_t = chunk_s[i];
-            float log_value_t = chunk_log_values[i];
-            float hidden_val = chunk_hidden[i];
-            float gate_val = chunk_gate[i];
+            float a_star_t = sm_chunk_a_star[shared_base + i];
+            float s_t = sm_chunk_s[shared_base + i];
+            float log_value_t = sm_chunk_log_values[shared_base + i];
+            float hidden_val = sm_chunk_hidden[shared_base + i];
+            float gate_val = sm_chunk_gate[shared_base + i];
 
             float proj_val = to_float(combined_p_base[t_offset]);
             int input_idx = out_base + (t - 1) * H;
@@ -376,11 +376,10 @@ __global__ void mingru_scan_backward(PrefixScan scan,
             float z = log_value_t - a_star_t;
 
             float grad_out_val = to_float(grad_out[input_idx]);
-            float grad_scan_from_next = (t == T_seq) ? to_float(grad_next_state[state_idx]) : 0.0f;
             float proj_sigmoid = sigmoid(proj_val);
 
             // Highway gate gradients: out = sigmoid(proj) * scan_result + (1 - sigmoid(proj)) * x
-            float grad_scan_result = grad_scan_from_next + grad_out_val * proj_sigmoid;
+            float grad_scan_result = grad_out_val * proj_sigmoid;
             float grad_proj = grad_out_val * (scan_result - x_val) * proj_sigmoid * (1.0f - proj_sigmoid);
             grad_input[input_idx] = from_float(grad_out_val * (1.0f - proj_sigmoid));
 
@@ -452,7 +451,10 @@ __global__ void assemble_decoder_grad(
 static PrecisionTensor encoder_forward(void* w, void* activations, PrecisionTensor input, cudaStream_t stream) {
     EncoderWeights* ew = (EncoderWeights*)w;
     EncoderActivations* a = (EncoderActivations*)activations;
-    if (a->saved_input.data) puf_copy(&a->saved_input, &input, stream);
+    // fbr: Training inputs remain live through backward. Alias them instead of
+    // copying the full minibatch solely for the weight-gradient GEMM.
+    // fbr: Alias the live decoder input instead of materializing a training copy.
+    if (a->saved_input.shape[0]) a->saved_input.data = input.data;
     puf_mm(&input, &ew->weight, &a->out, stream);
     return a->out;
 }
@@ -486,7 +488,6 @@ static void encoder_reg_train(void* w, void* activations, Allocator* acts, Alloc
         .wgrad_scratch =    {.shape = {ew->out_dim, ew->in_dim}},
     };
     alloc_register(acts,&a->out);
-    alloc_register(acts,&a->saved_input);
     alloc_register(grads,&a->wgrad_scratch);
 }
 
@@ -525,9 +526,7 @@ struct DecoderActivations {
 static PrecisionTensor decoder_forward(void* w, void* activations, PrecisionTensor input, cudaStream_t stream) {
     DecoderWeights* dw = (DecoderWeights*)w;
     DecoderActivations* a = (DecoderActivations*)activations;
-    if (a->saved_input.data) {
-        puf_copy(&a->saved_input, &input, stream);
-    }
+    if (a->saved_input.shape[0]) a->saved_input.data = input.data;
     puf_mm(&input, &dw->weight, &a->out, stream);
     return a->out;
 }
@@ -564,7 +563,6 @@ static void decoder_reg_train(void* w, void* activations, Allocator* acts, Alloc
         .logstd_scratch =   {.shape = {1, dw->output_dim}},
     };
     alloc_register(acts,&a->out);
-    alloc_register(acts,&a->saved_input);
     alloc_register(acts,&a->grad_out);
     alloc_register(acts,&a->grad_input);
     alloc_register(grads,&a->wgrad_scratch);
@@ -622,7 +620,8 @@ struct MinGRUActivations {
     PrecisionTensor* combined_bufs;  // (B*TT, 3*T)[num_layers]
     PrecisionTensor* wgrad_scratch;  // (3*T, T)[num_layers]
     PrecisionTensor grad_input_buf;  // (B*TT, T)
-    PrecisionTensor grad_next_state; // (B, 1, T)
+    // fbr: There is no grad_next_state buffer: truncated minibatches never
+    // propagate a gradient across their initial recurrent-state boundary.
 };
 
 void mingru_activations_free(MinGRUActivations* a) {
@@ -672,9 +671,7 @@ static void mingru_reg_train(void* w, void* activations, Allocator* acts, Alloca
     a->combined_bufs = (PrecisionTensor*)calloc(m->num_layers, sizeof(PrecisionTensor));
     a->wgrad_scratch = (PrecisionTensor*)calloc(m->num_layers, sizeof(PrecisionTensor));
     a->grad_input_buf = {.shape = {B_TT, H}};
-    a->grad_next_state = {.shape = {B, 1, H}};
     alloc_register(acts,&a->grad_input_buf);
-    alloc_register(acts,&a->grad_next_state);
     for (int i = 0; i < m->num_layers; i++) {
         a->scan_bufs[i] = {
             .B = B, .T = TT, .H = H,
@@ -690,7 +687,6 @@ static void mingru_reg_train(void* w, void* activations, Allocator* acts, Alloca
         a->saved_inputs[i]  = {.shape = {B, TT, H}};
         a->combined_bufs[i] = {.shape = {B_TT, 3 * H}};
         a->wgrad_scratch[i] = {.shape = {3 * H, H}};
-        alloc_register(acts,&a->saved_inputs[i]);
         alloc_register(acts,&a->combined_bufs[i]);
         alloc_register(acts,&a->scan_bufs[i].out);
         alloc_register(acts,&a->scan_bufs[i].next_state);
@@ -699,7 +695,6 @@ static void mingru_reg_train(void* w, void* activations, Allocator* acts, Alloca
         alloc_register(acts,&a->scan_bufs[i].log_values_buf);
         alloc_register(acts,&a->scan_bufs[i].grad_combined);
         alloc_register(acts,&a->scan_bufs[i].grad_state);
-        alloc_register(acts,&a->scan_bufs[i].grad_input);
         alloc_register(grads,&a->wgrad_scratch[i]);
     }
 }
@@ -764,48 +759,33 @@ static PrecisionTensor mingru_forward_train(void* w, PrecisionTensor x, Precisio
     MinGRUActivations* a = (MinGRUActivations*)activations;
     int B = x.shape[0];
     for (int i = 0; i < m->num_layers; i++) {
-        puf_copy(&a->saved_inputs[i], &x, stream);
+        // fbr: Each layer input remains live until backward; retain its pointer.
+        a->saved_inputs[i].data = x.data;
         PrecisionTensor state_i = mingru_state_layer(m, state, i);
         puf_mm(&x, &m->weights[i], &a->combined_bufs[i], stream);
         a->scan_bufs[i].combined_ptr = a->combined_bufs[i].data;
         a->scan_bufs[i].state_ptr = state_i.data;
         a->scan_bufs[i].input_ptr = a->saved_inputs[i].data;
-        mingru_scan_forward<<<grid_size(B*m->hidden), BLOCK_SIZE, 0, stream>>>(a->scan_bufs[i]);
+        mingru_scan_forward<<<grid_size(B*m->hidden), BLOCK_SIZE, 0, stream>>>(
+            a->scan_bufs[i]);
         x = a->scan_bufs[i].out;
     }
     return x;
 }
-
-__global__ void add_kernel(float* __restrict__ dst,
-        const precision_t* __restrict__ src, int n) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx < n) {
-        dst[idx] += to_float(src[idx]);
-    }
-}
-
-#ifndef PRECISION_FLOAT
-__global__ void add_kernel(precision_t* __restrict__ dst,
-        const precision_t* __restrict__ src, int n) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx < n) {
-        dst[idx] = from_float(to_float(dst[idx]) + to_float(src[idx]));
-    }
-}
-#endif
 
 static PrecisionTensor mingru_backward(void* w, PrecisionTensor grad, void* activations, cudaStream_t stream) {
     MinGRUWeights* m = (MinGRUWeights*)w;
     MinGRUActivations* a = (MinGRUActivations*)activations;
     for (int i = m->num_layers - 1; i >= 0; i--) {
         PrefixScan& scan = a->scan_bufs[i];
+        // fbr: Write the highway branch into the GEMM destination. beta=1 then
+        // accumulates the projected recurrent gradient in the same pass.
+        scan.grad_input.data = a->grad_input_buf.data;
         mingru_scan_backward<<<grid_size(scan.B*scan.H), BLOCK_SIZE, 0, stream>>>(
-            scan, grad.data, a->grad_next_state.data);
+            scan, grad.data);
         puf_mm_tn(&scan.grad_combined, &a->saved_inputs[i], &a->wgrad_scratch[i], stream);
-        puf_mm_nn(&scan.grad_combined, &m->weights[i], &a->grad_input_buf, stream);
-        int n = numel(scan.grad_input.shape);
-        add_kernel<<<grid_size(n), BLOCK_SIZE, 0, stream>>>(
-            a->grad_input_buf.data, scan.grad_input.data, n);
+        puf_mm_nn(&scan.grad_combined, &m->weights[i], &a->grad_input_buf,
+            stream, 1.0f, 1.0f);
         grad = a->grad_input_buf;
     }
     return grad;
@@ -1013,6 +993,37 @@ __global__ void muon_norm_apply(precision_t* __restrict__ dst, const float* __re
     }
 }
 
+// fbr: Normalize one or more contiguous matrix slices in a single launch. Muon's
+// small matrices were previously paying three launches per slice (partials,
+// reduce, apply), which dominates the 4x64 decoder and the six packed GRU
+// slices. One block owns a slice and reuses its reduction result immediately.
+__global__ void muon_normalize_slices(precision_t* __restrict__ data,
+        int slice_elems, int slices, float eps) {
+    __shared__ float sum_data[256];
+    __shared__ float inv_norm;
+    int slice = blockIdx.x;
+    if (slice >= slices) return;
+    precision_t* base = data + (long)slice * slice_elems;
+    float sum = 0.0f;
+    for (int i = threadIdx.x; i < slice_elems; i += blockDim.x) {
+        float value = to_float(base[i]);
+        sum += value * value;
+    }
+    sum_data[threadIdx.x] = sum;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            sum_data[threadIdx.x] += sum_data[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) inv_norm = 1.0f / fmaxf(sqrtf(sum_data[0]), eps);
+    __syncthreads();
+    for (int i = threadIdx.x; i < slice_elems; i += blockDim.x) {
+        base[i] = from_float(to_float(base[i]) * inv_norm);
+    }
+}
+
 // Nesterov with f32 momentum accumulator and precision_t gradients
 __global__ void muon_nesterov(float* __restrict__ mb, precision_t* __restrict__ gc, float mu, int n) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -1119,6 +1130,7 @@ void muon_init(Muon* m, Allocator* param_alloc, double lr_val,
     }
 }
 
+
 void muon_post_create(Muon* m) {
     m->lr_ptr = m->lr_puf.data;
     m->lr_derived_ptr = m->lr_derived_puf.data;
@@ -1142,6 +1154,7 @@ void muon_step(Muon* m, FloatTensor weights, PrecisionTensor grads, float max_gr
     muon_nesterov<<<grid_size(numel(m->mb_puf.shape)), BLOCK_SIZE, 0, stream>>>(
         m->mb_puf.data, grads.data, (float)m->momentum, numel(m->mb_puf.shape));
 
+
     long offset = 0;
     for (int _i = 0; _i < m->param_alloc->num_regs; _i++) {
         AllocEntry& e = m->param_alloc->regs[_i];
@@ -1154,37 +1167,37 @@ void muon_step(Muon* m, FloatTensor weights, PrecisionTensor grads, float max_gr
         // Orthogonalize the update
         if (ndim(e.shape) >= 2) {
             long R = e.shape[0], C = ne / R;
-            long M = min(R, C), N = max(R, C);
-            bool tall = R > C;
-            PrecisionTensor x = {.data = gc_ptr, .shape = {R, C}};
-            PrecisionTensor x_buf = {.data = m->x_buf.data, .shape = {R, C}};
-            PrecisionTensor gram = {.data = m->gram.data, .shape = {M, M}};
-            PrecisionTensor gram_buf = {.data = m->gram_buf.data, .shape = {M, M}};
+                long M = min(R, C), N = max(R, C);
+                bool tall = R > C;
+                PrecisionTensor x = {.data = gc_ptr, .shape = {R, C}};
+                PrecisionTensor x_buf = {.data = m->x_buf.data, .shape = {R, C}};
+                PrecisionTensor gram = {.data = m->gram.data, .shape = {M, M}};
+                PrecisionTensor gram_buf = {.data = m->gram_buf.data, .shape = {M, M}};
 
-            int nblk = min((int)grid_size(numel(x.shape)), 256);
-            muon_norm_partials<<<nblk, 256, 0, stream>>>(
-                m->norm_partials.data, x.data, numel(x.shape));
-            muon_norm_reduce<<<1, 256, 0, stream>>>(m->norm_ptr, m->norm_partials.data, nblk);
-            muon_norm_apply<<<grid_size(numel(x.shape)), BLOCK_SIZE, 0, stream>>>(
-                x.data, m->norm_ptr, 1e-7f, numel(x.shape));
+                muon_normalize_slices<<<1,256,0,stream>>>(
+                    x.data, numel(x.shape), 1, 1e-7f);
 
-            cublasOperation_t gram_op_a = tall ? CUBLAS_OP_T : CUBLAS_OP_N;
-            cublasOperation_t gram_op_b = tall ? CUBLAS_OP_N : CUBLAS_OP_T;
-            for (int i = 0; i < 5; ++i) {
-                PrecisionTensor& src = (i % 2 == 0) ? x : x_buf;
-                PrecisionTensor& dst = (i % 2 == 0) ? x_buf : x;
-                cublasGemmExDense(gram_op_a, gram_op_b, (int)M, (int)M, (int)N,
-                    src.data, src.data, gram.data, stream);
-                puf_copy(&gram_buf, &gram, stream);
-                puf_addmm_nn(&gram, &gram, &gram_buf, ns_coeffs[i][2], ns_coeffs[i][1], stream);
-                puf_copy(&dst, &src, stream);
-                cublasGemmExDense(CUBLAS_OP_N, CUBLAS_OP_N, (int)R, (int)C, (int)M,
-                    tall ? src.data : gram_buf.data, tall ? gram_buf.data : src.data, dst.data,
-                    stream, 1.0f, ns_coeffs[i][0]);
-            }
+                cublasOperation_t gram_op_a = tall ? CUBLAS_OP_T : CUBLAS_OP_N;
+                cublasOperation_t gram_op_b = tall ? CUBLAS_OP_N : CUBLAS_OP_T;
+                for (int i = 0; i < 5; ++i) {
+                    PrecisionTensor& src = (i % 2 == 0) ? x : x_buf;
+                    PrecisionTensor& dst = (i % 2 == 0) ? x_buf : x;
+                    cublasGemmExDense(gram_op_a, gram_op_b,
+                        (int)M, (int)M, (int)N,
+                        src.data, src.data, gram.data, stream);
+                    puf_copy(&gram_buf, &gram, stream);
+                    puf_addmm_nn(&gram, &gram, &gram_buf,
+                        ns_coeffs[i][2], ns_coeffs[i][1], stream);
+                    puf_copy(&dst, &src, stream);
+                    cublasGemmExDense(CUBLAS_OP_N, CUBLAS_OP_N,
+                        (int)R, (int)C, (int)M,
+                        tall ? src.data : gram_buf.data,
+                        tall ? gram_buf.data : src.data,
+                        dst.data, stream, 1.0f, ns_coeffs[i][0]);
+                }
 
-            update_ptr = x_buf.data;
-            scale = sqrtf(fmaxf(1.0f, (float)R / (float)C));
+                update_ptr = x_buf.data;
+                scale = sqrtf(fmaxf(1.0f, (float)R / (float)C));
         }
 
         muon_weight_update<<<grid_size(ne), BLOCK_SIZE, 0, stream>>>(
@@ -1490,6 +1503,8 @@ struct PPOBuffersPuf {
 
 void register_ppo_buffers(PPOBuffersPuf& bufs, Allocator* alloc, int N, int T, int A_total, bool is_continuous) {
     long total = (long)N * T;
+    // fbr: Reserve partial sums for a parallel mean/variance reduction.
+    int moment_blocks = min((int)grid_size(total), 256);
     bufs = (PPOBuffersPuf){
         .loss_output = {.shape = {1}},
         .grad_loss = {.shape = {1}},
@@ -1497,7 +1512,7 @@ void register_ppo_buffers(PPOBuffersPuf& bufs, Allocator* alloc, int N, int T, i
         .grad_logits = {.shape = {N, T, A_total}},
         .grad_values = {.shape = {N, T, 1}},
         .grad_logstd = {.shape = {N, T, A_total}},
-        .adv_scratch = {.shape = {2}},
+        .adv_scratch = {.shape = {2 + 2 * moment_blocks}},
     };
     alloc_register(alloc, &bufs.loss_output);
     alloc_register(alloc, &bufs.saved_for_bwd);
@@ -1789,42 +1804,58 @@ __global__ void ppo_loss_reduce(
     }
 }
 
-__global__ void ppo_var_mean(const precision_t* __restrict__ src,
-        float* __restrict__ var_out, float* __restrict__ mean_out, int n) {
-    __shared__ float sdata[256];
+// fbr: Replace the single-block two-pass advantage reduction with parallel
+// sum and square-sum partials followed by one deterministic final reduction.
+__global__ void ppo_moments_partials(const precision_t* __restrict__ src,
+        float* __restrict__ sum_out, float* __restrict__ sq_out, int n) {
+    __shared__ float sum_data[256];
+    __shared__ float sq_data[256];
     int tid = threadIdx.x;
     float sum = 0.0f;
-    for (int i = tid; i < n; i += blockDim.x) {
-        sum += to_float(src[i]);
+    float sum_sq = 0.0f;
+    for (int i = blockIdx.x * blockDim.x + tid; i < n;
+            i += blockDim.x * gridDim.x) {
+        float value = to_float(src[i]);
+        sum += value;
+        sum_sq += value * value;
     }
-    sdata[tid] = sum;
+    sum_data[tid] = sum;
+    sq_data[tid] = sum_sq;
     __syncthreads();
     for (int s = blockDim.x / 2; s > 0; s >>= 1) {
         if (tid < s) {
-            sdata[tid] += sdata[tid + s];
+            sum_data[tid] += sum_data[tid + s];
+            sq_data[tid] += sq_data[tid + s];
         }
         __syncthreads();
     }
-    float mean = sdata[0] / (float)n;
     if (tid == 0) {
+        sum_out[blockIdx.x] = sum_data[0];
+        sq_out[blockIdx.x] = sq_data[0];
+    }
+}
+
+__global__ void ppo_moments_reduce(const float* __restrict__ sum_in,
+        const float* __restrict__ sq_in, float* __restrict__ var_out,
+        float* __restrict__ mean_out, int blocks, int n) {
+    __shared__ float sum_data[256];
+    __shared__ float sq_data[256];
+    int tid = threadIdx.x;
+    sum_data[tid] = tid < blocks ? sum_in[tid] : 0.0f;
+    sq_data[tid] = tid < blocks ? sq_in[tid] : 0.0f;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            sum_data[tid] += sum_data[tid + s];
+            sq_data[tid] += sq_data[tid + s];
+        }
+        __syncthreads();
+    }
+    if (tid == 0) {
+        float sum = sum_data[0];
+        float mean = sum / (float)n;
         *mean_out = mean;
-    }
-    __syncthreads();
-    float ss = 0.0f;
-    for (int i = tid; i < n; i += blockDim.x) {
-        float d = to_float(src[i]) - mean;
-        ss += d * d;
-    }
-    sdata[tid] = ss;
-    __syncthreads();
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) {
-            sdata[tid] += sdata[tid + s];
-        }
-        __syncthreads();
-    }
-    if (tid == 0) {
-        *var_out = sdata[0] / (float)(n - 1);
+        *var_out = fmaxf(0.0f, (sq_data[0] - sum * mean) / (float)(n - 1));
     }
 }
 
@@ -1848,8 +1879,14 @@ void ppo_loss_fwd_bwd(
 
     float* adv_var_ptr = bufs.adv_scratch.data;
     float* adv_mean_ptr = adv_var_ptr + 1;
-    ppo_var_mean<<<1, 256, 0, stream>>>(
-        graph.mb_advantages.data, adv_var_ptr, adv_mean_ptr, numel(graph.mb_advantages.shape));
+    int adv_n = numel(graph.mb_advantages.shape);
+    int moment_blocks = min((int)grid_size(adv_n), 256);
+    float* moment_sums = adv_mean_ptr + 1;
+    float* moment_squares = moment_sums + moment_blocks;
+    ppo_moments_partials<<<moment_blocks, 256, 0, stream>>>(
+        graph.mb_advantages.data, moment_sums, moment_squares, adv_n);
+    ppo_moments_reduce<<<1, 256, 0, stream>>>(moment_sums, moment_squares,
+        adv_var_ptr, adv_mean_ptr, moment_blocks, adv_n);
 
     int ppo_grid = (total + PPO_THREADS - 1) / PPO_THREADS;
 

--- a/src/pufferl.cu
+++ b/src/pufferl.cu
@@ -147,12 +147,13 @@ void puf_mm_tn(PrecisionTensor* a, PrecisionTensor* b, PrecisionTensor* out, cud
 }
 
 // out(...,N) = a(...,K) @ b(K,N)  — leading dims folded into M
-void puf_mm_nn(PrecisionTensor* a, PrecisionTensor* b, PrecisionTensor* out, cudaStream_t stream) {
+void puf_mm_nn(PrecisionTensor* a, PrecisionTensor* b, PrecisionTensor* out,
+        cudaStream_t stream, float alpha = 1.0f, float beta = 0.0f) {
     int M = batch_size(a->shape) * a->shape[ndim(a->shape)-2];
     int K = a->shape[ndim(a->shape)-1];
     int N = b->shape[ndim(b->shape)-1];
     cublasGemmExDense(CUBLAS_OP_N, CUBLAS_OP_N, M, N, K,
-        a->data, b->data, out->data, stream);
+        a->data, b->data, out->data, stream, alpha, beta);
 }
 
 __global__ void cast(precision_t* __restrict__ dst,
@@ -757,6 +758,9 @@ typedef int atomic_int;
 
 struct PuffeRL;
 void pufferl_forward(struct PuffeRL* pufferl, int buf, int t, cudaStream_t stream);
+#ifdef PUFFER_CUDA_ENV
+void pufferl_rollout_buffer(struct PuffeRL* pufferl, int buf, cudaStream_t stream);
+#endif
 
 typedef struct ObsTensor {
     obs_t* data;
@@ -810,7 +814,30 @@ typedef struct VecEnv {
     int action_mask_size;
     int num_banks;
     int* bank_layout;
+#ifdef PUFFER_CUDA_ENV
+    // fbr: Pointer-free environment state remains resident on the device.
+    void* gpu_env_state;
+#endif
 } VecEnv;
+
+#ifdef PUFFER_CUDA_ENV
+// fbr: CUDA environment callbacks enqueue device-only work on the rollout stream.
+static void puf_cuda_env_init(VecEnv* vec, cudaStream_t stream);
+static void puf_cuda_env_step(VecEnv* vec, int env_start, int env_count,
+    int agent_start, int agent_count, const precision_t* actions,
+    float* observations, float* rewards, float* terminals,
+    cudaStream_t stream);
+static void puf_cuda_env_step_direct(VecEnv* vec, int env_start, int env_count,
+    int agent_start, int agent_count, const precision_t* actions,
+    precision_t* observations, precision_t* rewards, precision_t* terminals,
+    cudaStream_t stream);
+static void puf_cuda_env_sync_logs(VecEnv* vec, int clear, cudaStream_t stream);
+static void puf_cuda_env_close(VecEnv* vec);
+#ifndef PUFFER_CUDA_ENV_IMPL
+#error "PUFFER_CUDA_ENV requires PUFFER_CUDA_ENV_IMPL to name its adapter implementation"
+#endif
+#include PUFFER_CUDA_ENV_IMPL
+#endif
 
 struct VecWorker {
     VecEnv* vec;
@@ -823,15 +850,18 @@ static void* vec_thread_main(void* arg) {
     VecWorker* worker_arg = (VecWorker*)arg;
     VecEnv* vec = worker_arg->vec;
     int buf = worker_arg->buf;
+#ifndef PUFFER_CUDA_ENV
     int horizon = worker_arg->horizon;
+#endif
     struct PuffeRL* pufferl = worker_arg->pufferl;
 
+#ifndef PUFFER_CUDA_ENV
     int agents_per_buffer = vec->agents_per_buffer;
     int agent_start = buf * agents_per_buffer;
     int env_start = vec->buffer_env_starts[buf];
     int env_count = vec->buffer_env_counts[buf];
-
     Env* envs = vec->envs;
+#endif
 
     while (true) {
         while (atomic_load(&vec->buffer_states[buf]) != OMP_RUNNING) {
@@ -844,6 +874,13 @@ static void* vec_thread_main(void* arg) {
         float* my_accum = &vec->accum[buf * NUM_VEC_PROF];
         struct timespec t0, t1;
 
+#ifdef PUFFER_CUDA_ENV
+        clock_gettime(CLOCK_MONOTONIC, &t0);
+        pufferl_rollout_buffer(pufferl, buf, stream);
+        clock_gettime(CLOCK_MONOTONIC, &t1);
+        my_accum[VEC_GPU] += (t1.tv_sec - t0.tv_sec) * 1000.0f
+            + (t1.tv_nsec - t0.tv_nsec) / 1e6f;
+#else
         for (int t = 0; t < horizon; t++) {
             clock_gettime(CLOCK_MONOTONIC, &t0);
             pufferl_forward(pufferl, buf, t, stream);
@@ -890,6 +927,7 @@ static void* vec_thread_main(void* arg) {
                     cudaMemcpyHostToDevice, stream);
             }
         }
+#endif
         cudaStreamSynchronize(stream);
         atomic_store(&vec->buffer_states[buf], OMP_WAITING);
     }
@@ -1097,6 +1135,9 @@ void vec_reset(VecEnv* vec) {
             (size_t)vec->total_agents * vec->action_mask_size * sizeof(unsigned char),
             cudaMemcpyHostToDevice);
     }
+#ifdef PUFFER_CUDA_ENV
+    puf_cuda_env_init(vec, 0);
+#endif
     cudaDeviceSynchronize();
 }
 
@@ -1139,6 +1180,9 @@ void vec_close(VecEnv* vec) {
     free(vec->bank_layout);
 
     cudaDeviceSynchronize();
+#ifdef PUFFER_CUDA_ENV
+    puf_cuda_env_close(vec);
+#endif
     cudaFree(vec->gpu_observations);
     cudaFree(vec->gpu_actions);
     cudaFree(vec->gpu_rewards);
@@ -1157,6 +1201,10 @@ void vec_close(VecEnv* vec) {
 }
 
 void vec_log(VecEnv* vec, Dict* out, int clear) {
+#ifdef PUFFER_CUDA_ENV
+    puf_cuda_env_sync_logs(vec, clear, 0);
+    cudaStreamSynchronize(0);
+#endif
     Env* envs = vec->envs;
     Log aggregate;
     memset(&aggregate, 0, sizeof(Log));
@@ -1340,7 +1388,10 @@ typedef struct PuffeRL {
     EnvBuf env;
     TrainGraph train_buf;
     PrecisionTensor advantages_puf;  // Pre-allocated for train_impl (B, T)
-    cudaGraphExec_t* fused_rollout_cudagraphs;  // [horizon][num_buffers]
+    // fbr: CUDA environments capture one entire horizon per buffer. CPU environments
+    // retain one graph per timestep because host stepping separates inference
+    // calls and cannot be captured into a device-only horizon.
+    cudaGraphExec_t* fused_rollout_cudagraphs;
     cudaGraphExec_t train_cudagraph;
     cudaStream_t* streams;  // per-buffer raw CUDA streams
     cudaStream_t default_stream;  // main-thread stream (captured once at init)
@@ -1683,6 +1734,7 @@ __global__ void sample_logits(
 
 void pufferl_forward(PuffeRL* pufferl, int buf, int t, cudaStream_t stream) {
     HypersT& hypers = pufferl->hypers;
+#ifndef PUFFER_CUDA_ENV
     int graph = t * hypers.num_buffers + buf;
     profile_begin("fused_rollout", hypers.profile);
 
@@ -1698,6 +1750,7 @@ void pufferl_forward(PuffeRL* pufferl, int buf, int t, cudaStream_t stream) {
         assert(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal) == cudaSuccess
                 && "cudaStreamBeginCapture failed");
     }
+#endif
 
     RolloutBuf& rollouts = pufferl->rollouts;
     EnvBuf& env = pufferl->env;
@@ -1707,6 +1760,10 @@ void pufferl_forward(PuffeRL* pufferl, int buf, int t, cudaStream_t stream) {
     ObsTensor& obs_env = env.obs;
     int n = block_size * obs_env.shape[1];
     PrecisionTensor obs_dst = puf_slice(rollouts.observations, t, start, block_size);
+#ifdef PUFFER_CUDA_ENV
+    // fbr: Later timesteps are written directly by the previous CUDA environment step.
+    if (t == 0) {
+#endif
     cast_dispatch(obs_dst.data, obs_env.data + (long)start*obs_env.shape[1], n, stream);
 
     PrecisionTensor rew_dst = puf_slice(rollouts.rewards, t, start, block_size);
@@ -1717,6 +1774,9 @@ void pufferl_forward(PuffeRL* pufferl, int buf, int t, cudaStream_t stream) {
     PrecisionTensor term_dst = puf_slice(rollouts.terminals, t, start, block_size);
     cast<<<grid_size(n), BLOCK_SIZE, 0, stream>>>(
         term_dst.data, env.terminals.data + start, n);
+#ifdef PUFFER_CUDA_ENV
+    }
+#endif
 
     // Copy action mask from env into rollout buffer (if env opted in)
     PrecisionTensor mask_slice = {};
@@ -1737,7 +1797,9 @@ void pufferl_forward(PuffeRL* pufferl, int buf, int t, cudaStream_t stream) {
     // per-buffer-relative so each worker writes only inside its own chunk.
     // Cudagraph capture absorbs the extra kernel launches.
     int num_banks = 1 + pufferl->num_frozen_banks;
+#ifndef PUFFER_CUDA_ENV
     long act_cols = env.actions.shape[1];
+#endif
     for (int b = 0; b < num_banks; b++) {
         int bank_off = pufferl->bank_layout ? pufferl->bank_layout[b] : 0;
         int bank_end = pufferl->bank_layout ? pufferl->bank_layout[b + 1] : block_size;
@@ -1788,11 +1850,40 @@ void pufferl_forward(PuffeRL* pufferl, int buf, int t, cudaStream_t stream) {
             pufferl->rng_states[buf] + bank_off,
             mask_b.data, mask_stride_b);
 
+#ifndef PUFFER_CUDA_ENV
         cast<<<grid_size(numel(act_b.shape)), BLOCK_SIZE, 0, stream>>>(
-                env.actions.data + (long)sub_start * act_cols,
-                act_b.data, numel(act_b.shape));
+            env.actions.data + (long)sub_start * act_cols,
+            act_b.data, numel(act_b.shape));
+#endif
     }
 
+#ifdef PUFFER_CUDA_ENV
+    // fbr: Pass sampled precision_t actions straight into the device environment.
+    int env_start = pufferl->vec->buffer_env_starts[buf];
+    int env_count = pufferl->vec->buffer_env_counts[buf];
+    PrecisionTensor action_slice = puf_slice(
+        rollouts.actions, t, start, block_size);
+    const precision_t* action_src = action_slice.data;
+    if (t + 1 < hypers.horizon) {
+        PrecisionTensor next_obs = puf_slice(
+            rollouts.observations, t + 1, start, block_size);
+        PrecisionTensor next_rew = puf_slice(
+            rollouts.rewards, t + 1, start, block_size);
+        PrecisionTensor next_term = puf_slice(
+            rollouts.terminals, t + 1, start, block_size);
+        puf_cuda_env_step_direct(pufferl->vec, env_start, env_count,
+            start, block_size, action_src,
+            next_obs.data, next_rew.data, next_term.data, stream);
+    } else {
+        // fbr: Preserve the final state in the float buffers used by timestep zero.
+        puf_cuda_env_step(pufferl->vec, env_start, env_count,
+            start, block_size, action_src,
+            obs_env.data + (long)start * obs_env.shape[1],
+            env.rewards.data + start, env.terminals.data + start, stream);
+    }
+#endif
+
+#ifndef PUFFER_CUDA_ENV
     if (capturing) {
         cudaGraph_t _graph;
         assert(cudaStreamEndCapture(stream, &_graph) == cudaSuccess
@@ -1803,7 +1894,25 @@ void pufferl_forward(PuffeRL* pufferl, int buf, int t, cudaStream_t stream) {
         cudaDeviceSynchronize();
     }
     profile_end(hypers.profile);
+#endif
 }
+
+#ifdef PUFFER_CUDA_ENV
+// fbr: Launch one captured 64-step rollout graph per CUDA environment buffer.
+void pufferl_rollout_buffer(PuffeRL* pufferl, int buf, cudaStream_t stream) {
+    HypersT& hypers = pufferl->hypers;
+    profile_begin("fused_rollout_horizon", hypers.profile);
+    if (pufferl->rollout_captured) {
+        assert(cudaGraphLaunch(pufferl->fused_rollout_cudagraphs[buf], stream)
+                == cudaSuccess && "full-horizon cudaGraphLaunch failed");
+    } else {
+        for (int t = 0; t < hypers.horizon; ++t) {
+            pufferl_forward(pufferl, buf, t, stream);
+        }
+    }
+    profile_end(hypers.profile);
+}
+#endif
 
 // Zero advantages on frozen-bank rows so prio_replay never samples them. Frozen
 // rollout rows hold actions/logprobs from the frozen policy; training the
@@ -2412,7 +2521,16 @@ PuffeRL* create_pufferl_impl(HypersT& hypers, Dict* vec_kwargs,
 
     // Cudagraph rolluts and entire training step
     if (hypers.cudagraphs >= 0) {
-        pufferl->fused_rollout_cudagraphs = (cudaGraphExec_t*)calloc(horizon*num_buffers, sizeof(cudaGraphExec_t));
+#ifdef PUFFER_CUDA_ENV
+        // fbr: Capture runs before the normal post-create reset, so seed the
+        // device state before recording the full-horizon graphs.
+        vec_reset(vec);
+        pufferl->fused_rollout_cudagraphs =
+            (cudaGraphExec_t*)calloc(num_buffers, sizeof(cudaGraphExec_t));
+#else
+        pufferl->fused_rollout_cudagraphs =
+            (cudaGraphExec_t*)calloc(horizon*num_buffers, sizeof(cudaGraphExec_t));
+#endif
         pufferl->train_warmup = 0;
 
         // Snapshot weights + optimizer state before init-time capture
@@ -2437,6 +2555,35 @@ PuffeRL* create_pufferl_impl(HypersT& hypers, Dict* vec_kwargs,
         cudaStreamCreate(&warmup_stream);
         pufferl->default_stream = warmup_stream;
 
+#ifdef PUFFER_CUDA_ENV
+        // fbr: Warm every library/kernel path before capture. Then record all
+        // horizon timesteps into one graph per buffer. Timestep-specific rollout
+        // pointers become fixed graph-node arguments, while stream ordering
+        // carries recurrent state and environment outputs through the horizon.
+        for (pufferl->epoch = 0; pufferl->epoch < hypers.cudagraphs; pufferl->epoch++) {
+            for (int buf = 0; buf < num_buffers; ++buf) {
+                pufferl_rollout_buffer(pufferl, buf, pufferl->streams[buf]);
+            }
+            cudaDeviceSynchronize();
+        }
+        for (int buf = 0; buf < num_buffers; ++buf) {
+            cudaStream_t stream = pufferl->streams[buf];
+            assert(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal)
+                    == cudaSuccess && "full-horizon cudaStreamBeginCapture failed");
+            for (int t = 0; t < horizon; ++t) {
+                pufferl_forward(pufferl, buf, t, stream);
+            }
+            cudaGraph_t graph;
+            assert(cudaStreamEndCapture(stream, &graph) == cudaSuccess
+                    && "full-horizon cudaStreamEndCapture failed");
+            assert(cudaGraphInstantiate(&pufferl->fused_rollout_cudagraphs[buf],
+                    graph, 0) == cudaSuccess
+                    && "full-horizon cudaGraphInstantiate failed");
+            assert(cudaGraphDestroy(graph) == cudaSuccess
+                    && "full-horizon cudaGraphDestroy failed");
+        }
+        cudaDeviceSynchronize();
+#else
         for (pufferl->epoch = 0; pufferl->epoch <= hypers.cudagraphs; pufferl->epoch++) {
             for (int i = 0; i < num_buffers * horizon; ++i) {
                 int buf = i % num_buffers;
@@ -2444,6 +2591,7 @@ PuffeRL* create_pufferl_impl(HypersT& hypers, Dict* vec_kwargs,
                 cudaDeviceSynchronize();
             }
         }
+#endif
         pufferl->rollout_captured = true;
 
         for (int i = 0; i <= hypers.cudagraphs; i++) {
@@ -2508,9 +2656,21 @@ void close_impl(PuffeRL& pufferl) {
         cudaProfilerStop();
     }
 
-    cudaGraphExecDestroy(pufferl.train_cudagraph);
-    for (int i = 0; i < pufferl.hypers.horizon * pufferl.hypers.num_buffers; i++) {
-        cudaGraphExecDestroy(pufferl.fused_rollout_cudagraphs[i]);
+    if (pufferl.train_cudagraph) {
+        cudaGraphExecDestroy(pufferl.train_cudagraph);
+    }
+    if (pufferl.fused_rollout_cudagraphs) {
+#ifdef PUFFER_CUDA_ENV
+        int rollout_graph_count = pufferl.hypers.num_buffers;
+#else
+        int rollout_graph_count =
+            pufferl.hypers.horizon * pufferl.hypers.num_buffers;
+#endif
+        for (int i = 0; i < rollout_graph_count; i++) {
+            if (pufferl.fused_rollout_cudagraphs[i]) {
+                cudaGraphExecDestroy(pufferl.fused_rollout_cudagraphs[i]);
+            }
+        }
     }
 
     policy_weights_free(&pufferl.policy, &pufferl.weights);

--- a/tests/profile_kernels.cu
+++ b/tests/profile_kernels.cu
@@ -241,7 +241,7 @@ void profile_logcoeffs(int B, int T, int H) {
 
 struct FusedScanProfile {
     PrefixScan scan;
-    PrecisionTensor grad_out, grad_next_state;
+    PrecisionTensor grad_out;
     Allocator alloc;
     int B, T, H;
 };
@@ -269,7 +269,6 @@ FusedScanProfile* create_fusedscan(int B, int T, int H) {
     s.grad_input     = {.shape = {B, T, H}};
 
     p->grad_out        = {.shape = {B, T, H}};
-    p->grad_next_state = {.shape = {B, H}};
 
     p->alloc = {};
     alloc_register(&p->alloc, &combined_t);
@@ -284,7 +283,6 @@ FusedScanProfile* create_fusedscan(int B, int T, int H) {
     alloc_register(&p->alloc, &s.grad_state);
     alloc_register(&p->alloc, &s.grad_input);
     alloc_register(&p->alloc, &p->grad_out);
-    alloc_register(&p->alloc, &p->grad_next_state);
     alloc_create(&p->alloc);
 
     s.combined_ptr = combined_t.data;
@@ -303,7 +301,6 @@ FusedScanProfile* create_fusedscan(int B, int T, int H) {
     float_to_device(s.input_ptr, buf, N_out);
     float_to_device(p->grad_out.data, buf, N_out);
     for (int i = 0; i < N_state; ++i) buf[i] = rand1();
-    float_to_device(p->grad_next_state.data, buf, N_state);
     free(buf);
     return p;
 }
@@ -313,8 +310,10 @@ void run_fusedscan_fwd(FusedScanProfile* p) {
 }
 
 void run_fusedscan_bwd(FusedScanProfile* p) {
+    // fbr: Training truncates the recurrent state boundary, so the production
+    // scan backward accepts only the timestep output gradient.
     mingru_scan_backward<<<grid_size(p->B * p->H), BLOCK_SIZE>>>(
-        p->scan, p->grad_out.data, p->grad_next_state.data);
+        p->scan, p->grad_out.data);
 }
 
 void profile_fusedscan(int B, int T, int H) {

--- a/tests/test_breakout_cuda.cu
+++ b/tests/test_breakout_cuda.cu
@@ -1,0 +1,145 @@
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include "pufferl.cu"
+
+#ifndef PUFFER_BREAKOUT_CUDA
+#error "test_breakout_cuda.cu must be built with the Breakout environment"
+#endif
+
+// fbr: Exercise CPU and CUDA Breakout from identical states and actions so the
+// device adapter can be reviewed independently from throughput measurements.
+static void configure_breakout(Breakout* env, int seed) {
+    *env = {};
+    env->num_agents = 1;
+    env->frameskip = 4;
+    env->width = 576;
+    env->height = 330;
+    env->initial_paddle_width = 62;
+    env->paddle_height = 8;
+    env->ball_width = 32;
+    env->ball_height = 32;
+    env->brick_width = 32;
+    env->brick_height = 12;
+    env->brick_rows = 6;
+    env->brick_cols = 18;
+    env->initial_ball_speed = 256;
+    env->max_ball_speed = 448;
+    env->paddle_speed = 620;
+    env->continuous = 0;
+    env->rng = seed;
+    allocate(env);
+    puf_reset(env);
+}
+
+static bool close_enough(float actual, float expected) {
+    float atol = USE_BF16 ? 4.0e-3f : 2.0e-4f;
+    float rtol = USE_BF16 ? 4.0e-3f : 2.0e-5f;
+    return fabsf(actual - expected) <= atol + rtol * fabsf(expected);
+}
+
+int main() {
+    constexpr int B = 65;
+    constexpr int STEPS = 4096;
+    std::vector<Breakout> cpu(B);
+    std::vector<BreakoutCudaState> initial(B);
+    for (int i = 0; i < B; ++i) {
+        configure_breakout(&cpu[i], i + 1);
+        initial[i] = bc_from_host(cpu[i]);
+    }
+
+    BreakoutCudaState* states;
+    precision_t *actions, *observations, *rewards, *terminals;
+    cudaMalloc(&states, B * sizeof(*states));
+    cudaMalloc(&actions, B * sizeof(*actions));
+    cudaMalloc(&observations, (size_t)B * OBS_SIZE * sizeof(*observations));
+    cudaMalloc(&rewards, B * sizeof(*rewards));
+    cudaMalloc(&terminals, B * sizeof(*terminals));
+    cudaMemcpy(states, initial.data(), B * sizeof(*states), cudaMemcpyHostToDevice);
+
+    size_t shared_bytes = (size_t)bc_block_size * sizeof(BreakoutCudaState);
+    cudaFuncSetAttribute(bc_step<precision_t>, cudaFuncAttributeMaxDynamicSharedMemorySize,
+        (int)shared_bytes);
+    std::vector<precision_t> host_actions(B);
+    std::vector<precision_t> gpu_obs((size_t)B * OBS_SIZE);
+    std::vector<precision_t> gpu_rewards(B), gpu_terminals(B);
+    int episodes = 0;
+
+    for (int step = 0; step < STEPS; ++step) {
+        for (int i = 0; i < B; ++i) {
+            float action = (float)((step / 7 + i) % 3);
+            host_actions[i] = from_float(action);
+            cpu[i].agents[0].actions[0] = action;
+            puf_step(&cpu[i]);
+        }
+        cudaMemcpy(actions, host_actions.data(), B * sizeof(*actions), cudaMemcpyHostToDevice);
+        bc_step<precision_t><<<(B + bc_block_size - 1) / bc_block_size,
+            bc_block_size, shared_bytes>>>(
+            states, B, actions, observations, rewards, terminals);
+        bc_observe_warp<precision_t><<<(B + BC_OBSERVE_WARPS_PER_BLOCK - 1)
+                / BC_OBSERVE_WARPS_PER_BLOCK,
+            BC_OBSERVE_BLOCK_SIZE>>>(states, B, observations);
+        cudaError_t error = cudaGetLastError();
+        if (error == cudaSuccess) error = cudaDeviceSynchronize();
+        if (error != cudaSuccess) {
+            fprintf(stderr, "CUDA Breakout step failed: %s\n", cudaGetErrorString(error));
+            return 1;
+        }
+        cudaMemcpy(gpu_obs.data(), observations,
+            gpu_obs.size() * sizeof(precision_t), cudaMemcpyDeviceToHost);
+        cudaMemcpy(gpu_rewards.data(), rewards,
+            B * sizeof(precision_t), cudaMemcpyDeviceToHost);
+        cudaMemcpy(gpu_terminals.data(), terminals,
+            B * sizeof(precision_t), cudaMemcpyDeviceToHost);
+
+        for (int i = 0; i < B; ++i) {
+            float expected_reward = cpu[i].agents[0].rewards[0];
+            float expected_terminal = cpu[i].agents[0].terminals[0];
+            float actual_reward = to_float(gpu_rewards[i]);
+            float actual_terminal = to_float(gpu_terminals[i]);
+            if (actual_reward != expected_reward || actual_terminal != expected_terminal) {
+                fprintf(stderr,
+                    "step %d env %d reward/terminal mismatch: gpu=(%g,%g) cpu=(%g,%g)\n",
+                    step, i, actual_reward, actual_terminal,
+                    expected_reward, expected_terminal);
+                return 1;
+            }
+            episodes += expected_terminal != 0.0f;
+            for (int j = 0; j < OBS_SIZE; ++j) {
+                float expected = ((obs_t*)cpu[i].agents[0].observations)[j];
+                float actual = to_float(gpu_obs[(size_t)i * OBS_SIZE + j]);
+                if (!close_enough(actual, expected)) {
+                    fprintf(stderr,
+                        "step %d env %d obs %d mismatch: gpu=%g cpu=%g error=%g\n",
+                        step, i, j, actual, expected, fabsf(actual - expected));
+                    return 1;
+                }
+            }
+        }
+    }
+
+    std::vector<BreakoutCudaState> final_states(B);
+    cudaMemcpy(final_states.data(), states, B * sizeof(*states), cudaMemcpyDeviceToHost);
+    for (int i = 0; i < B; ++i) {
+        const Log& gpu = final_states[i].log;
+        const Log& host = cpu[i].log;
+        if (gpu.n != host.n || gpu.score != host.score
+                || gpu.episode_return != host.episode_return
+                || gpu.episode_length != host.episode_length
+                || !close_enough(gpu.perf, host.perf)) {
+            fprintf(stderr, "env %d log mismatch after %d steps\n", i, STEPS);
+            return 1;
+        }
+    }
+
+    for (Breakout& env : cpu) free_allocated(&env);
+    cudaFree(states); cudaFree(actions); cudaFree(observations);
+    cudaFree(rewards); cudaFree(terminals);
+    printf("Breakout CUDA %s direct-write parity PASS: %d envs x %d steps, "
+        "%d completed episodes, %zu-byte state\n",
+        USE_BF16 ? "BF16" : "FP32", B, STEPS, episodes,
+        sizeof(BreakoutCudaState));
+    return 0;
+}


### PR DESCRIPTION
## Summary

- move Breakout physics, reset, reward, terminal, and observation generation onto CUDA
- write rollout observations directly into BF16 storage and consume sampled precision actions without an intermediate action cast
- compact brick state into a four-word bitset and use warp-cooperative observation writes
- capture a complete rollout horizon per buffer and tune Breakout to two buffers
- remove redundant saved-activation copies and accumulate the MinGRU highway gradient through GEMM beta=1
- keep MinGRU backward checkpoints in shared memory, fuse Muon slice normalization, and parallelize PPO advantage moments
- add deterministic CPU/CUDA Breakout parity coverage

Runtime changes are marked with `fbr:` comments for review. CUDA 13/NCCL build compatibility comments are intentionally untagged.

## Verification

- `./build.sh breakout --cuda-env-test && ./test_cuda_env` (BF16): PASS, 65 envs x 4096 steps, 1658 completed episodes
- `./build.sh breakout --cuda-env-test --float && ./test_cuda_env` (FP32): PASS
- `./build.sh breakout`: PASS
- `./build.sh breakout --cpu-env`: PASS
- `./build.sh breakout --profile`: PASS
- `./puffer train breakout`: reaches score 864; approximately 20-22M SPS on an RTX 3080 Ti depending on GPU clock state
- `git diff --check`: PASS

## Notes

Experimental direct/parallel MinGRU scans, specialized small-Muon kernels, and larger-minibatch variants were profiled but intentionally excluded because they did not improve verified end-to-end training.