### PR TITLE
Fix OSRS renderer lifecycle test on Linux

### DIFF
--- a/tests/test_osrs_puffer_render.py
+++ b/tests/test_osrs_puffer_render.py
@@ -84,6 +84,7 @@ int main(void) {{
     subprocess.run(
         [
             compiler,
+            "-D_POSIX_C_SOURCE=200809L",
             "-std=c11",
             "-I",
             str(REPOSITORY_ROOT),


### PR DESCRIPTION
Define POSIX feature visibility so the lifecycle fixture compiles against clock_gettime on Linux.