### PR TITLE
Add native kinematic bicycle environments

### DIFF
--- a/config/kinematic_bicycle.ini
+++ b/config/kinematic_bicycle.ini
@@ -1,0 +1,51 @@
+[base]
+env_name = kinematic_bicycle kinematic_bicycle_integral
+
+[vec]
+total_agents = 4096
+backend = Serial
+
+[policy]
+hidden_size = 128
+num_layers = 2
+
+[env]
+dt = 0.05
+v = 2.0
+wheelbase = 2.5
+psi_max = 0.785
+y_max = 2.0
+max_steps = 500
+
+d_y = 0.0
+regime_switch_step = -1
+d_y_after_switch = 0.0
+
+k_psi = 1.0
+action_delay_steps = 0
+
+sensor_noise_y_std = 0.0
+sensor_noise_theta_std = 0.0
+
+y0_min = -0.5
+y0_max = 0.5
+theta0_min = -0.2
+theta0_max = 0.2
+
+w_y = 1.0
+w_theta = 0.5
+w_psi = 0.01
+alive_bonus = 0.1
+failure_penalty = 100.0
+w_center4 = 0.0
+
+z_clip = 5.0
+reference = 0.0
+lambda = 0.0
+
+[train]
+total_timesteps = 10_000_000
+gamma = 0.99
+learning_rate = 0.0003
+minibatch_size = 32768
+ent_coef = 0.01

--- a/ocean/kinematic_bicycle/binding.c
+++ b/ocean/kinematic_bicycle/binding.c
@@ -1,0 +1,72 @@
+#include "kinematic_bicycle.h"
+
+#define OBS_SIZE 2
+#define NUM_ATNS 1
+#define ACT_SIZES {1}
+#define OBS_TENSOR_T FloatTensor
+
+#define Env KinematicBicycle
+#include "vecenv.h"
+
+void my_init(Env* env, Dict* kwargs) {
+    env->num_agents = 1;
+
+    env->dt = (float)dict_get(kwargs, "dt")->value;
+    env->v = (float)dict_get(kwargs, "v")->value;
+    env->wheelbase = (float)dict_get(kwargs, "wheelbase")->value;
+    env->psi_max = (float)dict_get(kwargs, "psi_max")->value;
+    env->y_max = (float)dict_get(kwargs, "y_max")->value;
+    env->max_steps = (int)dict_get(kwargs, "max_steps")->value;
+
+    env->d_y = (float)dict_get(kwargs, "d_y")->value;
+    env->regime_switch_step =
+        (int)dict_get(kwargs, "regime_switch_step")->value;
+    env->d_y_after_switch =
+        (float)dict_get(kwargs, "d_y_after_switch")->value;
+
+    env->k_psi = (float)dict_get(kwargs, "k_psi")->value;
+    env->action_delay_steps =
+        (int)dict_get(kwargs, "action_delay_steps")->value;
+
+    env->sensor_noise_y_std =
+        (float)dict_get(kwargs, "sensor_noise_y_std")->value;
+    env->sensor_noise_theta_std =
+        (float)dict_get(kwargs, "sensor_noise_theta_std")->value;
+
+    env->y0_min = (float)dict_get(kwargs, "y0_min")->value;
+    env->y0_max = (float)dict_get(kwargs, "y0_max")->value;
+    env->theta0_min = (float)dict_get(kwargs, "theta0_min")->value;
+    env->theta0_max = (float)dict_get(kwargs, "theta0_max")->value;
+
+    env->w_y = (float)dict_get(kwargs, "w_y")->value;
+    env->w_theta = (float)dict_get(kwargs, "w_theta")->value;
+    env->w_psi = (float)dict_get(kwargs, "w_psi")->value;
+    env->alive_bonus = (float)dict_get(kwargs, "alive_bonus")->value;
+    env->failure_penalty =
+        (float)dict_get(kwargs, "failure_penalty")->value;
+    env->w_center4 = (float)dict_get(kwargs, "w_center4")->value;
+
+    env->z_clip = 0.0f;
+    env->reference = 0.0f;
+    env->lambda_value = 0.0f;
+
+    if (env->action_delay_steps < 0) {
+        env->action_delay_steps = 0;
+    }
+
+    if (env->action_delay_steps > 0) {
+        env->action_buffer = (float*)calloc(
+            (size_t)env->action_delay_steps,
+            sizeof(float)
+        );
+        assert(env->action_buffer != NULL);
+    }
+}
+
+void my_log(Log* log, Dict* out) {
+    dict_set(out, "perf", log->perf);
+    dict_set(out, "score", log->score);
+    dict_set(out, "episode_return", log->episode_return);
+    dict_set(out, "episode_length", log->episode_length);
+    dict_set(out, "failures", log->failures);
+}

