### PR TITLE
Render OSRS checkpoints through puffer eval

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ set -e
 #   ./build.sh robot_arm             # CUDA-only; implies --cu
 #   ./build.sh breakout --float      # float32 precision (required for --slowly)
 #   ./build.sh breakout --cpu        # Play/eval binary (optimized) -> ./ENV
+#   ./build.sh osrs_inferno --cpu     # OSRS visual policy viewer -> ./osrs_inferno
 #   ./build.sh breakout myplay --cpu # Play -> ./myplay
 #   ./build.sh breakout --debug      # Debug (-O0 -g; sanitizers on --cpu)
 #   ./build.sh breakout --web        # Emscripten web build
@@ -225,22 +226,34 @@ else
     LINK_OPT="-O2"
 fi
 if [ "$MODE" = "cpu" ]; then
-    ENV_HEADER="$SRC_DIR/$ENV.h"
-    if ! grep -q 'typedef[[:space:]].*obs_t' "$ENV_HEADER" 2>/dev/null; then
-        echo "Error: $ENV_HEADER must typedef obs_t for standalone eval"
-        exit 1
-    fi
+    STANDALONE_SOURCE="src/puffercpu.c"
+    STANDALONE_DEFINES=()
+    case "$ENV" in
+        osrs_*)
+            STANDALONE_SOURCE="$SRC_FILE"
+            ;;
+        *)
+            ENV_HEADER="$SRC_DIR/$ENV.h"
+            if ! grep -q 'typedef[[:space:]].*obs_t' "$ENV_HEADER" 2>/dev/null; then
+                echo "Error: $ENV_HEADER must typedef obs_t for standalone eval"
+                exit 1
+            fi
+            STANDALONE_DEFINES=(
+                -DPUFFERCPU_EVAL_MAIN
+                -DENV_HEADER=\"$ENV_HEADER\"
+                -DPUFFER_ENV_NAME=\"$ENV\"
+            )
+            ;;
+    esac
     FLAGS=(
         -I. -Isrc -I$SRC_DIR -Ivendor "${INCLUDES[@]}"
-        src/puffercpu.c $EXTRA_SRC -o "$OUTPUT_NAME"
+        "$STANDALONE_SOURCE" $EXTRA_SRC -o "$OUTPUT_NAME"
         "${LINK_ARCHIVES[@]}"
         "${EXTRA_LDFLAGS[@]}"
         "${STANDALONE_LDFLAGS[@]}"
         -lm -lpthread "${OMP_FLAGS[@]}"
         -DPLATFORM_DESKTOP
-        -DPUFFERCPU_EVAL_MAIN
-        -DENV_HEADER=\"$ENV_HEADER\"
-        -DPUFFER_ENV_NAME=\"$ENV\"
+        "${STANDALONE_DEFINES[@]}"
         "${EXTRA_CFLAGS[@]}"
     )
     echo "Compiling $ENV..."

--- a/build.sh
+++ b/build.sh
@@ -410,6 +410,19 @@ if [ "$MODE" = "native" ]; then
     if [ "$SNAKE_RAW" = "1" ]; then
         EXTRA_CFLAGS+=(-DSNAKE_ONEHOT=0)
     fi
+    OSRS_RENDER_OBJECT=""
+    case "$ENV" in
+        osrs_*)
+            OSRS_RENDER_OBJECT="build/osrs_puffer_render.o"
+            ENV_COMPILE_FLAGS+=(-DOSRS_PUFFER_RENDER)
+            $CC $LINK_OPT "${CLANG_WARN[@]}" "${SIMD_FLAGS[@]}" -std=c11 \
+                -I. -Isrc -I$SRC_DIR -Ivendor \
+                "${INCLUDES[@]}" \
+                -DPLATFORM_DESKTOP \
+                -c ocean/osrs/osrs_puffer_render.c \
+                -o "$OSRS_RENDER_OBJECT"
+            ;;
+    esac
     echo "Compiling native train/eval binary ($ARCH) -> $TRAIN_BIN..."
     $NVCC $NVCC_OPT -arch=$ARCH -std=c++17 \
         -I. -Isrc -I$SRC_DIR -Ivendor \
@@ -426,6 +439,7 @@ if [ "$MODE" = "native" ]; then
 	    $PRECISION \
 	    src/pufferl.cu \
         $EXTRA_SRC \
+        $OSRS_RENDER_OBJECT \
         "${LINK_ARCHIVES[@]}" \
         -L$CUDA_HOME/lib64 $NCCL_LFLAG \
         "${EXTRA_LDFLAGS[@]}" \

