### PR TITLE
fix(ocean/tmaze): migrate binding.c from env_binding.h to vecenv.h API

### DIFF
--- a/ocean/tmaze/binding.c
+++ b/ocean/tmaze/binding.c
@@ -1,17 +1,21 @@
 #include "tmaze.h"
 
-#define Env TMaze
-#include "../env_binding.h"
+#define OBS_SIZE 4
+#define NUM_ATNS 1
+#define ACT_SIZES {3}
+#define OBS_TENSOR_T ByteTensor
 
-static int my_init(Env* env, PyObject* args, PyObject* kwargs) {
-    env->size = unpack(kwargs, "size");
-    return 0;
+#define Env TMaze
+#include "vecenv.h"
+
+void my_init(Env* env, Dict* kwargs) {
+    env->size = dict_get(kwargs, "size", 15);
+    allocate_TMaze(env);
 }
 
-static int my_log(PyObject* dict, Log* log) {
-    assign_to_dict(dict, "perf", log->perf);
-    assign_to_dict(dict, "score", log->score);
-    assign_to_dict(dict, "episode_return", log->episode_return);
-    assign_to_dict(dict, "episode_length", log->episode_length);
-    return 0;
+void my_log(Log* log, Dict* out) {
+    dict_set(out, "perf", log->perf);
+    dict_set(out, "score", log->score);
+    dict_set(out, "episode_return", log->episode_return);
+    dict_set(out, "episode_length", log->episode_length);
 }

--- a/ocean/tmaze/binding.c
+++ b/ocean/tmaze/binding.c
@@ -9,8 +9,8 @@
 #include "vecenv.h"
 
 void my_init(Env* env, Dict* kwargs) {
-    env->size = dict_get(kwargs, "size", 15);
-    allocate_TMaze(env);
+    env->size = (int)dict_get(kwargs, "size")->value;
+    env->num_agents = 1;
 }
 
 void my_log(Log* log, Dict* out) {

--- a/ocean/tmaze/tmaze.c
+++ b/ocean/tmaze/tmaze.c
@@ -8,12 +8,12 @@ int main() {
     c_render(&env);
     while (!WindowShouldClose()) {
         if (IsKeyDown(KEY_LEFT_SHIFT)) {
-            env.actions[0] = FORWARD;
-            if (IsKeyDown(KEY_LEFT)  || IsKeyDown(KEY_A)) env.actions[0] = LEFT;
-            if (IsKeyDown(KEY_RIGHT) || IsKeyDown(KEY_D)) env.actions[0] = RIGHT;
+            env.actions[0] = (float)FORWARD;
+            if (IsKeyDown(KEY_LEFT)  || IsKeyDown(KEY_A)) env.actions[0] = (float)LEFT;
+            if (IsKeyDown(KEY_RIGHT) || IsKeyDown(KEY_D)) env.actions[0] = (float)RIGHT;
 
         } else {
-            env.actions[0] = rand() % 3;
+            env.actions[0] = (float)(rand() % 3);
         }
         c_step(&env);
         c_render(&env);

--- a/ocean/tmaze/tmaze.h
+++ b/ocean/tmaze/tmaze.h
@@ -27,11 +27,13 @@ typedef struct {
 typedef struct {
     Log log; // Required field. Env binding code uses this to aggregate logs
     unsigned char* observations; // Required. You can use any obs type, but make sure it matches in Python!
-    int* actions; // Required. int* for discrete/multidiscrete, float* for box
+    float* actions; // Required. float* to match vecenv.h allocation
     float* rewards; // Required
-    unsigned char* terminals; // Required. We don't yet have truncations as standard yet
+    float* terminals; // Required. float* to match vecenv.h allocation
     int size; // length of the corridor
     int tick;
+    int num_agents; // Required by vecenv.h default my_vec_init
+    unsigned int rng; // Required by vecenv.h default my_vec_init
 
     unsigned char state; // Internal current position in the maze
     unsigned char starting_state; // Starting state (2 or 3)
@@ -42,9 +44,9 @@ typedef struct {
 
 TMaze* allocate_TMaze(TMaze *env) {
     env->observations = calloc(4, sizeof(unsigned char));
-    env->actions = calloc(1, sizeof(int));
+    env->actions = calloc(1, sizeof(float));
     env->rewards = calloc(1, sizeof(float));
-    env->terminals = calloc(1, sizeof(unsigned char));
+    env->terminals = calloc(1, sizeof(float));
     return env;
 }
 
@@ -99,7 +101,7 @@ void c_step(TMaze* env) {
     env->terminals[0] = 0;
     env->rewards[0] = 0;
 
-    int action = env->actions[0];
+    int action = (int)env->actions[0];
 
     if (env->state == env->size -1) {
         const int left_reward = (env->starting_state == 2) ? 1 : -1;


### PR DESCRIPTION
## What
Migrate tmaze environment from the deprecated `env_binding.h` API to the current `vecenv.h` API.

## Why
The tmaze environment uses `env_binding.h` which no longer exists in PufferLib 4.0, causing compilation errors:
```
ocean/tmaze/binding.c:4:10: fatal error: '../env_binding.h' file not found
```

## How
- Use `vecenv.h` instead of `env_binding.h`
- Use `dict_get()` for reading kwargs (size parameter)
- Use `dict_set()` for exporting log values
- Remove Python-specific `PyObject*` types

## Testing
- Verified the binding.c compiles with the new API
- Follows the same pattern as the existing `ocean/target/binding.c`

Fixes #542 (for tmaze environment)