--- a/ocean/kinematic_bicycle/kinematic_bicycle.h
+++ b/ocean/kinematic_bicycle/kinematic_bicycle.h
@@ -1,0 +1,23 @@
+#ifndef KINEMATIC_BICYCLE_H
+#define KINEMATIC_BICYCLE_H
+
+#include "../kinematic_bicycle_common.h"
+
+void c_reset(KinematicBicycle* env) {
+    kb_reset_state(env, 0);
+}
+
+void c_step(KinematicBicycle* env) {
+    kb_step(env, 0);
+}
+
+void c_render(KinematicBicycle* env) {
+    (void)env;
+}
+
+void c_close(KinematicBicycle* env) {
+    free(env->action_buffer);
+    env->action_buffer = NULL;
+}
+
+#endif

--- a/ocean/kinematic_bicycle_common.h
+++ b/ocean/kinematic_bicycle_common.h
@@ -1,0 +1,283 @@
+#ifndef KINEMATIC_BICYCLE_COMMON_H
+#define KINEMATIC_BICYCLE_COMMON_H
+
+#include <math.h>
+#include <stdlib.h>
+
+typedef struct {
+    float perf;
+    float score;
+    float episode_return;
+    float episode_length;
+    float failures;
+    float n;
+} Log;
+
+typedef struct {
+    Log log;
+
+    float* observations;
+    float* actions;
+    float* rewards;
+    float* terminals;
+
+    int num_agents;
+    unsigned int rng;
+
+    float x;
+    float y;
+    float theta;
+    float z;
+    float previous_y;
+
+    int step_count;
+    float current_episode_return;
+
+    float dt;
+    float v;
+    float wheelbase;
+    float psi_max;
+    float y_max;
+    int max_steps;
+
+    float d_y;
+    int regime_switch_step;
+    float d_y_after_switch;
+
+    float k_psi;
+    int action_delay_steps;
+    float* action_buffer;
+    int action_buffer_index;
+
+    float sensor_noise_y_std;
+    float sensor_noise_theta_std;
+
+    float y0_min;
+    float y0_max;
+    float theta0_min;
+    float theta0_max;
+
+    float w_y;
+    float w_theta;
+    float w_psi;
+    float alive_bonus;
+    float failure_penalty;
+    float w_center4;
+
+    float z_clip;
+    float reference;
+    float lambda_value;
+
+} KinematicBicycle;
+
+static inline float kb_clamp(float value, float lower, float upper) {
+    if (value < lower) {
+        return lower;
+    }
+    if (value > upper) {
+        return upper;
+    }
+    return value;
+}
+
+static inline float kb_uniform(KinematicBicycle* env, float lower, float upper) {
+    float unit = (float)rand_r(&env->rng) / (float)RAND_MAX;
+    return lower + unit * (upper - lower);
+}
+
+static inline float kb_standard_normal(KinematicBicycle* env) {
+    // Box-Muller transform. Clamp u1 away from zero before logf().
+    float u1 = kb_uniform(env, 1.0e-7f, 1.0f);
+    float u2 = kb_uniform(env, 0.0f, 1.0f);
+    return sqrtf(-2.0f * logf(u1)) * cosf(2.0f * 3.14159265358979323846f * u2);
+}
+
+static inline void kb_reset_action_buffer(KinematicBicycle* env) {
+    env->action_buffer_index = 0;
+
+    for (int i = 0; i < env->action_delay_steps; i++) {
+        env->action_buffer[i] = 0.0f;
+    }
+}
+
+static inline float kb_apply_action_delay(
+    KinematicBicycle* env,
+    float psi_cmd
+) {
+    if (env->action_delay_steps <= 0) {
+        return psi_cmd;
+    }
+
+    float delayed = env->action_buffer[env->action_buffer_index];
+    env->action_buffer[env->action_buffer_index] = psi_cmd;
+
+    env->action_buffer_index += 1;
+    if (env->action_buffer_index >= env->action_delay_steps) {
+        env->action_buffer_index = 0;
+    }
+
+    return delayed;
+}
+
+static inline void kb_write_observation(
+    KinematicBicycle* env,
+    int include_integral
+) {
+    float y_observed = env->y;
+    float theta_observed = env->theta;
+
+    if (env->sensor_noise_y_std > 0.0f) {
+        y_observed += (
+            env->sensor_noise_y_std
+            * kb_standard_normal(env)
+        );
+    }
+
+    if (env->sensor_noise_theta_std > 0.0f) {
+        theta_observed += (
+            env->sensor_noise_theta_std
+            * kb_standard_normal(env)
+        );
+    }
+
+    env->observations[0] = y_observed;
+    env->observations[1] = theta_observed;
+
+    if (include_integral) {
+        env->observations[2] = env->z;
+    }
+
+    // The integral state uses the previously observed lateral position,
+    // matching the Python wrapper behavior.
+    env->previous_y = y_observed;
+}
+
+static inline void kb_reset_state(
+    KinematicBicycle* env,
+    int include_integral
+) {
+    env->x = 0.0f;
+    env->y = kb_uniform(env, env->y0_min, env->y0_max);
+    env->theta = kb_uniform(
+        env,
+        env->theta0_min,
+        env->theta0_max
+    );
+
+    env->z = 0.0f;
+    env->previous_y = env->y;
+    env->step_count = 0;
+    env->current_episode_return = 0.0f;
+
+    kb_reset_action_buffer(env);
+    kb_write_observation(env, include_integral);
+}
+
+static inline float kb_active_disturbance(const KinematicBicycle* env) {
+    if (
+        env->regime_switch_step >= 0
+        && env->step_count >= env->regime_switch_step
+    ) {
+        return env->d_y_after_switch;
+    }
+
+    return env->d_y;
+}
+
+static inline void kb_finish_episode(
+    KinematicBicycle* env,
+    int failed
+) {
+    env->log.episode_return += env->current_episode_return;
+    env->log.episode_length += (float)env->step_count;
+    env->log.score += env->current_episode_return;
+    env->log.failures += failed ? 1.0f : 0.0f;
+    env->log.perf += failed ? 0.0f : 1.0f;
+    env->log.n += 1.0f;
+}
+
+static inline void kb_step(
+    KinematicBicycle* env,
+    int include_integral
+) {
+    env->rewards[0] = 0.0f;
+    env->terminals[0] = 0.0f;
+
+    if (include_integral) {
+        env->z = kb_clamp(
+            env->z + env->dt * (env->reference - env->previous_y),
+            -env->z_clip,
+            env->z_clip
+        );
+    }
+
+    float normalized_action = kb_clamp(
+        env->actions[0],
+        -1.0f,
+        1.0f
+    );
+    float psi_cmd = normalized_action * env->psi_max;
+    float psi_cmd_applied = kb_apply_action_delay(env, psi_cmd);
+    float psi = env->k_psi * psi_cmd_applied;
+    float disturbance = kb_active_disturbance(env);
+
+    float x_next = (
+        env->x
+        + env->v * cosf(env->theta) * env->dt
+    );
+    float y_next = (
+        env->y
+        + env->v * sinf(env->theta) * env->dt
+        + disturbance * env->dt
+    );
+    float theta_next = (
+        env->theta
+        + (env->v / env->wheelbase) * tanf(psi) * env->dt
+    );
+
+    env->x = x_next;
+    env->y = y_next;
+    env->theta = theta_next;
+    env->step_count += 1;
+
+    float tracking_cost = (
+        env->w_y * env->y * env->y
+        + env->w_theta * env->theta * env->theta
+        + env->w_psi * psi * psi
+    );
+    float centerline_penalty = (
+        env->w_center4
+        * env->y * env->y * env->y * env->y
+    );
+
+    float reward = (
+        env->alive_bonus
+        - tracking_cost
+        - centerline_penalty
+    );
+
+    if (include_integral) {
+        reward -= env->lambda_value * env->z * env->z;
+    }
+
+    int failed = fabsf(env->y) > env->y_max;
+    int truncated = env->step_count >= env->max_steps;
+
+    if (failed) {
+        reward -= env->failure_penalty;
+    }
+
+    env->rewards[0] = reward;
+    env->current_episode_return += reward;
+
+    if (failed || truncated) {
+        env->terminals[0] = 1.0f;
+        kb_finish_episode(env, failed);
+        kb_reset_state(env, include_integral);
+        return;
+    }
+
+    kb_write_observation(env, include_integral);
+}
+
+#endif