--- a/ocean/osrs/osrs_puffer_render.c
+++ b/ocean/osrs/osrs_puffer_render.c
@@ -1,0 +1,39 @@
+#define OSRS_VISUAL
+
+#include <stdlib.h>
+
+#include "osrs_puffer_render.h"
+#include "osrs_render_scene.h"
+
+typedef struct {
+    OsrsEnv env;
+} OsrsPufferRenderer;
+
+void* osrs_puffer_render_create(
+    const void* encounter_def,
+    void* encounter_state,
+    void* encounter_context
+) {
+    const EncounterDef* def = (const EncounterDef*)encounter_def;
+    OsrsPufferRenderer* renderer = (OsrsPufferRenderer*)calloc(1, sizeof(*renderer));
+    if (renderer == NULL) abort();
+
+    renderer->env.encounter_def = def;
+    renderer->env.encounter_state = encounter_state;
+    renderer->env.encounter_context = encounter_context;
+    visual_load_encounter_collision_map(def, &renderer->env, def->name);
+    visual_init_render_scene(&renderer->env, def->name, NULL);
+    return renderer;
+}
+
+void osrs_puffer_render_draw(void* opaque_renderer) {
+    OsrsPufferRenderer* renderer = (OsrsPufferRenderer*)opaque_renderer;
+    pvp_render(&renderer->env);
+}
+
+void osrs_puffer_render_destroy(void* opaque_renderer) {
+    OsrsPufferRenderer* renderer = (OsrsPufferRenderer*)opaque_renderer;
+    render_destroy_client((RenderClient*)renderer->env.client);
+    collision_map_free((CollisionMap*)renderer->env.collision_map);
+    free(renderer);
+}

--- a/ocean/osrs/osrs_puffer_render.h
+++ b/ocean/osrs/osrs_puffer_render.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void* osrs_puffer_render_create(
+    const void* encounter_def,
+    void* encounter_state,
+    void* encounter_context);
+void osrs_puffer_render_draw(void* renderer);
+void osrs_puffer_render_destroy(void* renderer);
+
+#ifdef __cplusplus
+}
+#endif

