### PR TITLE
Preserve training config during evaluation

### DIFF
--- a/src/ini.h
+++ b/src/ini.h
@@ -166,6 +166,23 @@ typedef struct {
     int num_sections;
 } Ini;
 
+static inline void puf_ini_copy(Ini* dst, Ini* src) {
+    memset(dst, 0, sizeof(*dst));
+    if (!src->num_sections) {
+        return;
+    }
+
+    dst->sections = (Dict*)calloc((size_t)src->num_sections, sizeof(Dict));
+    if (!dst->sections) {
+        perror("calloc");
+        exit(1);
+    }
+    dst->num_sections = src->num_sections;
+    for (int i = 0; i < src->num_sections; i++) {
+        dict_copy(&dst->sections[i], &src->sections[i]);
+    }
+}
+
 static char* puf_ini_trim(char* s) {
     while (isspace((unsigned char)*s)) {
         s++;

--- a/src/pufferl.cu
+++ b/src/pufferl.cu
@@ -2994,9 +2994,12 @@ static PuffeRL* eval_make(Ini* ini, TrainContext* ctx, int mode) {
 EvalResult run_eval(Ini* ini, TrainContext* ctx, int mode, int verbose) {
     long n = puf_ini_get(ini, "base", "eval_episodes");
     assert((mode == EVAL_RENDER || n > 0) && "eval requires positive base.eval_episodes");
-    PuffeRL* p = eval_make(ini, ctx, mode);
-    EvalResult r = eval_loop(ini, p, mode, verbose, n, NULL, 0);
+    Ini eval_ini = {0};
+    puf_ini_copy(&eval_ini, ini);
+    PuffeRL* p = eval_make(&eval_ini, ctx, mode);
+    EvalResult r = eval_loop(&eval_ini, p, mode, verbose, n, NULL, 0);
     close_pufferl(p);
+    puf_ini_free(&eval_ini);
     return r;
 }
 
@@ -3249,16 +3252,18 @@ TrainResult run_train(Ini* ini, TrainContext* ctx) {
     close_pufferl(pufferl);
 
     if (pool_eval && ctx->artifact_owner) {
-        puf_ini_put(ini, "base.load_model_path", final_checkpoint);
+        Ini eval_ini = {0};
+        puf_ini_copy(&eval_ini, ini);
+        puf_ini_put(&eval_ini, "base.load_model_path", final_checkpoint);
         int n_opp = 0;
         float sum = 0;
         for (int i = 0; i < selfplay.pool_size && n_opp < max_opp; i++) {
             if (strcmp(selfplay.pool[i], final_checkpoint) == 0) {
                 continue;
             }
-            puf_ini_put(ini, "base.load_enemy_model_path", selfplay.pool[i]);
-            PuffeRL* ep = eval_make(ini, ctx, EVAL_MATCH);
-            EvalResult r = eval_loop(ini, ep, EVAL_MATCH, 0, pool_games, NULL, 0);
+            puf_ini_put(&eval_ini, "base.load_enemy_model_path", selfplay.pool[i]);
+            PuffeRL* ep = eval_make(&eval_ini, ctx, EVAL_MATCH);
+            EvalResult r = eval_loop(&eval_ini, ep, EVAL_MATCH, 0, pool_games, NULL, 0);
             close_pufferl(ep);
             sum += r.score;
             n_opp++;
@@ -3273,6 +3278,7 @@ TrainResult run_train(Ini* ini, TrainContext* ctx) {
             dict_set(&last_log, "selfplay/pool_score", result.score);
             printf("selfplay_eval mean_score=%.4f n=%d\n", result.score, n_opp);
         }
+        puf_ini_free(&eval_ini);
     }
 
     if (ctx->artifact_owner) {

--- a/tests/test_ini_copy.c
+++ b/tests/test_ini_copy.c
@@ -1,0 +1,36 @@
+// Build: cc -std=c11 -I src tests/test_ini_copy.c -o test_ini_copy
+
+#include <assert.h>
+#include <string.h>
+
+#include "ini.h"
+
+int main(void) {
+    Ini original = {0};
+    Ini copy = {0};
+
+    puf_ini_set(puf_ini_section(&original, "base", 1),
+        "load_model_path", "train.pt");
+    puf_ini_set(puf_ini_section(&original, "train", 1), "horizon", "64");
+    puf_ini_set(puf_ini_section(&original, "env", 1), "weights", "1,2,3");
+
+    puf_ini_copy(&copy, &original);
+
+    assert(copy.sections != original.sections);
+    assert(puf_ini_get(&copy, "train", "horizon") == 64);
+    assert(strcmp(puf_ini_get_str(&copy, "base", "load_model_path"), "train.pt") == 0);
+    assert(puf_ini_section(&copy, "base", 0)->items[0].str
+        != puf_ini_section(&original, "base", 0)->items[0].str);
+    assert(puf_ini_section(&copy, "env", 0)->items[0].values
+        != puf_ini_section(&original, "env", 0)->items[0].values);
+
+    puf_ini_put(&copy, "train.horizon", "1");
+    puf_ini_put(&copy, "base.load_model_path", "eval.pt");
+    assert(puf_ini_get(&original, "train", "horizon") == 64);
+    assert(strcmp(puf_ini_get_str(&original, "base", "load_model_path"), "train.pt") == 0);
+
+    puf_ini_free(&copy);
+    assert(puf_ini_get(&original, "train", "horizon") == 64);
+    puf_ini_free(&original);
+    return 0;
+}

--- a/tests/test_ini_copy.py
+++ b/tests/test_ini_copy.py
@@ -1,0 +1,31 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "tests" / "test_ini_copy.c"
+
+
+def test_ini_copy_is_independent(tmp_path):
+    compiler = os.environ.get("CC") or shutil.which("cc") or shutil.which("gcc")
+    if not compiler:
+        pytest.skip("No C compiler available")
+
+    executable = tmp_path / ("test_ini_copy.exe" if os.name == "nt" else "test_ini_copy")
+    subprocess.run(
+        [
+            compiler,
+            "-std=c11",
+            "-I",
+            str(ROOT / "src"),
+            str(SOURCE),
+            "-o",
+            str(executable),
+        ],
+        check=True,
+    )
+    subprocess.run([str(executable)], check=True)


### PR DESCRIPTION
## Summary
- deep-copy the parsed Ini before applying standalone evaluation overrides
- isolate self-play pool evaluation checkpoint and match settings from the training Ini
- add a native regression test covering numeric, string, and list ownership across copies

## Why
Evaluation currently mutates the training Ini in place. The final log then serializes evaluation values such as agent count, policy layout, and self-play settings instead of the hyperparameters used for training.

## Testing
- `python3 -m pytest tests/test_ini_copy.py -q` (1 passed)
- `cc -std=c11 -Wall -Wextra -Werror -Wno-unused-function -I src tests/test_ini_copy.c -o /tmp/test_ini_copy && /tmp/test_ini_copy`
- `python -m py_compile tests/test_ini_copy.py`
- `git diff --check`

A full CUDA training run was not available locally.

Fixes #619