--- a/ocean/kinematic_bicycle_integral/binding.c
+++ b/ocean/kinematic_bicycle_integral/binding.c
@@ -1,0 +1,72 @@
+#include "kinematic_bicycle_integral.h"
+
+#define OBS_SIZE 3
+#define NUM_ATNS 1
+#define ACT_SIZES {1}
+#define OBS_TENSOR_T FloatTensor
+
+#define Env KinematicBicycle
+#include "vecenv.h"
+
+void my_init(Env* env, Dict* kwargs) {
+    env->num_agents = 1;
+
+    env->dt = (float)dict_get(kwargs, "dt")->value;
+    env->v = (float)dict_get(kwargs, "v")->value;
+    env->wheelbase = (float)dict_get(kwargs, "wheelbase")->value;
+    env->psi_max = (float)dict_get(kwargs, "psi_max")->value;
+    env->y_max = (float)dict_get(kwargs, "y_max")->value;
+    env->max_steps = (int)dict_get(kwargs, "max_steps")->value;
+
+    env->d_y = (float)dict_get(kwargs, "d_y")->value;
+    env->regime_switch_step =
+        (int)dict_get(kwargs, "regime_switch_step")->value;
+    env->d_y_after_switch =
+        (float)dict_get(kwargs, "d_y_after_switch")->value;
+
+    env->k_psi = (float)dict_get(kwargs, "k_psi")->value;
+    env->action_delay_steps =
+        (int)dict_get(kwargs, "action_delay_steps")->value;
+
+    env->sensor_noise_y_std =
+        (float)dict_get(kwargs, "sensor_noise_y_std")->value;
+    env->sensor_noise_theta_std =
+        (float)dict_get(kwargs, "sensor_noise_theta_std")->value;
+
+    env->y0_min = (float)dict_get(kwargs, "y0_min")->value;
+    env->y0_max = (float)dict_get(kwargs, "y0_max")->value;
+    env->theta0_min = (float)dict_get(kwargs, "theta0_min")->value;
+    env->theta0_max = (float)dict_get(kwargs, "theta0_max")->value;
+
+    env->w_y = (float)dict_get(kwargs, "w_y")->value;
+    env->w_theta = (float)dict_get(kwargs, "w_theta")->value;
+    env->w_psi = (float)dict_get(kwargs, "w_psi")->value;
+    env->alive_bonus = (float)dict_get(kwargs, "alive_bonus")->value;
+    env->failure_penalty =
+        (float)dict_get(kwargs, "failure_penalty")->value;
+    env->w_center4 = (float)dict_get(kwargs, "w_center4")->value;
+
+    env->z_clip = (float)dict_get(kwargs, "z_clip")->value;
+    env->reference = (float)dict_get(kwargs, "reference")->value;
+    env->lambda_value = (float)dict_get(kwargs, "lambda")->value;
+
+    if (env->action_delay_steps < 0) {
+        env->action_delay_steps = 0;
+    }
+
+    if (env->action_delay_steps > 0) {
+        env->action_buffer = (float*)calloc(
+            (size_t)env->action_delay_steps,
+            sizeof(float)
+        );
+        assert(env->action_buffer != NULL);
+    }
+}
+
+void my_log(Log* log, Dict* out) {
+    dict_set(out, "perf", log->perf);
+    dict_set(out, "score", log->score);
+    dict_set(out, "episode_return", log->episode_return);
+    dict_set(out, "episode_length", log->episode_length);
+    dict_set(out, "failures", log->failures);
+}