--- a/ocean/osrs/osrs_render_scene.h
+++ b/ocean/osrs/osrs_render_scene.h
@@ -1,0 +1,198 @@
+#pragma once
+
+#include <stdio.h>
+#include <string.h>
+
+#include "encounters/encounter_nh_pvp.h"
+#include "encounters/encounter_zulrah.h"
+#include "encounters/encounter_inferno.h"
+#include "encounters/encounter_colosseum.h"
+#include "osrs_render.h"
+
+static int encounter_name_is_pvp(const char* encounter_name) {
+    return encounter_name &&
+        (strcmp(encounter_name, "pvp") == 0 ||
+         strcmp(encounter_name, "nh_pvp") == 0);
+}
+
+static void visual_require_gui_item_sprite(int raw_osrs_id, void* context) {
+    gui_require_sprite_by_osrs_id((GuiState*)context, raw_osrs_id);
+}
+
+typedef struct {
+    CollisionMap* cmap;
+    int offset_x;
+    int offset_y;
+} VisualCollisionLoad;
+
+static VisualCollisionLoad visual_load_encounter_collision_map(
+    const EncounterDef* encounter_def,
+    OsrsEnv* env,
+    const char* encounter_name
+) {
+    CollisionMap* collision_map = NULL;
+    int offset_x = 0;
+    int offset_y = 0;
+
+    if (encounter_name_is_pvp(encounter_name)) {
+        collision_map = collision_map_load(OSRS_ASSET("wilderness.cmap"));
+    } else if (strcmp(encounter_name, "zulrah") == 0) {
+        collision_map = collision_map_load(OSRS_ASSET("zulrah.cmap"));
+        offset_x = 2256;
+        offset_y = 3061;
+    } else if (strcmp(encounter_name, "inferno") == 0) {
+        collision_map = collision_map_load(OSRS_ASSET("inferno.cmap"));
+        offset_x = 2246;
+        offset_y = 5315;
+    } else if (strcmp(encounter_name, "colosseum") == 0) {
+        collision_map = collision_map_load(OSRS_ASSET("colosseum.cmap"));
+        offset_x = 1808;
+        offset_y = 3090;
+    }
+
+    VisualCollisionLoad result = {NULL, offset_x, offset_y};
+    if (collision_map == NULL) return result;
+
+    if (!encounter_name_is_pvp(encounter_name)) {
+        encounter_def->put_int(
+            env->encounter_state,
+            env->encounter_context,
+            "world_offset_x",
+            offset_x);
+        encounter_def->put_int(
+            env->encounter_state,
+            env->encounter_context,
+            "world_offset_y",
+            offset_y);
+    }
+    encounter_def->put_ptr(
+        env->encounter_state,
+        env->encounter_context,
+        "collision_map",
+        collision_map);
+    env->collision_map = collision_map;
+    result.cmap = collision_map;
+    return result;
+}
+
+static RenderClient* visual_init_render_scene(
+    OsrsEnv* env,
+    const char* encounter_name,
+    const EncounterArenaTopology* route_topology
+) {
+    RenderClient* render_client = render_make_client(env);
+    env->client = render_client;
+    render_client->route_topology = route_topology;
+    pvp_actor_route_caches_clear(render_client->player_route_cache);
+#ifdef __EMSCRIPTEN__
+    if (!encounter_name || encounter_name_is_pvp(encounter_name)) {
+        render_client->ticks_per_second = 15.0f;
+    }
+#endif
+
+    if (!encounter_name || encounter_name_is_pvp(encounter_name)) {
+        osrs_asset_require_group(OSRS_ASSET_GROUP_PVP);
+    } else if (strcmp(encounter_name, "zulrah") == 0) {
+        osrs_asset_require_group(OSRS_ASSET_GROUP_ZULRAH);
+        osrs_asset_require_group(OSRS_ASSET_GROUP_COMBAT_VISUALS);
+    } else if (strcmp(encounter_name, "inferno") == 0) {
+        osrs_asset_require_group(OSRS_ASSET_GROUP_INFERNO);
+        osrs_asset_require_group(OSRS_ASSET_GROUP_COMBAT_VISUALS);
+    } else if (strcmp(encounter_name, "colosseum") == 0) {
+        osrs_asset_require_group(OSRS_ASSET_GROUP_COLOSSEUM);
+        osrs_asset_require_group(OSRS_ASSET_GROUP_COMBAT_VISUALS);
+        col_for_each_display_inventory_sprite_raw_osrs_id(
+            visual_require_gui_item_sprite,
+            &render_client->gui);
+    }
+
+    if (env->collision_map) {
+        render_client->collision_map = (const CollisionMap*)env->collision_map;
+    }
+
+    render_client->model_cache = model_cache_load(OSRS_ASSET("equipment.models"));
+    if (render_client->model_cache) render_client->show_models = 1;
+    render_client->anim_cache = anim_cache_load(OSRS_ASSET("equipment.anims"));
+    render_load_projectile_assets(render_client);
+    render_init_overlay_models(render_client);
+
+    if (!encounter_name || encounter_name_is_pvp(encounter_name)) {
+        render_client->terrain = terrain_load(OSRS_ASSET("wilderness.terrain"));
+    } else if (strcmp(encounter_name, "zulrah") == 0) {
+        render_client->terrain = terrain_load(OSRS_ASSET("zulrah.terrain"));
+        render_client->objects = objects_load(OSRS_ASSET("zulrah.objects"));
+
+        int offset_x = 2256;
+        int offset_y = 3061;
+        if (render_client->terrain)
+            terrain_offset(render_client->terrain, offset_x, offset_y);
+        if (render_client->objects)
+            objects_offset(render_client->objects, offset_x, offset_y);
+
+        render_client->collision_world_offset_x = offset_x;
+        render_client->collision_world_offset_y = offset_y;
+        render_client->npc_model_cache = model_cache_load(OSRS_ASSET("zulrah.models"));
+        render_client->npc_anim_cache = anim_cache_load(OSRS_ASSET("zulrah.anims"));
+        fprintf(stderr, "zulrah: npc_models=%d, npc_anims=%d seqs\n",
+            render_client->npc_model_cache ? render_client->npc_model_cache->count : 0,
+            render_client->npc_anim_cache ? render_client->npc_anim_cache->seq_count : 0);
+    } else if (strcmp(encounter_name, "inferno") == 0) {
+        render_client->terrain = terrain_load_region(OSRS_ASSET("inferno.terrain"), 35, 83);
+        render_client->objects = objects_load(OSRS_ASSET("inferno.objects"));
+        render_client->objects_zuk = objects_load(OSRS_ASSET("inferno_zuk.objects"));
+        if (render_client->terrain)
+            terrain_offset(render_client->terrain, 2246, 5315);
+        if (render_client->objects)
+            objects_offset(render_client->objects, 2246, 5315);
+        if (render_client->objects_zuk)
+            objects_offset(render_client->objects_zuk, 2246, 5315);
+
+        render_client->npc_model_cache = model_cache_load(OSRS_ASSET("inferno.models"));
+        render_client->npc_anim_cache = anim_cache_load(OSRS_ASSET("inferno.anims"));
+        if (env->collision_map) {
+            render_client->collision_world_offset_x = 2246;
+            render_client->collision_world_offset_y = 5315;
+        }
+        fprintf(stderr, "inferno: terrain=%s, cmap=%s, npc_models=%d, npc_anims=%d seqs\n",
+            render_client->terrain ? "loaded" : "MISSING",
+            render_client->collision_map ? "loaded" : "MISSING",
+            render_client->npc_model_cache ? render_client->npc_model_cache->count : 0,
+            render_client->npc_anim_cache ? render_client->npc_anim_cache->seq_count : 0);
+    } else if (strcmp(encounter_name, "colosseum") == 0) {
+        render_client->terrain = terrain_load(OSRS_ASSET("colosseum.terrain"));
+        render_client->objects = objects_load(OSRS_ASSET("colosseum.objects"));
+        if (render_client->terrain)
+            terrain_offset(render_client->terrain, 1808, 3090);
+        if (render_client->objects)
+            objects_offset(render_client->objects, 1808, 3090);
+        render_client->npc_model_cache = model_cache_load(OSRS_ASSET("colosseum_npcs.models"));
+        render_client->npc_anim_cache = anim_cache_load(OSRS_ASSET("colosseum_npcs.anims"));
+        if (env->collision_map) {
+            render_client->collision_world_offset_x = 1808;
+            render_client->collision_world_offset_y = 3090;
+        }
+        fprintf(stderr, "colosseum: terrain=%s, cmap=%s, npc_models=%d, npc_anims=%d seqs\n",
+            render_client->terrain ? "loaded" : "MISSING",
+            render_client->collision_map ? "loaded" : "MISSING",
+            render_client->npc_model_cache ? render_client->npc_model_cache->count : 0,
+            render_client->npc_anim_cache ? render_client->npc_anim_cache->seq_count : 0);
+    }
+
+    render_populate_entities(render_client, env);
+    render_client->cam_target_x = (float)render_client->arena_base_x +
+        (float)render_client->arena_width / 2.0f;
+    render_client->cam_target_z = -((float)render_client->arena_base_y +
+        (float)render_client->arena_height / 2.0f);
+
+    for (int i = 0; i < render_client->entity_count; i++) {
+        int size = render_client->entities[i].npc_size > 1
+            ? render_client->entities[i].npc_size
+            : 1;
+        render_client->sub_x[i] = render_client->entities[i].x * 128 + size * 64;
+        render_client->sub_y[i] = render_client->entities[i].y * 128 + size * 64;
+        render_client->dest_x[i] = render_client->sub_x[i];
+        render_client->dest_y[i] = render_client->sub_y[i];
+    }
+
+    return render_client;
+}

