### PR TITLE
Double pendulum env 5.0 fix

### DIFF
--- a/config/double_pendulum.ini
+++ b/config/double_pendulum.ini
@@ -24,7 +24,7 @@ num_layers = 2
 
 [train]
 gpus = 1
-total_timesteps = 50000000
+total_timesteps = 200000000
 learning_rate = 0.005
 anneal_lr = 1
 min_lr_ratio = 0

--- a/ocean/double_pendulum/double_pendulum.h
+++ b/ocean/double_pendulum/double_pendulum.h
@@ -52,7 +52,6 @@ struct Env {
     int max_upright_steps;
     int upright_count;
     float best_height;
-    int got_upright;
     int physics_failed;
 
     float cart_mass;
@@ -178,7 +177,6 @@ void puf_reset(DoublePendulum* env) {
     env->max_upright_steps = 0;
     env->upright_count = 0;
     env->best_height = 0.0f;
-    env->got_upright = 0;
     env->physics_failed = 0;
     compute_observations(env);
 }
@@ -305,9 +303,8 @@ float height_record_reward(DoublePendulum* env) {
     if (height > env->best_height && height > 0.9f) {
         reward += 0.05f * (height - 0.9f) / 0.1f;
     }
-    if (stable && !env->got_upright) {
+    if (stable) {
         reward += 0.1f;
-        env->got_upright = 1;
     }
     env->best_height = fmaxf(env->best_height, height);
     return reward;


### PR DESCRIPTION
- `got_upright` latched the 0.1 stability bonus to fire once per episode, so once the height records saturate nothing rewards staying up.
- `total_timesteps` 50M -> 200M. Takeoff completes around 125M, so the previous budget could not learn the task.
- `hold_time` 0.12 -> 510.8 +/- 5.1 out of 600, `x_threshold_termination` 0.30 -> 0.000, ~40s on one laptop GPU.