--- a/ocean/kinematic_bicycle_integral/kinematic_bicycle_integral.h
+++ b/ocean/kinematic_bicycle_integral/kinematic_bicycle_integral.h
@@ -1,0 +1,23 @@
+#ifndef KINEMATIC_BICYCLE_INTEGRAL_H
+#define KINEMATIC_BICYCLE_INTEGRAL_H
+
+#include "../kinematic_bicycle_common.h"
+
+void c_reset(KinematicBicycle* env) {
+    kb_reset_state(env, 1);
+}
+
+void c_step(KinematicBicycle* env) {
+    kb_step(env, 1);
+}
+
+void c_render(KinematicBicycle* env) {
+    (void)env;
+}
+
+void c_close(KinematicBicycle* env) {
+    free(env->action_buffer);
+    env->action_buffer = NULL;
+}
+
+#endif

--- a/src/bindings_cpu.cpp
+++ b/src/bindings_cpu.cpp
@@ -113,6 +113,12 @@ static std::unique_ptr<VecEnv> create_vec(py::dict args, int gpu = 0) {
         py::gil_scoped_release no_gil;
         ve->vec = create_static_vec(total_agents, num_buffers, 0, vec_dict, env_dict);
     }
+
+    free(vec_dict->items);
+    free(vec_dict);
+    free(env_dict->items);
+    free(env_dict);
+
     ve->total_agents = total_agents;
     ve->obs_size = get_obs_size();
     ve->num_atns = get_num_atns();