--- a/ocean/osrs/osrs_visual.c
+++ b/ocean/osrs/osrs_visual.c
@@ -23,6 +23,7 @@
 
 #ifdef OSRS_VISUAL
 #include "osrs_render.h"
+#include "osrs_render_scene.h"
 #include "puffercpu.c"
 #include "osrs_visual_net.h"
 
@@ -199,9 +200,6 @@ static const EntityEncoderDescriptor* visual_policy_entity_descriptor(
     return NULL;
 }
 
-static void visual_require_gui_item_sprite(int raw_osrs_id, void* ctx) {
-    gui_require_sprite_by_osrs_id((GuiState*)ctx, raw_osrs_id);
-}
 #endif
 
 #ifdef __EMSCRIPTEN__
@@ -210,11 +208,6 @@ static void visual_require_gui_item_sprite(int raw_osrs_id, void* ctx) {
 #include <pthread.h>
 #endif
 
-static int encounter_name_is_pvp(const char* encounter_name) {
-    return encounter_name &&
-        (strcmp(encounter_name, "pvp") == 0 ||
-         strcmp(encounter_name, "nh_pvp") == 0);
-}
 
 static void print_player_state(Player* p, int idx) {
     printf("Player %d: HP=%d/%d Prayer=%d Gear=%d Pos=(%d,%d) Frozen=%d\n",
@@ -459,50 +452,6 @@ static void osrs_print_inferno_profile_results(int total_steps) {
 }
 #endif
 
-typedef struct {
-    CollisionMap* cmap;
-    int offset_x;
-    int offset_y;
-} VisualCollisionLoad;
-
-static VisualCollisionLoad visual_load_encounter_collision_map(
-    const EncounterDef* edef, OsrsEnv* env, const char* encounter_name
-) {
-    CollisionMap* cmap = NULL;
-    int offset_x = 0, offset_y = 0;
-    if (encounter_name_is_pvp(encounter_name)) {
-        cmap = collision_map_load(OSRS_ASSET("wilderness.cmap"));
-    } else
-    if (strcmp(encounter_name, "zulrah") == 0) {
-        cmap = collision_map_load(OSRS_ASSET("zulrah.cmap"));
-        offset_x = 2256; offset_y = 3061;
-    } else if (strcmp(encounter_name, "inferno") == 0) {
-        cmap = collision_map_load(OSRS_ASSET("inferno.cmap"));
-        offset_x = 2246; offset_y = 5315;
-    } else if (strcmp(encounter_name, "colosseum") == 0) {
-        cmap = collision_map_load(OSRS_ASSET("colosseum.cmap"));
-        offset_x = 1808; offset_y = 3090;
-    }
-    VisualCollisionLoad result = { NULL, offset_x, offset_y };
-    if (cmap) {
-        if (!encounter_name_is_pvp(encounter_name)) {
-            edef->put_int(
-                env->encounter_state,
-                env->encounter_context,
-                "world_offset_x",
-                offset_x);
-            edef->put_int(
-                env->encounter_state,
-                env->encounter_context,
-                "world_offset_y",
-                offset_y);
-        }
-        edef->put_ptr(env->encounter_state, env->encounter_context, "collision_map", cmap);
-        env->collision_map = cmap;
-        result.cmap = cmap;
-    }
-    return result;
-}
 
 static const EncounterDef* visual_open_encounter(OsrsEnv* env, const char* encounter_name) {
     const EncounterDef* edef = encounter_find(encounter_name);
@@ -2163,125 +2112,11 @@ static void run_visual(
     }
 
 
+    RenderClient* rc = visual_init_render_scene(
+        env,
+        encounter_name,
+        direct_pvp_topology);
     pvp_render(env);
-    RenderClient* rc = (RenderClient*)env->client;
-    rc->route_topology = direct_pvp_topology;
-    pvp_actor_route_caches_clear(rc->player_route_cache);
-#ifdef __EMSCRIPTEN__
-    if (!encounter_name || encounter_name_is_pvp(encounter_name)) {
-        rc->ticks_per_second = 15.0f;
-    }
-#endif
-
-    if (!encounter_name || encounter_name_is_pvp(encounter_name)) {
-        osrs_asset_require_group(OSRS_ASSET_GROUP_PVP);
-    } else if (strcmp(encounter_name, "zulrah") == 0) {
-        osrs_asset_require_group(OSRS_ASSET_GROUP_ZULRAH);
-        osrs_asset_require_group(OSRS_ASSET_GROUP_COMBAT_VISUALS);
-    } else if (strcmp(encounter_name, "inferno") == 0) {
-        osrs_asset_require_group(OSRS_ASSET_GROUP_INFERNO);
-        osrs_asset_require_group(OSRS_ASSET_GROUP_COMBAT_VISUALS);
-    } else if (strcmp(encounter_name, "colosseum") == 0) {
-        osrs_asset_require_group(OSRS_ASSET_GROUP_COLOSSEUM);
-        osrs_asset_require_group(OSRS_ASSET_GROUP_COMBAT_VISUALS);
-        col_for_each_display_inventory_sprite_raw_osrs_id(
-            visual_require_gui_item_sprite,
-            &rc->gui);
-    }
-
-    if (env->collision_map) {
-        rc->collision_map = (const CollisionMap*)env->collision_map;
-    }
-
-    rc->model_cache = model_cache_load(OSRS_ASSET("equipment.models"));
-    if (rc->model_cache) {
-        rc->show_models = 1;
-    }
-    rc->anim_cache = anim_cache_load(OSRS_ASSET("equipment.anims"));
-    render_load_projectile_assets(rc);
-    render_init_overlay_models(rc);
-    if (!encounter_name || encounter_name_is_pvp(encounter_name)) {
-        rc->terrain = terrain_load(OSRS_ASSET("wilderness.terrain"));
-        rc->objects = NULL;
-        rc->npcs = NULL;
-    } else if (strcmp(encounter_name, "zulrah") == 0) {
-        rc->terrain = terrain_load(OSRS_ASSET("zulrah.terrain"));
-        rc->objects = objects_load(OSRS_ASSET("zulrah.objects"));
-
-        int zul_off_x = 2240 + 16;
-        int zul_off_y = 3008 + 53;
-        if (rc->terrain)
-            terrain_offset(rc->terrain, zul_off_x, zul_off_y);
-        if (rc->objects)
-            objects_offset(rc->objects, zul_off_x, zul_off_y);
-
-        rc->collision_map = (const CollisionMap*)env->collision_map;
-        rc->collision_world_offset_x = 2256;
-        rc->collision_world_offset_y = 3061;
-
-        rc->npc_model_cache = model_cache_load(OSRS_ASSET("zulrah.models"));
-        rc->npc_anim_cache = anim_cache_load(OSRS_ASSET("zulrah.anims"));
-        fprintf(stderr, "zulrah: npc_models=%d, npc_anims=%d seqs\n",
-                rc->npc_model_cache ? rc->npc_model_cache->count : 0,
-                rc->npc_anim_cache ? rc->npc_anim_cache->seq_count : 0);
-    } else if (encounter_name && strcmp(encounter_name, "inferno") == 0) {
-        rc->terrain = terrain_load_region(OSRS_ASSET("inferno.terrain"), 35, 83);
-        rc->objects = objects_load(OSRS_ASSET("inferno.objects"));
-        rc->objects_zuk = objects_load(OSRS_ASSET("inferno_zuk.objects"));
-        if (rc->terrain)
-            terrain_offset(rc->terrain, 2246, 5315);
-        if (rc->objects)
-            objects_offset(rc->objects, 2246, 5315);
-        if (rc->objects_zuk)
-            objects_offset(rc->objects_zuk, 2246, 5315);
-
-        rc->npc_model_cache = model_cache_load(OSRS_ASSET("inferno.models"));
-        rc->npc_anim_cache = anim_cache_load(OSRS_ASSET("inferno.anims"));
-
-        if (env->collision_map) {
-            rc->collision_map = (const CollisionMap*)env->collision_map;
-            rc->collision_world_offset_x = 2246;
-            rc->collision_world_offset_y = 5315;
-        }
-
-        fprintf(stderr, "inferno: terrain=%s, cmap=%s, npc_models=%d, npc_anims=%d seqs\n",
-                rc->terrain ? "loaded" : "MISSING",
-                rc->collision_map ? "loaded" : "MISSING",
-                rc->npc_model_cache ? rc->npc_model_cache->count : 0,
-                rc->npc_anim_cache ? rc->npc_anim_cache->seq_count : 0);
-    } else if (encounter_name && strcmp(encounter_name, "colosseum") == 0) {
-        rc->terrain = terrain_load(OSRS_ASSET("colosseum.terrain"));
-        rc->objects = objects_load(OSRS_ASSET("colosseum.objects"));
-        if (rc->terrain)
-            terrain_offset(rc->terrain, 1808, 3090);
-        if (rc->objects)
-            objects_offset(rc->objects, 1808, 3090);
-        rc->npc_model_cache = model_cache_load(OSRS_ASSET("colosseum_npcs.models"));
-        rc->npc_anim_cache = anim_cache_load(OSRS_ASSET("colosseum_npcs.anims"));
-        if (env->collision_map) {
-            rc->collision_map = (const CollisionMap*)env->collision_map;
-            rc->collision_world_offset_x = 1808;
-            rc->collision_world_offset_y = 3090;
-        }
-        fprintf(stderr, "colosseum: terrain=%s, cmap=%s, npc_models=%d, npc_anims=%d seqs\n",
-                rc->terrain ? "loaded" : "MISSING",
-                rc->collision_map ? "loaded" : "MISSING",
-                rc->npc_model_cache ? rc->npc_model_cache->count : 0,
-                rc->npc_anim_cache ? rc->npc_anim_cache->seq_count : 0);
-    }
-
-    render_populate_entities(rc, env);
-
-    rc->cam_target_x = (float)rc->arena_base_x + (float)rc->arena_width / 2.0f;
-    rc->cam_target_z = -((float)rc->arena_base_y + (float)rc->arena_height / 2.0f);
-
-    for (int i = 0; i < rc->entity_count; i++) {
-        int size = rc->entities[i].npc_size > 1 ? rc->entities[i].npc_size : 1;
-        rc->sub_x[i] = rc->entities[i].x * 128 + size * 64;
-        rc->sub_y[i] = rc->entities[i].y * 128 + size * 64;
-        rc->dest_x[i] = rc->sub_x[i];
-        rc->dest_y[i] = rc->sub_y[i];
-    }
 
     ReplayFile* replay = NULL;
     if (replay_path && env->encounter_def) {

--- a/ocean/osrs_colosseum/osrs_colosseum.h
+++ b/ocean/osrs_colosseum/osrs_colosseum.h
@@ -13,6 +13,9 @@ typedef float obs_t;
 #define Log OsrsSharedLog
 #include "../osrs/encounters/encounter_colosseum.h"
 #undef Log
+#ifdef OSRS_PUFFER_RENDER
+#include "../osrs/osrs_puffer_render.h"
+#endif
 
 #define OBS_SIZE COLO_NUM_OBS
 #define NUM_ATNS COLO_NUM_ACTION_HEADS
@@ -111,6 +114,9 @@ struct Env {
     int acts_staging[COLO_NUM_ACTION_HEADS];
     uint64_t damage_scale_anneal_step;
     uint64_t dpt_sample_step;
+#ifdef OSRS_PUFFER_RENDER
+    void* renderer;
+#endif
     float max_episode_depth_seen;
 };
 
@@ -494,10 +500,23 @@ void puf_env_profile_report(void) {
 #endif
 
 void puf_render(Env* env) {
+#ifdef OSRS_PUFFER_RENDER
+    if (env->renderer == NULL) {
+        env->renderer = osrs_puffer_render_create(
+            &ENCOUNTER_COLOSSEUM,
+            COLO_ENV_STATE(env),
+            COLO_ENV_CONTEXT(env));
+    }
+    osrs_puffer_render_draw(env->renderer);
+#else
     (void)env;
+#endif
 }
 
 void puf_close(Env* env) {
+#ifdef OSRS_PUFFER_RENDER
+    if (env->renderer != NULL) osrs_puffer_render_destroy(env->renderer);
+#endif
     ENCOUNTER_COLOSSEUM.destroy_context(COLO_ENV_CONTEXT(env));
 }
 
@@ -517,6 +536,7 @@ void puf_log(Log* log, Dict* out) {
     dict_set(out, "prayer_correct_rate", prayer_rate);
 
     dict_set(out, "score", log->score);
+    dict_set(out, "perf", log->score);
     dict_set(out, "sol_min_hp", log->sol_min_hp);
     dict_set(out, "max_depth_reached", log->max_depth_reached);
     dict_set(out, "avoid_total", log->avoid_total);

--- a/ocean/osrs_inferno/osrs_inferno.h
+++ b/ocean/osrs_inferno/osrs_inferno.h
@@ -14,6 +14,9 @@ typedef float obs_t;
 #pragma GCC diagnostic ignored "-Wunused-function"
 #include "../osrs/encounters/encounter_inferno.h"
 #pragma GCC diagnostic pop
+#ifdef OSRS_PUFFER_RENDER
+#include "../osrs/osrs_puffer_render.h"
+#endif
 
 #define OBS_SIZE INF_NUM_OBS
 #define NUM_ATNS INF_NUM_ACTION_HEADS
@@ -35,6 +38,9 @@ struct Env {
     InfernoState state;
     InfernoContext context;
     int config_start_wave;
+#ifdef OSRS_PUFFER_RENDER
+    void* renderer;
+#endif
 };
 
 static inline uint32_t inf_lowbias32(uint32_t x) {
@@ -418,10 +424,23 @@ void puf_step(Env* env) {
 }
 
 void puf_render(Env* env) {
+#ifdef OSRS_PUFFER_RENDER
+    if (env->renderer == NULL) {
+        env->renderer = osrs_puffer_render_create(
+            &ENCOUNTER_INFERNO,
+            INF_ENV_STATE(env),
+            INF_ENV_CONTEXT(env));
+    }
+    osrs_puffer_render_draw(env->renderer);
+#else
     (void)env;
+#endif
 }
 
 void puf_close(Env* env) {
+#ifdef OSRS_PUFFER_RENDER
+    if (env->renderer != NULL) osrs_puffer_render_destroy(env->renderer);
+#endif
     ENCOUNTER_INFERNO.destroy_context(INF_ENV_CONTEXT(env));
 }
 
@@ -536,6 +555,7 @@ void puf_log(Log* log, Dict* out) {
         score = wr + (1.0f - wr) * wave_frac * 0.5f;
     }
     dict_set(out, "score", score);
+    dict_set(out, "perf", score);
 
     if (log->n_normal > 0.0f) {
         float min_zuk_hp_normal = log->min_zuk_hp_normal / log->n_normal;

--- a/ocean/osrs_pvp/osrs_pvp.h
+++ b/ocean/osrs_pvp/osrs_pvp.h
@@ -10,6 +10,9 @@ typedef float obs_t;
 #define Log OsrsSharedLog
 #include "../osrs/encounters/encounter_nh_pvp.h"
 #undef Log
+#ifdef OSRS_PUFFER_RENDER
+#include "../osrs/osrs_puffer_render.h"
+#endif
 
 #define OBS_SIZE NH_PVP_NUM_OBS
 #define NUM_ATNS OSRS_BASE_NUM_ACTION_HEADS
@@ -46,6 +49,9 @@ struct Env {
     NhPvpState state;
     NhPvpContext context;
     int acts_staging[OSRS_BASE_NUM_ACTION_HEADS];
+#ifdef OSRS_PUFFER_RENDER
+    void* renderer;
+#endif
 };
 
 static inline uint32_t nh_pvp_lowbias32(uint32_t x) {
@@ -186,10 +192,23 @@ void puf_step(Env* env) {
 }
 
 void puf_render(Env* env) {
+#ifdef OSRS_PUFFER_RENDER
+    if (env->renderer == NULL) {
+        env->renderer = osrs_puffer_render_create(
+            &ENCOUNTER_NH_PVP,
+            NH_PVP_ENV_STATE(env),
+            NH_PVP_ENV_CONTEXT(env));
+    }
+    osrs_puffer_render_draw(env->renderer);
+#else
     (void)env;
+#endif
 }
 
 void puf_close(Env* env) {
+#ifdef OSRS_PUFFER_RENDER
+    if (env->renderer != NULL) osrs_puffer_render_destroy(env->renderer);
+#endif
     pvp_close(&env->state.env);
     ENCOUNTER_NH_PVP.destroy_context(NH_PVP_ENV_CONTEXT(env));
 }
@@ -211,6 +230,7 @@ void puf_log(Log* log, Dict* out) {
     dict_set(out, "damage_per_hit",
         log->attacks_landed > 0.0f ? log->damage_dealt / log->attacks_landed : 0.0f);
     float damage_fraction = log->damage_dealt / 99.0f;
-    dict_set(out, "score",
-        log->wins + (1.0f - log->wins) * damage_fraction * 0.5f);
+    float score = log->wins + (1.0f - log->wins) * damage_fraction * 0.5f;
+    dict_set(out, "score", score);
+    dict_set(out, "perf", score);
 }

--- a/ocean/osrs_zulrah/osrs_zulrah.h
+++ b/ocean/osrs_zulrah/osrs_zulrah.h
@@ -11,6 +11,9 @@ typedef float obs_t;
 #define Log OsrsSharedLog
 #include "../osrs/encounters/encounter_zulrah.h"
 #undef Log
+#ifdef OSRS_PUFFER_RENDER
+#include "../osrs/osrs_puffer_render.h"
+#endif
 
 #define OBS_SIZE ZUL_NUM_OBS
 #define NUM_ATNS ZUL_NUM_ACTION_HEADS
@@ -46,6 +49,9 @@ struct Env {
     ZulrahState state;
     ZulrahContext context;
     int acts_staging[ZUL_NUM_ACTION_HEADS];
+#ifdef OSRS_PUFFER_RENDER
+    void* renderer;
+#endif
 };
 
 static inline uint32_t zul_lowbias32(uint32_t x) {
@@ -169,10 +175,23 @@ void puf_step(Env* env) {
 }
 
 void puf_render(Env* env) {
+#ifdef OSRS_PUFFER_RENDER
+    if (env->renderer == NULL) {
+        env->renderer = osrs_puffer_render_create(
+            &ENCOUNTER_ZULRAH,
+            ZUL_ENV_STATE(env),
+            ZUL_ENV_CONTEXT(env));
+    }
+    osrs_puffer_render_draw(env->renderer);
+#else
     (void)env;
+#endif
 }
 
 void puf_close(Env* env) {
+#ifdef OSRS_PUFFER_RENDER
+    if (env->renderer != NULL) osrs_puffer_render_destroy(env->renderer);
+#endif
     ENCOUNTER_ZULRAH.destroy_context(ZUL_ENV_CONTEXT(env));
 }
 
@@ -182,6 +201,7 @@ void puf_log(Log* log, Dict* out) {
     dict_set(out, "wins", log->wins);
     dict_set(out, "kills", log->kills);
     dict_set(out, "score", log->score);
+    dict_set(out, "perf", log->score);
     dict_set(out, "damage_dealt", log->damage_dealt);
     dict_set(out, "damage_received", log->damage_received);
     dict_set(out, "cloud_occupancy_frac", log->cloud_occupancy_frac);

--- a/src/pufferl.cu
+++ b/src/pufferl.cu
@@ -2883,7 +2883,12 @@ static EvalResult eval_loop(Ini* ini, PuffeRL* p, int mode, int verbose,
 static PuffeRL* eval_make(Ini* ini, TrainContext* ctx, int mode, int render) {
     int match = mode == EVAL_MATCH;
     long eval_agents = puf_ini_get(ini, "base", "eval_agents");
-    if (!render && eval_agents != -1) {
+    if (render) {
+        puf_ini_put(ini, "vec.total_agents", "1");
+        puf_ini_put(ini, "vec.num_buffers", "1");
+        puf_ini_put(ini, "vec.num_threads", "1");
+        puf_ini_put(ini, "train.verb_eps", "1");
+    } else if (eval_agents != -1) {
         char buf[64];
         snprintf(buf, sizeof(buf), "%ld", eval_agents);
         puf_ini_put(ini, "vec.total_agents", buf);

--- a/tests/test_osrs_cpu_build.py
+++ b/tests/test_osrs_cpu_build.py
@@ -1,0 +1,58 @@
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def write_executable(path: Path, source: str) -> None:
+    path.write_text(source)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_osrs_cpu_build_selects_visual_entrypoint(tmp_path: Path) -> None:
+    shutil.copy(REPOSITORY_ROOT / "build.sh", tmp_path / "build.sh")
+
+    source = tmp_path / "ocean/osrs_inferno/osrs_inferno.c"
+    source.parent.mkdir(parents=True)
+    source.write_text("")
+
+    scripts = tmp_path / "ocean/osrs/scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "osrs_asset_manifest.py").write_text("")
+    write_executable(scripts / "setup-data.sh", "#!/bin/bash\n")
+    (tmp_path / "ocean/osrs/asset_manifest.json").write_text("{}")
+
+    for raylib in ("raylib-5.5_linux_amd64", "raylib-5.5_macos"):
+        (tmp_path / raylib).mkdir()
+
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    write_executable(tools / "brew", "#!/bin/bash\nprintf '%s\\n' \"$PWD/libomp\"\n")
+    compiler_arguments = tmp_path / "compiler-arguments"
+    write_executable(
+        tools / "capture-compiler",
+        "#!/bin/bash\nprintf '%s\\n' \"$@\" > \"$COMPILER_ARGUMENTS\"\n",
+    )
+
+    environment = os.environ | {
+        "CC": str(tools / "capture-compiler"),
+        "COMPILER_ARGUMENTS": str(compiler_arguments),
+        "PATH": f"{tools}:{os.environ['PATH']}",
+    }
+    result = subprocess.run(
+        ["bash", "build.sh", "osrs_inferno", "--cpu"],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    arguments = compiler_arguments.read_text().splitlines()
+    assert "ocean/osrs_inferno/osrs_inferno.c" in arguments
+    assert "src/puffercpu.c" not in arguments
+    assert arguments[arguments.index("-o") + 1] == "osrs_inferno"

--- a/tests/test_osrs_puffer_render.py
+++ b/tests/test_osrs_puffer_render.py
@@ -1,0 +1,102 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+WRAPPERS = (
+    "ocean/osrs_inferno/osrs_inferno.h",
+    "ocean/osrs_colosseum/osrs_colosseum.h",
+    "ocean/osrs_zulrah/osrs_zulrah.h",
+    "ocean/osrs_pvp/osrs_pvp.h",
+)
+
+
+@pytest.mark.parametrize("wrapper", WRAPPERS)
+def test_puf_render_owns_renderer_lifecycle(tmp_path: Path, wrapper: str) -> None:
+    compiler = shutil.which("clang") or shutil.which("cc")
+    if compiler is None:
+        pytest.skip("C compiler unavailable")
+    raylib_include = next(REPOSITORY_ROOT.glob("raylib-*/include"), None)
+    if raylib_include is None:
+        pytest.skip("raylib headers unavailable")
+
+    source = tmp_path / "render_lifecycle.c"
+    executable = tmp_path / "render_lifecycle"
+    source.write_text(
+        f"""
+#include <assert.h>
+#include <stddef.h>
+
+static int create_calls;
+static int draw_calls;
+static int destroy_calls;
+static int renderer_token;
+
+void* osrs_puffer_render_create(const void* encounter_def, void* encounter_state, void* encounter_context) {{
+    assert(encounter_def != NULL);
+    assert(encounter_state != NULL);
+    assert(encounter_context != NULL);
+    create_calls++;
+    return &renderer_token;
+}}
+
+void osrs_puffer_render_draw(void* renderer) {{
+    assert(renderer == &renderer_token);
+    draw_calls++;
+}}
+
+void osrs_puffer_render_destroy(void* renderer) {{
+    assert(renderer == &renderer_token);
+    destroy_calls++;
+}}
+
+#define OSRS_PUFFER_RENDER
+#include "{wrapper}"
+
+int main(void) {{
+    Env env = {{0}};
+
+    puf_render(&env);
+    puf_render(&env);
+
+    assert(create_calls == 1);
+    assert(draw_calls == 2);
+
+    puf_close(&env);
+    assert(destroy_calls == 1);
+    Env unrendered_env = {{0}};
+    puf_close(&unrendered_env);
+    assert(destroy_calls == 1);
+
+    Log log = {{0}};
+    Dict metrics = {{0}};
+    puf_log(&log, &metrics);
+    assert(dict_find(&metrics, "perf") != NULL);
+    dict_clear(&metrics);
+    return 0;
+}}
+"""
+    )
+
+    subprocess.run(
+        [
+            compiler,
+            "-std=c11",
+            "-I",
+            str(REPOSITORY_ROOT),
+            "-I",
+            str(REPOSITORY_ROOT / "src"),
+            "-I",
+            str(raylib_include),
+            str(source),
+            "-lm",
+            "-o",
+            str(executable),
+        ],
+        check=True,
+        cwd=REPOSITORY_ROOT,
+    )
+    subprocess.run([executable], check=True, cwd=REPOSITORY_ROOT)


### PR DESCRIPTION
Routes rendered OSRS evaluation through puffer eval instead of a parallel CPU viewer. Adds the OSRS perf metric required by eval and shares scene setup with osrs_visual.