### PR TITLE
Env sweeps over battle and drone

### DIFF
--- a/config/drone.ini
+++ b/config/drone.ini
@@ -85,6 +85,12 @@ max = 2e8
 mean = 8e7
 scale = auto
 
+[sweep.train.clip_coef]
+distribution = uniform
+min = 0.01
+max = 0.9
+scale = auto
+
 # hover
 [sweep.env.hover_alpha_dist]
 distribution = log_normal

--- a/ocean/battle/battle.h
+++ b/ocean/battle/battle.h
@@ -767,9 +767,9 @@ void compute_observations(Battle* env) {
         obs[obs_idx++] = agent->y;
         obs[obs_idx++] = agent->z;
         obs[obs_idx++] = agent->y - ground_height(env, agent->x, agent->z);
-        obs[obs_idx++] = abs(agent->x) - 0.95f*env->size_x;
-        obs[obs_idx++] = abs(agent->z) - 0.95f*env->size_z;
-        obs[obs_idx++] = abs(agent->y) - 0.95f*env->size_y;
+        obs[obs_idx++] = fabsf(agent->x) - 0.95f*env->size_x;
+        obs[obs_idx++] = fabsf(agent->z) - 0.95f*env->size_z;
+        obs[obs_idx++] = fabsf(agent->y) - 0.95f*env->size_y;
         obs[obs_idx++] = agent->speed;
         obs[obs_idx++] = agent->health;
         obs[obs_idx++] = agent->max_turn;
@@ -921,7 +921,8 @@ void puf_step(Battle* env) {
             if (i < env->num_agents/2) {
                 env->agents[i].rewards[0] = reward;
                 env->agents[i].terminals[0] = 1;
-                env->log.score = env->log.episode_return;
+                env->log.score += agent->episode_return;
+                env->log.perf += (agent->episode_return > 0.0f) ? 1 : 0;
                 env->log.episode_length += agent->episode_length;
                 env->log.episode_return += agent->episode_return;
                 env->log.collision_rate += collision;


### PR DESCRIPTION
# Drone

The default clip_coef is lower than the default bound, so added a smaller min to the sweep config to drone. Config file in discord, summary:

- perf = 0.916312
- score = 380.626
- hover/perf = 0.876612
- hover/score = 749.812
- race/perf = 0.956011
- race/score = 11.4407
- 128x4 policy net

There's a config that got perf ~0.94 but had hidden dim 512

## Hover rollout
https://github.com/user-attachments/assets/bfcf8d09-8a9d-4506-b4ab-7eff2a14794a

## Race rollout
https://github.com/user-attachments/assets/cc6efd45-5611-4043-af0c-4c2597fabbc5

### Constellation:
<img width="1902" height="1139" alt="image" src="https://github.com/user-attachments/assets/1b579aa0-8337-4fa1-b69b-04699b72e69b" />

# Battle

Fixed a few numerics on logging, no other modifications functionally. Perf is fraction of episodes with positive return. Maybe could be good to make the different types of units more distinguishable for the render?

Config file in discord, summary:

- perf = 0.808419
- score = 3.2605
- 512x3 policy net

### Rollout of the policy:

https://github.com/user-attachments/assets/f6256399-ac7a-443d-9a91-235f1f081b82

### For comparison, this is a random init policy:

https://github.com/user-attachments/assets/8d32c3cd-3a78-440a-883d-aa2cfc6c34db

### Constellation:
<img width="1902" height="1139" alt="image" src="https://github.com/user-attachments/assets/742d2335-a83d-4d3b-a6a4-de972cfc63e8" />