### PR TITLE
Restore OSRS CPU viewer builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ set -e
 #   ./build.sh robot_arm             # CUDA-only; implies --cu
 #   ./build.sh breakout --float      # float32 precision (required for --slowly)
 #   ./build.sh breakout --cpu        # Play/eval binary (optimized) -> ./ENV
+#   ./build.sh osrs_inferno --cpu     # OSRS visual policy viewer -> ./osrs_inferno
 #   ./build.sh breakout myplay --cpu # Play -> ./myplay
 #   ./build.sh breakout --debug      # Debug (-O0 -g; sanitizers on --cpu)
 #   ./build.sh breakout --web        # Emscripten web build
@@ -225,22 +226,34 @@ else
     LINK_OPT="-O2"
 fi
 if [ "$MODE" = "cpu" ]; then
-    ENV_HEADER="$SRC_DIR/$ENV.h"
-    if ! grep -q 'typedef[[:space:]].*obs_t' "$ENV_HEADER" 2>/dev/null; then
-        echo "Error: $ENV_HEADER must typedef obs_t for standalone eval"
-        exit 1
-    fi
+    STANDALONE_SOURCE="src/puffercpu.c"
+    STANDALONE_DEFINES=()
+    case "$ENV" in
+        osrs_*)
+            STANDALONE_SOURCE="$SRC_FILE"
+            ;;
+        *)
+            ENV_HEADER="$SRC_DIR/$ENV.h"
+            if ! grep -q 'typedef[[:space:]].*obs_t' "$ENV_HEADER" 2>/dev/null; then
+                echo "Error: $ENV_HEADER must typedef obs_t for standalone eval"
+                exit 1
+            fi
+            STANDALONE_DEFINES=(
+                -DPUFFERCPU_EVAL_MAIN
+                -DENV_HEADER=\"$ENV_HEADER\"
+                -DPUFFER_ENV_NAME=\"$ENV\"
+            )
+            ;;
+    esac
     FLAGS=(
         -I. -Isrc -I$SRC_DIR -Ivendor "${INCLUDES[@]}"
-        src/puffercpu.c $EXTRA_SRC -o "$OUTPUT_NAME"
+        "$STANDALONE_SOURCE" $EXTRA_SRC -o "$OUTPUT_NAME"
         "${LINK_ARCHIVES[@]}"
         "${EXTRA_LDFLAGS[@]}"
         "${STANDALONE_LDFLAGS[@]}"
         -lm -lpthread "${OMP_FLAGS[@]}"
         -DPLATFORM_DESKTOP
-        -DPUFFERCPU_EVAL_MAIN
-        -DENV_HEADER=\"$ENV_HEADER\"
-        -DPUFFER_ENV_NAME=\"$ENV\"
+        "${STANDALONE_DEFINES[@]}"
         "${EXTRA_CFLAGS[@]}"
     )
     echo "Compiling $ENV..."

--- a/tests/test_osrs_cpu_build.py
+++ b/tests/test_osrs_cpu_build.py
@@ -1,0 +1,58 @@
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def write_executable(path: Path, source: str) -> None:
+    path.write_text(source)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_osrs_cpu_build_selects_visual_entrypoint(tmp_path: Path) -> None:
+    shutil.copy(REPOSITORY_ROOT / "build.sh", tmp_path / "build.sh")
+
+    source = tmp_path / "ocean/osrs_inferno/osrs_inferno.c"
+    source.parent.mkdir(parents=True)
+    source.write_text("")
+
+    scripts = tmp_path / "ocean/osrs/scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "osrs_asset_manifest.py").write_text("")
+    write_executable(scripts / "setup-data.sh", "#!/bin/bash\n")
+    (tmp_path / "ocean/osrs/asset_manifest.json").write_text("{}")
+
+    for raylib in ("raylib-5.5_linux_amd64", "raylib-5.5_macos"):
+        (tmp_path / raylib).mkdir()
+
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    write_executable(tools / "brew", "#!/bin/bash\nprintf '%s\\n' \"$PWD/libomp\"\n")
+    compiler_arguments = tmp_path / "compiler-arguments"
+    write_executable(
+        tools / "capture-compiler",
+        "#!/bin/bash\nprintf '%s\\n' \"$@\" > \"$COMPILER_ARGUMENTS\"\n",
+    )
+
+    environment = os.environ | {
+        "CC": str(tools / "capture-compiler"),
+        "COMPILER_ARGUMENTS": str(compiler_arguments),
+        "PATH": f"{tools}:{os.environ['PATH']}",
+    }
+    result = subprocess.run(
+        ["bash", "build.sh", "osrs_inferno", "--cpu"],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    arguments = compiler_arguments.read_text().splitlines()
+    assert "ocean/osrs_inferno/osrs_inferno.c" in arguments
+    assert "src/puffercpu.c" not in arguments
+    assert arguments[arguments.index("-o") + 1] == "osrs_inferno"


### PR DESCRIPTION
Route OSRS --cpu builds through the dedicated visual entrypoint while preserving the generic puffercpu path for other environments. This restores rendered checkpoint playback after the #644 merge changed standalone build routing.