### PR TITLE
Fix missing star texture in Target eval

### DIFF
--- a/ocean/target/target.h
+++ b/ocean/target/target.h
@@ -171,7 +171,7 @@ void c_render(Target* env) {
         SetTargetFPS(60);
         env->client = (Client*)calloc(1, sizeof(Client));
         env->client->puffer = LoadTexture("resources/shared/puffers_128.png");
-        env->client->star = LoadTexture("resources/shared/star.png");
+        env->client->star = LoadTexture("resources/onlyfish/star.png");
     }
 
     // Standard across our envs so exiting is always the same


### PR DESCRIPTION
## Summary

- point the Target renderer at the existing `resources/onlyfish/star.png` texture
- remove the missing-texture warning and restore visible goal markers during evaluation

Fixes #602.

## Validation

- Confirmed every `LoadTexture` path in `ocean/target/target.h` resolves to an existing file.
- Decoded `resources/onlyfish/star.png` successfully as a 128x128 PNG.
- Compiled the standalone Target environment against the bundled raylib 5.5 library on Ubuntu 24.04 (WSL) using GCC.
- `git diff --check` passes.