### PR TITLE
Fix loading configured self-play checkpoints

### DIFF
--- a/src/pufferl.cu
+++ b/src/pufferl.cu
@@ -1809,6 +1809,9 @@ void pufferl_load_policy(PuffeRL* pufferl, int i, const char* path) {
     Policy* pol = &pufferl->policies[i];
     puf_load_weights_into(pol->master_weights, pol->param,
         pufferl->default_stream, path);
+    if (i == 0 && pufferl->hypers.async) {
+        puf_copy(&pufferl->actor_param, &pol->param, pufferl->default_stream);
+    }
     cudaDeviceSynchronize();
 }
 
@@ -3030,6 +3033,12 @@ TrainResult run_train(Ini* ini, TrainContext* ctx) {
     }
 
     PuffeRL* pufferl = create_pufferl(ini, ctx);
+    char load_path_buf[4096];
+    const char* load_path = puf_checkpoint_path_key(
+        ini, "load_model_path", load_path_buf, sizeof(load_path_buf));
+    if (load_path) {
+        pufferl_load_policy(pufferl, 0, load_path);
+    }
     Selfplay selfplay = {0};
     if (use_selfplay) {
         char initial_checkpoint[4096];


### PR DESCRIPTION
## Summary

- load `base.load_model_path` before training starts
- seed the initial self-play pool checkpoint from the loaded policy instead of random initialization
- synchronize the async rollout actor after loading the primary policy

Fixes #618.

## Validation

- `git diff --check`
- static regression check verifies the configured policy load precedes the initial self-play checkpoint save
- static regression check verifies async actor parameters are copied from the loaded primary policy

A native end-to-end build was not run locally because the 5c trainer requires the Linux CUDA/NCCL toolchain.