--- a/tests/kinematic_bicycle_parity.py
+++ b/tests/kinematic_bicycle_parity.py
@@ -1,0 +1,661 @@
+import ctypes
+
+import numpy as np
+
+from pufferlib import _C
+
+
+BASE_ENV = "kinematic_bicycle"
+INTEGRAL_ENV = "kinematic_bicycle_integral"
+
+
+def float_view(ptr, count):
+    array_t = ctypes.c_float * count
+    return np.ctypeslib.as_array(array_t.from_address(ptr))
+
+
+def default_env_args():
+    return {
+        "dt": 0.05,
+        "v": 2.0,
+        "wheelbase": 2.5,
+        "psi_max": 0.785,
+        "y_max": 2.0,
+        "max_steps": 500,
+        "d_y": 0.0,
+        "regime_switch_step": -1,
+        "d_y_after_switch": 0.0,
+        "k_psi": 1.0,
+        "action_delay_steps": 0,
+        "sensor_noise_y_std": 0.0,
+        "sensor_noise_theta_std": 0.0,
+        "y0_min": 0.0,
+        "y0_max": 0.0,
+        "theta0_min": 0.0,
+        "theta0_max": 0.0,
+        "w_y": 1.0,
+        "w_theta": 0.5,
+        "w_psi": 0.01,
+        "alive_bonus": 0.1,
+        "failure_penalty": 100.0,
+        "w_center4": 0.0,
+        "z_clip": 5.0,
+        "reference": 0.0,
+        "lambda": 0.0,
+    }
+
+
+def make_vec(env_args):
+    args = {
+        "vec": {
+            "total_agents": 1,
+            "num_buffers": 1,
+            "num_threads": 1,
+        },
+        "env": env_args,
+    }
+
+    vec = _C.create_vec(args, 0)
+    vec.reset()
+
+    obs = float_view(vec.obs_ptr, vec.obs_size)
+    rewards = float_view(vec.rewards_ptr, 1)
+    terminals = float_view(vec.terminals_ptr, 1)
+    actions = np.zeros((1, 1), dtype=np.float32)
+
+    return vec, obs, rewards, terminals, actions
+
+
+def test_zero_action_straight_line():
+    env_args = default_env_args()
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        np.testing.assert_allclose(obs[:2], [0.0, 0.0], atol=1e-7)
+
+        vec.cpu_step(actions.ctypes.data)
+
+        np.testing.assert_allclose(obs[:2], [0.0, 0.0], atol=1e-7)
+        np.testing.assert_allclose(rewards[0], 0.1, atol=1e-6)
+        assert terminals[0] == 0.0
+    finally:
+        vec.close()
+
+
+def test_positive_steering_changes_heading():
+    env_args = default_env_args()
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        actions[0, 0] = 1.0
+        vec.cpu_step(actions.ctypes.data)
+
+        expected_theta = (
+            env_args["v"]
+            / env_args["wheelbase"]
+            * np.tan(env_args["psi_max"])
+            * env_args["dt"]
+        )
+
+        np.testing.assert_allclose(obs[0], 0.0, atol=1e-7)
+        np.testing.assert_allclose(obs[1], expected_theta, rtol=1e-5)
+        assert terminals[0] == 0.0
+    finally:
+        vec.close()
+
+
+def test_lateral_disturbance():
+    env_args = default_env_args()
+    env_args["d_y"] = 0.4
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        vec.cpu_step(actions.ctypes.data)
+        expected_y = env_args["d_y"] * env_args["dt"]
+        np.testing.assert_allclose(obs[0], expected_y, atol=1e-7)
+    finally:
+        vec.close()
+
+
+def test_failure_penalty_and_auto_reset():
+    env_args = default_env_args()
+    env_args["y0_min"] = 1.99
+    env_args["y0_max"] = 1.99
+    env_args["d_y"] = 1.0
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        vec.cpu_step(actions.ctypes.data)
+
+        expected_failed_y = 1.99 + env_args["d_y"] * env_args["dt"]
+        expected_reward = (
+            env_args["alive_bonus"]
+            - env_args["w_y"] * expected_failed_y**2
+            - env_args["failure_penalty"]
+        )
+
+        np.testing.assert_allclose(rewards[0], expected_reward, rtol=1e-6)
+        assert terminals[0] == 1.0
+
+        # The native vector automatically resets after termination.
+        np.testing.assert_allclose(obs[0], 1.99, atol=1e-7)
+        np.testing.assert_allclose(obs[1], 0.0, atol=1e-7)
+    finally:
+        vec.close()
+
+
+
+def test_negative_steering_changes_heading():
+    env_args = default_env_args()
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        actions[0, 0] = -1.0
+        vec.cpu_step(actions.ctypes.data)
+
+        expected_theta = (
+            env_args["v"]
+            / env_args["wheelbase"]
+            * np.tan(-env_args["psi_max"])
+            * env_args["dt"]
+        )
+
+        np.testing.assert_allclose(obs[1], expected_theta, rtol=1e-5)
+        assert obs[1] < 0.0
+        assert terminals[0] == 0.0
+    finally:
+        vec.close()
+
+
+def test_action_clamping():
+    env_args = default_env_args()
+
+    vec_one, obs_one, _, _, actions_one = make_vec(env_args)
+    vec_large, obs_large, _, _, actions_large = make_vec(env_args)
+
+    try:
+        actions_one[0, 0] = 1.0
+        actions_large[0, 0] = 4.0
+
+        vec_one.cpu_step(actions_one.ctypes.data)
+        vec_large.cpu_step(actions_large.ctypes.data)
+
+        np.testing.assert_allclose(
+            obs_large[:2],
+            obs_one[:2],
+            rtol=1e-6,
+            atol=1e-7,
+        )
+    finally:
+        vec_one.close()
+        vec_large.close()
+
+
+def test_steering_effectiveness():
+    env_args = default_env_args()
+    env_args["k_psi"] = 0.5
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        actions[0, 0] = 1.0
+        vec.cpu_step(actions.ctypes.data)
+
+        applied_psi = env_args["k_psi"] * env_args["psi_max"]
+        expected_theta = (
+            env_args["v"]
+            / env_args["wheelbase"]
+            * np.tan(applied_psi)
+            * env_args["dt"]
+        )
+
+        np.testing.assert_allclose(obs[1], expected_theta, rtol=1e-5)
+    finally:
+        vec.close()
+
+
+def test_action_delay():
+    env_args = default_env_args()
+    env_args["action_delay_steps"] = 2
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        actions[0, 0] = 1.0
+        vec.cpu_step(actions.ctypes.data)
+        np.testing.assert_allclose(obs[1], 0.0, atol=1e-7)
+
+        actions[0, 0] = 0.0
+        vec.cpu_step(actions.ctypes.data)
+        np.testing.assert_allclose(obs[1], 0.0, atol=1e-7)
+
+        vec.cpu_step(actions.ctypes.data)
+
+        expected_theta = (
+            env_args["v"]
+            / env_args["wheelbase"]
+            * np.tan(env_args["psi_max"])
+            * env_args["dt"]
+        )
+
+        np.testing.assert_allclose(obs[1], expected_theta, rtol=1e-5)
+    finally:
+        vec.close()
+
+
+def test_disturbance_regime_switch():
+    env_args = default_env_args()
+    env_args["d_y"] = 0.2
+    env_args["regime_switch_step"] = 1
+    env_args["d_y_after_switch"] = -0.4
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        vec.cpu_step(actions.ctypes.data)
+        expected_first_y = 0.2 * env_args["dt"]
+        np.testing.assert_allclose(obs[0], expected_first_y, atol=1e-7)
+
+        vec.cpu_step(actions.ctypes.data)
+        expected_second_y = expected_first_y - 0.4 * env_args["dt"]
+        np.testing.assert_allclose(obs[0], expected_second_y, atol=1e-7)
+    finally:
+        vec.close()
+
+
+
+def test_max_steps_truncation():
+    env_args = default_env_args()
+    env_args["max_steps"] = 2
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        vec.cpu_step(actions.ctypes.data)
+        assert terminals[0] == 0.0
+
+        vec.cpu_step(actions.ctypes.data)
+        assert terminals[0] == 1.0
+
+        np.testing.assert_allclose(obs[:2], [0.0, 0.0], atol=1e-7)
+    finally:
+        vec.close()
+
+
+def test_centerline_fourth_power_penalty():
+    env_args = default_env_args()
+    env_args["y0_min"] = 0.5
+    env_args["y0_max"] = 0.5
+    env_args["w_center4"] = 2.0
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        vec.cpu_step(actions.ctypes.data)
+
+        expected_reward = (
+            env_args["alive_bonus"]
+            - env_args["w_y"] * 0.5**2
+            - env_args["w_center4"] * 0.5**4
+        )
+
+        np.testing.assert_allclose(rewards[0], expected_reward, rtol=1e-6)
+    finally:
+        vec.close()
+
+
+
+
+def test_reset_ranges():
+    env_args = default_env_args()
+    env_args["y0_min"] = -0.35
+    env_args["y0_max"] = 0.45
+    env_args["theta0_min"] = -0.15
+    env_args["theta0_max"] = 0.25
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        observed_y = []
+        observed_theta = []
+
+        for _ in range(100):
+            vec.reset()
+
+            y_value = float(obs[0])
+            theta_value = float(obs[1])
+
+            assert env_args["y0_min"] <= y_value <= env_args["y0_max"]
+            assert (
+                env_args["theta0_min"]
+                <= theta_value
+                <= env_args["theta0_max"]
+            )
+
+            observed_y.append(y_value)
+            observed_theta.append(theta_value)
+
+        assert np.ptp(observed_y) > 0.1
+        assert np.ptp(observed_theta) > 0.05
+    finally:
+        vec.close()
+
+
+def test_zero_sensor_noise_is_deterministic():
+    env_args = default_env_args()
+    env_args["y0_min"] = 0.25
+    env_args["y0_max"] = 0.25
+    env_args["theta0_min"] = -0.1
+    env_args["theta0_max"] = -0.1
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        for _ in range(20):
+            vec.reset()
+            np.testing.assert_allclose(
+                obs[:2],
+                [0.25, -0.1],
+                atol=1e-7,
+            )
+    finally:
+        vec.close()
+
+
+def test_sensor_noise_is_finite_and_variable():
+    env_args = default_env_args()
+    env_args["sensor_noise_y_std"] = 0.1
+    env_args["sensor_noise_theta_std"] = 0.05
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        samples = []
+
+        for _ in range(200):
+            vec.reset()
+            samples.append(obs[:2].copy())
+
+        samples = np.asarray(samples)
+
+        assert np.isfinite(samples).all()
+        assert np.std(samples[:, 0]) > 0.03
+        assert np.std(samples[:, 1]) > 0.015
+
+        np.testing.assert_allclose(
+            np.mean(samples[:, 0]),
+            0.0,
+            atol=0.04,
+        )
+        np.testing.assert_allclose(
+            np.mean(samples[:, 1]),
+            0.0,
+            atol=0.025,
+        )
+    finally:
+        vec.close()
+
+
+
+def test_multi_environment_vector():
+    num_envs = 32
+    env_args = default_env_args()
+    env_args["y0_min"] = -0.4
+    env_args["y0_max"] = 0.4
+    # Keep heading deterministic so steering direction can be checked.
+    env_args["theta0_min"] = 0.0
+    env_args["theta0_max"] = 0.0
+
+    args = {
+        "vec": {
+            "total_agents": num_envs,
+            "num_buffers": 1,
+            "num_threads": 1,
+        },
+        "env": env_args,
+    }
+
+    vec = _C.create_vec(args, 0)
+    vec.reset()
+
+    obs = float_view(
+        vec.obs_ptr,
+        num_envs * vec.obs_size,
+    ).reshape(num_envs, vec.obs_size)
+    rewards = float_view(vec.rewards_ptr, num_envs)
+    terminals = float_view(vec.terminals_ptr, num_envs)
+    actions = np.linspace(
+        -1.0,
+        1.0,
+        num_envs,
+        dtype=np.float32,
+    ).reshape(num_envs, 1)
+
+    try:
+        assert np.isfinite(obs).all()
+        assert np.ptp(obs[:, 0]) > 0.1
+
+        vec.cpu_step(actions.ctypes.data)
+
+        assert np.isfinite(obs).all()
+        assert np.isfinite(rewards).all()
+        assert np.isfinite(terminals).all()
+
+        assert obs[0, 1] < 0.0
+        assert obs[-1, 1] > 0.0
+    finally:
+        vec.close()
+
+
+def test_repeated_create_reset_close():
+    for _ in range(100):
+        env_args = default_env_args()
+        env_args["action_delay_steps"] = 3
+
+        vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+        try:
+            for _ in range(5):
+                vec.reset()
+                actions[0, 0] = 0.5
+                vec.cpu_step(actions.ctypes.data)
+
+                assert np.isfinite(obs).all()
+                assert np.isfinite(rewards).all()
+                assert np.isfinite(terminals).all()
+        finally:
+            vec.close()
+
+
+def test_long_vector_stress():
+    num_envs = 128
+    num_steps = 5000
+
+    env_args = default_env_args()
+    env_args["d_y"] = 0.1
+    env_args["regime_switch_step"] = 100
+    env_args["d_y_after_switch"] = -0.1
+    env_args["action_delay_steps"] = 2
+    env_args["sensor_noise_y_std"] = 0.01
+    env_args["sensor_noise_theta_std"] = 0.005
+
+    args = {
+        "vec": {
+            "total_agents": num_envs,
+            "num_buffers": 1,
+            "num_threads": 1,
+        },
+        "env": env_args,
+    }
+
+    vec = _C.create_vec(args, 0)
+    vec.reset()
+
+    obs = float_view(
+        vec.obs_ptr,
+        num_envs * vec.obs_size,
+    ).reshape(num_envs, vec.obs_size)
+    rewards = float_view(vec.rewards_ptr, num_envs)
+    terminals = float_view(vec.terminals_ptr, num_envs)
+
+    rng = np.random.default_rng(1234)
+    actions = np.zeros((num_envs, 1), dtype=np.float32)
+
+    try:
+        for _ in range(num_steps):
+            actions[:, 0] = rng.uniform(
+                -1.5,
+                1.5,
+                size=num_envs,
+            )
+            vec.cpu_step(actions.ctypes.data)
+
+        assert np.isfinite(obs).all()
+        assert np.isfinite(rewards).all()
+        assert np.isfinite(terminals).all()
+    finally:
+        vec.close()
+
+
+def test_integral_lambda_penalty():
+    if _C.env_name != INTEGRAL_ENV:
+        return
+
+    env_args = default_env_args()
+    env_args["y0_min"] = 0.5
+    env_args["y0_max"] = 0.5
+    env_args["lambda"] = 2.0
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        vec.cpu_step(actions.ctypes.data)
+
+        expected_z = -env_args["dt"] * 0.5
+        expected_reward = (
+            env_args["alive_bonus"]
+            - env_args["w_y"] * 0.5**2
+            - env_args["lambda"] * expected_z**2
+        )
+
+        np.testing.assert_allclose(obs[2], expected_z, atol=1e-7)
+        np.testing.assert_allclose(
+            rewards[0],
+            expected_reward,
+            rtol=1e-6,
+        )
+    finally:
+        vec.close()
+
+
+def test_integral_clip():
+    if _C.env_name != INTEGRAL_ENV:
+        return
+
+    env_args = default_env_args()
+    env_args["y0_min"] = 1.0
+    env_args["y0_max"] = 1.0
+    env_args["z_clip"] = 0.02
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        vec.cpu_step(actions.ctypes.data)
+        np.testing.assert_allclose(obs[2], -0.02, atol=1e-7)
+
+        vec.cpu_step(actions.ctypes.data)
+        np.testing.assert_allclose(obs[2], -0.02, atol=1e-7)
+    finally:
+        vec.close()
+
+
+def test_integral_nonzero_reference():
+    if _C.env_name != INTEGRAL_ENV:
+        return
+
+    env_args = default_env_args()
+    env_args["y0_min"] = 0.25
+    env_args["y0_max"] = 0.25
+    env_args["reference"] = 0.75
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        vec.cpu_step(actions.ctypes.data)
+
+        expected_z = (
+            env_args["dt"]
+            * (env_args["reference"] - 0.25)
+        )
+
+        np.testing.assert_allclose(obs[2], expected_z, atol=1e-7)
+    finally:
+        vec.close()
+
+
+def test_integral_observation():
+    if _C.env_name != INTEGRAL_ENV:
+        return
+
+    env_args = default_env_args()
+    env_args["y0_min"] = 0.5
+    env_args["y0_max"] = 0.5
+
+    vec, obs, rewards, terminals, actions = make_vec(env_args)
+
+    try:
+        assert vec.obs_size == 3
+        np.testing.assert_allclose(obs, [0.5, 0.0, 0.0], atol=1e-7)
+
+        vec.cpu_step(actions.ctypes.data)
+
+        expected_z = -env_args["dt"] * 0.5
+        np.testing.assert_allclose(obs[2], expected_z, atol=1e-7)
+    finally:
+        vec.close()
+
+
+def main():
+    assert _C.env_name in {BASE_ENV, INTEGRAL_ENV}
+    expected_obs_size = 2 if _C.env_name == BASE_ENV else 3
+
+    assert _C.gpu == 0
+
+    probe_args = default_env_args()
+    vec, _, _, _, _ = make_vec(probe_args)
+    try:
+        assert vec.obs_size == expected_obs_size
+        assert vec.num_atns == 1
+        assert list(vec.act_sizes) == [1]
+    finally:
+        vec.close()
+
+    test_zero_action_straight_line()
+    test_positive_steering_changes_heading()
+    test_negative_steering_changes_heading()
+    test_action_clamping()
+    test_steering_effectiveness()
+    test_action_delay()
+    test_lateral_disturbance()
+    test_disturbance_regime_switch()
+    test_failure_penalty_and_auto_reset()
+    test_max_steps_truncation()
+    test_centerline_fourth_power_penalty()
+    test_reset_ranges()
+    test_zero_sensor_noise_is_deterministic()
+    test_sensor_noise_is_finite_and_variable()
+    test_multi_environment_vector()
+    test_repeated_create_reset_close()
+    test_long_vector_stress()
+    test_integral_lambda_penalty()
+    test_integral_clip()
+    test_integral_nonzero_reference()
+    test_integral_observation()
+
+    print(f"PASS: {_C.env_name} deterministic parity checks")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds two native Ocean environments for kinematic bicycle lane tracking:

- `kinematic_bicycle` with observations `[y, theta]`
- `kinematic_bicycle_integral` with observations `[y, theta, z]`

Both environments support configurable dynamics, reward terms, disturbances, actuator effectiveness, action delay, sensor noise, randomized resets, failure termination, truncation, and automatic reset.

The integral variant additionally supports a clipped integral state, configurable reference, and optional lambda-weighted integral penalty.

## Implementation

- Added shared native C implementation in `ocean/kinematic_bicycle_common.h`
- Added separate base and integral bindings
- Added `config/kinematic_bicycle.ini`
- Added deterministic, vectorized, lifecycle, stress, and integral-specific tests
- Fixed temporary configuration dictionary cleanup in the CPU binding

## Validation

- Both environments build successfully with the CPU backend
- Both pass the complete parity and stress test suite
- Tested with 128 environments over 5,000 steps
- Tested repeated create/reset/step/close lifecycle
- Valgrind found no indirect leaks from the environments or CPU binding after the dictionary cleanup
