### PR TITLE
Add Inferno pointer decoder and async defaults

### DIFF
--- a/config/osrs_inferno.ini
+++ b/config/osrs_inferno.ini
@@ -1,12 +1,12 @@
 # OSRS Inferno encounter.
 
 [base]
-async = 0
+async = 1
 
 [env]
 start_wave = 1
 damage_reward_coeff = 0.00600000052
-offensive_prayer_reward_coeff = 0
+offensive_prayer_reward_coeff = 0.0692558885
 shield_penalty_coeff = 0.000619554601
 tag_reward_coeff = 0.0866579264
 shield_tag_reward_coeff = 0.0147339059
@@ -23,7 +23,7 @@ classic_curriculum_mode = 1
 reward_profile = 2
 supply_milestone_brew_reward_coeff = 0.0
 supply_milestone_restore_reward_coeff = 0.0
-death_penalty_coeff = 0.393126726
+death_penalty_coeff = 0.26163137
 terminal_penalty_enabled = 0
 
 phase_900_bonus = 0.0
@@ -31,7 +31,7 @@ phase_600_bonus = 0.0
 phase_300_bonus = 0.0
 shield_penalty_episode_cap = 0.0
 curriculum_wave_1 = 67
-curriculum_frac_1 = 0.215649366
+curriculum_frac_1 = 0.186450824
 curriculum_wave_2 = 69
 curriculum_frac_2 = 0.0276919976
 curriculum_wave_3 = 70
@@ -39,7 +39,7 @@ curriculum_frac_3 = 0.000972120499
 curriculum_wave_4 = 71
 curriculum_frac_4 = 0
 curriculum_wave_5 = 58
-curriculum_frac_5 = 0.0466096848
+curriculum_frac_5 = 0.0685265288
 curriculum_wave_6 = 61
 curriculum_frac_6 = 0.0
 curriculum_frac_7 = 0.0
@@ -60,7 +60,7 @@ zuk_healer_phase_hp_delta_coeff = 0.0
 zuk_untagged_healer_tick_penalty_coeff = 0.0
 zuk_untagged_healer_target_bonus_coeff = 0.0
 zuk_safe_untagged_healer_target_bonus_coeff = 0.0
-zuk_untagged_healer_nonmagic_attack_bonus_coeff = 0.889728904
+zuk_untagged_healer_nonmagic_attack_bonus_coeff = 0.932179332
 zuk_healer_mage_attack_penalty_coeff = 0.036646951
 zuk_safe_untagged_healer_target_mask = 0
 zuk_force_safe_untagged_healer_target_mask = 0
@@ -79,221 +79,171 @@ hidden_size = 512
 num_layers = 2
 
 [train]
-total_timesteps = 462818912
+total_timesteps = 395922816
 horizon = 256
-learning_rate = 0.000529892568
-min_lr_ratio = 0.0251870397
-momentum = 0.994315207
-ent_coef = 1.02952106e-06
-gamma = 0.999357641
-gae_lambda = 0.490515351
+learning_rate = 0.000352853211
+min_lr_ratio = 0.0223900452
+momentum = 0.996223032
+ent_coef = 4.47068851e-06
+gamma = 0.999429405
+gae_lambda = 0.833382428
 vtrace_rho_clip = 2
 vtrace_c_clip = 0.864432693
-prio_alpha = 0.472142577
+prio_alpha = 0.469595075
 prio_beta0 = 0.227927983
-clip_coef = 0.16944842
-vf_coef = 3.44117165
-vf_clip_coef = 0.350708276
-max_grad_norm = 0.754219651
-replay_ratio = 4.68263817
+clip_coef = 0.145622194
+vf_coef = 2.38069582
+vf_clip_coef = 0.214555308
+max_grad_norm = 0.571861565
+replay_ratio = 4.0840683
 minibatch_size = 4096
 
 [sweep]
-max_suggestion_cost = 4800
+max_suggestion_cost = 7200
 max_runs = 400
 gpus = 1
-early_stop_quantile = 0.25
+early_stop_quantile = 0.15
 
 [sweep.train.total_timesteps]
-min = 25_000_000
-max = 1_000_000_000
+distribution = uniform
+min = 100000000
+max = 1000000000
+scale = time
 
 [sweep.policy.hidden_size]
+distribution = uniform_pow2
 min = 256
-max = 2048
+max = 1024
+scale = auto
+
+[sweep.policy.num_layers]
+distribution = int_uniform
+min = 1
+max = 3
+scale = auto
+
+[sweep.vec.total_agents]
+distribution = uniform_pow2
+min = 1024
+max = 4096
+scale = auto
+
+[sweep.vec.num_buffers]
+distribution = uniform_pow2
+min = 1
+max = 4
+scale = auto
 
 [sweep.train.horizon]
-min = 16
+distribution = uniform_pow2
+min = 64
 max = 512
+scale = auto
 
 [sweep.train.minibatch_size]
+distribution = uniform_pow2
+min = 2048
 max = 16384
+scale = auto
+
 [sweep.train.learning_rate]
-min = 0.0005
-max = 0.004
+distribution = log_normal
+min = 0.0002
+max = 0.0015
+scale = auto
 
 [sweep.train.ent_coef]
-min = 0.0000000001
+distribution = log_normal
+min = 0.00000001
 max = 0.002
+scale = auto
 
 [sweep.train.gamma]
-min = 0.9975
-max = 0.99997
+distribution = logit_normal
+min = 0.9989
+max = 0.99975
+scale = auto
 
 [sweep.train.gae_lambda]
-min = 0.25
+distribution = logit_normal
+min = 0.2
+max = 0.995
+scale = auto
+
+[sweep.train.replay_ratio]
+distribution = uniform
+min = 2.0
+max = 8.0
+scale = auto
+
+[sweep.train.clip_coef]
+distribution = log_normal
+min = 0.07
+max = 0.24
+scale = auto
+
+[sweep.train.vf_clip_coef]
+distribution = log_normal
+min = 0.07
+max = 0.5
+scale = auto
+
+[sweep.train.vf_coef]
+distribution = log_normal
+min = 0.5
+max = 5.0
+scale = auto
+
+[sweep.train.max_grad_norm]
+distribution = log_normal
+min = 0.5
+max = 10.0
+scale = auto
+
+[sweep.train.momentum]
+distribution = logit_normal
+min = 0.95
 max = 0.999
+scale = auto
 
 [sweep.train.min_lr_ratio]
 distribution = uniform
 min = 0.0
-max = 0.1
-scale = auto
-
-[sweep.train.vtrace_rho_clip]
-distribution = uniform
-min = 1.0
-max = 2.0
-scale = auto
-
-[sweep.train.vtrace_c_clip]
-distribution = uniform
-min = 0.3
-max = 1.0
+max = 0.06
 scale = auto
 
 [sweep.train.prio_alpha]
 distribution = logit_normal
-min = 0.0
+min = 0.1
 max = 0.6
-scale = auto
-
-[sweep.train.prio_beta0]
-distribution = logit_normal
-min = 0.05
-max = 0.4
-scale = auto
-
-[sweep.train.clip_coef]
-min = 0.001
-max = 0.24
-
-[sweep.train.vf_coef]
-distribution = log_normal
-min = 0.02
-
-[sweep.train.vf_clip_coef]
-min = 0.03
-max = 0.5
-
-[sweep.train.max_grad_norm]
-min = 0.3
-max = 8.0
-
-[sweep.train.replay_ratio]
-min = 3.0
-max = 6.0
-
-[sweep.env.curriculum_frac_1]
-distribution = uniform
-min = 0.0
-max = 0.35
-scale = auto
-
-[sweep.env.curriculum_frac_2]
-distribution = uniform
-min = 0.0
-max = 0.24
-scale = auto
-
-[sweep.env.curriculum_frac_3]
-distribution = uniform
-min = 0.0
-max = 0.05
-scale = auto
-
-[sweep.env.curriculum_frac_4]
-distribution = uniform
-min = 0.0
-max = 0.18
-scale = auto
-
-[sweep.env.curriculum_wave_5]
-distribution = int_uniform
-min = 52
-max = 59
-scale = auto
-
-[sweep.env.curriculum_frac_5]
-distribution = uniform
-min = 0.03
-max = 0.25
-scale = auto
-
-[sweep.env.curriculum_supply_jitter_mode]
-distribution = int_uniform
-min = 0
-max = 3
-scale = auto
-
-[sweep.env.curriculum_supply_shared_jitter]
-distribution = uniform
-min = 0.0
-max = 0.30
-scale = auto
-
-[sweep.env.curriculum_supply_brew_jitter]
-distribution = uniform
-min = 0.0
-max = 0.25
-scale = auto
-
-[sweep.env.curriculum_supply_restore_jitter]
-distribution = uniform
-min = 0.0
-max = 0.25
-scale = auto
-
-[sweep.env.curriculum_no_brew_mode]
-distribution = int_uniform
-min = 0
-max = 3
-scale = auto
-
-[sweep.env.curriculum_no_brew_frac]
-distribution = uniform
-min = 0.0
-max = 0.35
-scale = auto
-
-[sweep.env.damage_reward_coeff]
-distribution = log_normal
-min = 0.0015
-max = 0.00600000052
 scale = auto
 
 [sweep.env.offensive_prayer_reward_coeff]
 distribution = uniform
 min = 0.0
-max = 1.0
+max = 0.3
 scale = auto
 
-[sweep.env.shield_penalty_coeff]
+[sweep.env.curriculum_frac_1]
 distribution = uniform
-min = 0.0
-max = 0.003
+min = 0.12
+max = 0.35
 scale = auto
 
-[sweep.env.tag_reward_coeff]
-distribution = log_normal
-min = 0.05
-max = 1.25
-scale = auto
-
-[sweep.env.zuk_untagged_healer_nonmagic_attack_bonus_coeff]
+[sweep.env.curriculum_frac_5]
 distribution = uniform
-min = 0.0
-max = 1.0
-scale = auto
-
-[sweep.env.zuk_healer_mage_attack_penalty_coeff]
-distribution = uniform
-min = 0.0
-max = 0.30
+min = 0.03
+max = 0.12
 scale = auto
 
 [sweep.env.death_penalty_coeff]
 distribution = uniform
 min = 0.0
+max = 1.0
+scale = auto
+
+[sweep.env.zuk_untagged_healer_nonmagic_attack_bonus_coeff]
+distribution = uniform
+min = 0.4
 max = 1.0
 scale = auto

--- a/config/osrs_inferno.ini
+++ b/config/osrs_inferno.ini
@@ -99,6 +99,7 @@ replay_ratio = 4.0840683
 minibatch_size = 4096
 
 [sweep]
+metric_distribution = logit
 max_suggestion_cost = 7200
 max_runs = 400
 gpus = 1

--- a/ocean/osrs/osrs_entity_decoder.cu
+++ b/ocean/osrs/osrs_entity_decoder.cu
@@ -1,0 +1,396 @@
+static constexpr int OSRS_ENTITY_TARGET_BRANCH = 1;
+static constexpr int OSRS_ENTITY_TARGET_START = 25;
+static constexpr int OSRS_ENTITY_TARGET_SLOTS = 14;
+static constexpr int OSRS_ENTITY_TARGET_KEY_DIM = OSRS_ENTITY_BOTTLENECK;
+
+struct OsrsEntityDecoderWeights {
+    Prec linear_w;
+    Prec query_w;
+    Prec key_w;
+    Prec log_temperature;
+    int hidden_dim;
+    int output_dim;
+};
+
+struct OsrsEntityDecoderActivations {
+    OsrsEntityEncoderActivations* encoder;
+    Prec out;
+    Prec saved_input;
+    Prec linear_out;
+    Prec query;
+    Prec projected_keys;
+    Prec linear_grad;
+    Prec query_grad;
+    Prec projected_key_grad;
+    Prec key_grad;
+    Prec linear_hidden_grad;
+    Prec query_hidden_grad;
+    Prec grad_input;
+    Float temperature_grad_contrib;
+    Prec linear_wgrad;
+    Prec query_wgrad;
+    Prec key_wgrad;
+    Prec temperature_grad;
+};
+
+__global__ void osrs_entity_decoder_init_temperature(precision_t* value) {
+    value[0] = from_float(logf(10.0f));
+}
+
+__global__ void osrs_entity_decoder_assemble(
+    precision_t* __restrict__ out,
+    const precision_t* __restrict__ linear,
+    const precision_t* __restrict__ query,
+    const precision_t* __restrict__ keys,
+    const precision_t* __restrict__ log_temperature,
+    int B,
+    int output_dim
+) {
+    int output_stride = output_dim + 1;
+    int linear_dim = output_stride - OSRS_ENTITY_TARGET_SLOTS;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= B * output_stride) return;
+    int b = idx / output_stride;
+    int column = idx - b * output_stride;
+    if (column < OSRS_ENTITY_TARGET_START) {
+        out[idx] = linear[(int64_t)b * linear_dim + column];
+        return;
+    }
+    if (column >= OSRS_ENTITY_TARGET_START + OSRS_ENTITY_TARGET_SLOTS) {
+        out[idx] = linear[
+            (int64_t)b * linear_dim + column - OSRS_ENTITY_TARGET_SLOTS];
+        return;
+    }
+
+    int slot = column - OSRS_ENTITY_TARGET_START;
+    const precision_t* q = query + (int64_t)b * OSRS_ENTITY_TARGET_KEY_DIM;
+    const precision_t* key = keys +
+        ((int64_t)b * OSRS_ENTITY_TARGET_SLOTS + slot) *
+        OSRS_ENTITY_TARGET_KEY_DIM;
+    float dot = 0.0f;
+    float query_norm_squared = 0.0f;
+    float key_norm_squared = 0.0f;
+    for (int k = 0; k < OSRS_ENTITY_TARGET_KEY_DIM; k++) {
+        float q_value = to_float(q[k]);
+        float key_value = to_float(key[k]);
+        dot += q_value * key_value;
+        query_norm_squared += q_value * q_value;
+        key_norm_squared += key_value * key_value;
+    }
+    float denominator = sqrtf(fmaxf(
+        query_norm_squared * key_norm_squared, 1.0e-12f));
+    out[idx] = from_float(
+        expf(to_float(log_temperature[0])) * dot / denominator);
+}
+
+__global__ void osrs_entity_decoder_gather_linear_grad(
+    precision_t* __restrict__ linear_grad,
+    const float* __restrict__ grad_logits,
+    const float* __restrict__ grad_value,
+    int B,
+    int output_dim
+) {
+    int linear_dim = output_dim + 1 - OSRS_ENTITY_TARGET_SLOTS;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= B * linear_dim) return;
+    int b = idx / linear_dim;
+    int linear_column = idx - b * linear_dim;
+    int output_column = linear_column < OSRS_ENTITY_TARGET_START
+        ? linear_column : linear_column + OSRS_ENTITY_TARGET_SLOTS;
+    float value = output_column == output_dim
+        ? grad_value[b]
+        : grad_logits[(int64_t)b * output_dim + output_column];
+    linear_grad[idx] = from_float(value);
+}
+
+__global__ void osrs_entity_decoder_pointer_grad(
+    precision_t* __restrict__ query_grad,
+    precision_t* __restrict__ projected_key_grad,
+    float* __restrict__ temperature_grad_contrib,
+    const float* __restrict__ grad_logits,
+    const precision_t* __restrict__ query,
+    const precision_t* __restrict__ keys,
+    const precision_t* __restrict__ log_temperature,
+    int B,
+    int output_dim
+) {
+    int b = blockIdx.x;
+    int k = threadIdx.x;
+    if (b >= B || k >= OSRS_ENTITY_TARGET_KEY_DIM) return;
+    const precision_t* q = query + (int64_t)b * OSRS_ENTITY_TARGET_KEY_DIM;
+    float query_value = to_float(q[k]);
+    float query_norm_squared = 0.0f;
+    for (int d = 0; d < OSRS_ENTITY_TARGET_KEY_DIM; d++) {
+        float value = to_float(q[d]);
+        query_norm_squared += value * value;
+    }
+    float scale = expf(to_float(log_temperature[0]));
+    float accumulated_query_grad = 0.0f;
+    for (int slot = 0; slot < OSRS_ENTITY_TARGET_SLOTS; slot++) {
+        int record = b * OSRS_ENTITY_TARGET_SLOTS + slot;
+        const precision_t* key = keys +
+            (int64_t)record * OSRS_ENTITY_TARGET_KEY_DIM;
+        float dot = 0.0f;
+        float key_norm_squared = 0.0f;
+        for (int d = 0; d < OSRS_ENTITY_TARGET_KEY_DIM; d++) {
+            float q_value = to_float(q[d]);
+            float key_value = to_float(key[d]);
+            dot += q_value * key_value;
+            key_norm_squared += key_value * key_value;
+        }
+        float norm_product = query_norm_squared * key_norm_squared;
+        float denominator = sqrtf(fmaxf(norm_product, 1.0e-12f));
+        float cosine = dot / denominator;
+        float score = scale * cosine;
+        float gradient = grad_logits[
+            (int64_t)b * output_dim + OSRS_ENTITY_TARGET_START + slot];
+        float scaled_gradient = gradient * scale;
+        float key_value = to_float(key[k]);
+        float query_component = key_value / denominator;
+        float key_component = query_value / denominator;
+        if (norm_product > 1.0e-12f) {
+            query_component -=
+                cosine * query_value / query_norm_squared;
+            key_component -= cosine * key_value / key_norm_squared;
+        }
+        accumulated_query_grad += scaled_gradient * query_component;
+        projected_key_grad[
+            (int64_t)record * OSRS_ENTITY_TARGET_KEY_DIM + k] =
+            from_float(scaled_gradient * key_component);
+        if (k == 0) {
+            temperature_grad_contrib[record] = gradient * score;
+        }
+    }
+    query_grad[(int64_t)b * OSRS_ENTITY_TARGET_KEY_DIM + k] =
+        from_float(accumulated_query_grad);
+}
+
+__global__ void osrs_entity_decoder_add_hidden_grad(
+    precision_t* __restrict__ out,
+    const precision_t* __restrict__ linear_grad,
+    const precision_t* __restrict__ query_grad,
+    int count
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= count) return;
+    out[idx] = from_float(
+        to_float(linear_grad[idx]) + to_float(query_grad[idx]));
+}
+
+static Prec osrs_entity_decoder_forward(
+    void* weights,
+    void* activations,
+    Prec input,
+    cudaStream_t stream
+) {
+    OsrsEntityDecoderWeights* dw = (OsrsEntityDecoderWeights*)weights;
+    OsrsEntityDecoderActivations* a =
+        (OsrsEntityDecoderActivations*)activations;
+    int B = input.shape[0];
+    if (a->saved_input.data != nullptr) {
+        puf_copy(&a->saved_input, &input, stream);
+    }
+    OsrsEntityBranchActivations* branches =
+        osrs_entity_branch_activations(a->encoder);
+    Prec keys = branches[OSRS_ENTITY_TARGET_BRANCH].h1;
+    puf_mm(&input, &dw->linear_w, &a->linear_out, stream);
+    puf_mm(&input, &dw->query_w, &a->query, stream);
+    puf_mm(&keys, &dw->key_w, &a->projected_keys, stream);
+    int count = B * (dw->output_dim + 1);
+    osrs_entity_decoder_assemble<<<grid_size(count), BLOCK_SIZE, 0, stream>>>(
+        a->out.data, a->linear_out.data, a->query.data,
+        a->projected_keys.data, dw->log_temperature.data,
+        B, dw->output_dim);
+    return a->out;
+}
+
+static void osrs_entity_decoder_init_weights(
+    void* weights,
+    ulong* seed,
+    cudaStream_t stream
+) {
+    OsrsEntityDecoderWeights* dw = (OsrsEntityDecoderWeights*)weights;
+    puf_kaiming_init(&dw->linear_w, 1.0f, (*seed)++, stream);
+    puf_kaiming_init(&dw->query_w, 1.0f, (*seed)++, stream);
+    puf_kaiming_init(&dw->key_w, 1.0f, (*seed)++, stream);
+    osrs_entity_decoder_init_temperature<<<1, 1, 0, stream>>>(
+        dw->log_temperature.data);
+}
+
+static void osrs_entity_decoder_reg_params(void* weights, Allocator* allocator) {
+    OsrsEntityDecoderWeights* dw = (OsrsEntityDecoderWeights*)weights;
+    int linear_dim = dw->output_dim + 1 - OSRS_ENTITY_TARGET_SLOTS;
+    dw->linear_w = {.shape = {linear_dim, dw->hidden_dim}};
+    dw->query_w = {.shape = {OSRS_ENTITY_TARGET_KEY_DIM, dw->hidden_dim}};
+    dw->key_w = {
+        .shape = {OSRS_ENTITY_TARGET_KEY_DIM, OSRS_ENTITY_TARGET_KEY_DIM},
+    };
+    dw->log_temperature = {.shape = {1}};
+    alloc_register(allocator, &dw->linear_w);
+    alloc_register(allocator, &dw->query_w);
+    alloc_register(allocator, &dw->key_w);
+    alloc_register(allocator, &dw->log_temperature);
+}
+
+static void osrs_entity_decoder_reg_train(
+    void* weights,
+    void* activations,
+    Allocator* acts,
+    Allocator* grads,
+    int B
+) {
+    OsrsEntityDecoderWeights* dw = (OsrsEntityDecoderWeights*)weights;
+    OsrsEntityDecoderActivations* a =
+        (OsrsEntityDecoderActivations*)activations;
+    int linear_dim = dw->output_dim + 1 - OSRS_ENTITY_TARGET_SLOTS;
+    *a = {};
+    a->encoder = osrs_entity_encoder_last;
+    assert(a->encoder != nullptr);
+    a->out = {.shape = {B, dw->output_dim + 1}};
+    a->saved_input = {.shape = {B, dw->hidden_dim}};
+    a->linear_out = {.shape = {B, linear_dim}};
+    a->query = {.shape = {B, OSRS_ENTITY_TARGET_KEY_DIM}};
+    a->projected_keys = {
+        .shape = {
+            B * OSRS_ENTITY_TARGET_SLOTS,
+            OSRS_ENTITY_TARGET_KEY_DIM,
+        },
+    };
+    a->linear_grad = a->linear_out;
+    a->query_grad = a->query;
+    a->projected_key_grad = a->projected_keys;
+    a->key_grad = a->projected_keys;
+    a->linear_hidden_grad = {.shape = {B, dw->hidden_dim}};
+    a->query_hidden_grad = a->linear_hidden_grad;
+    a->grad_input = a->linear_hidden_grad;
+    a->temperature_grad_contrib = {
+        .shape = {B * OSRS_ENTITY_TARGET_SLOTS, 1},
+    };
+    alloc_register(acts, &a->out);
+    alloc_register(acts, &a->saved_input);
+    alloc_register(acts, &a->linear_out);
+    alloc_register(acts, &a->query);
+    alloc_register(acts, &a->projected_keys);
+    alloc_register(acts, &a->linear_grad);
+    alloc_register(acts, &a->query_grad);
+    alloc_register(acts, &a->projected_key_grad);
+    alloc_register(acts, &a->key_grad);
+    alloc_register(acts, &a->linear_hidden_grad);
+    alloc_register(acts, &a->query_hidden_grad);
+    alloc_register(acts, &a->grad_input);
+    alloc_register(acts, &a->temperature_grad_contrib);
+    a->linear_wgrad = {.shape = {linear_dim, dw->hidden_dim}};
+    a->query_wgrad = {
+        .shape = {OSRS_ENTITY_TARGET_KEY_DIM, dw->hidden_dim},
+    };
+    a->key_wgrad = {
+        .shape = {OSRS_ENTITY_TARGET_KEY_DIM, OSRS_ENTITY_TARGET_KEY_DIM},
+    };
+    a->temperature_grad = {.shape = {1}};
+    alloc_register(grads, &a->linear_wgrad);
+    alloc_register(grads, &a->query_wgrad);
+    alloc_register(grads, &a->key_wgrad);
+    alloc_register(grads, &a->temperature_grad);
+    osrs_entity_decoder_keygrad = &a->key_grad;
+}
+
+static void osrs_entity_decoder_reg_rollout(
+    void* weights,
+    void* activations,
+    Allocator* allocator,
+    int B
+) {
+    OsrsEntityDecoderWeights* dw = (OsrsEntityDecoderWeights*)weights;
+    OsrsEntityDecoderActivations* a =
+        (OsrsEntityDecoderActivations*)activations;
+    int linear_dim = dw->output_dim + 1 - OSRS_ENTITY_TARGET_SLOTS;
+    *a = {};
+    a->encoder = osrs_entity_encoder_last;
+    assert(a->encoder != nullptr);
+    a->out = {.shape = {B, dw->output_dim + 1}};
+    a->linear_out = {.shape = {B, linear_dim}};
+    a->query = {.shape = {B, OSRS_ENTITY_TARGET_KEY_DIM}};
+    a->projected_keys = {
+        .shape = {
+            B * OSRS_ENTITY_TARGET_SLOTS,
+            OSRS_ENTITY_TARGET_KEY_DIM,
+        },
+    };
+    alloc_register(allocator, &a->out);
+    alloc_register(allocator, &a->linear_out);
+    alloc_register(allocator, &a->query);
+    alloc_register(allocator, &a->projected_keys);
+}
+
+static void* osrs_entity_decoder_create_weights(void* self) {
+    Decoder* decoder = (Decoder*)self;
+    OsrsEntityDecoderWeights* weights =
+        (OsrsEntityDecoderWeights*)calloc(1, sizeof(OsrsEntityDecoderWeights));
+    weights->hidden_dim = decoder->hidden_dim;
+    weights->output_dim = decoder->output_dim;
+    return weights;
+}
+
+static Prec osrs_entity_decoder_backward(
+    void* weights,
+    void* activations,
+    Float grad_logits,
+    Float grad_logstd,
+    Float grad_value,
+    cudaStream_t stream
+) {
+    (void)grad_logstd;
+    OsrsEntityDecoderWeights* dw = (OsrsEntityDecoderWeights*)weights;
+    OsrsEntityDecoderActivations* a =
+        (OsrsEntityDecoderActivations*)activations;
+    int B = a->saved_input.shape[0];
+    int linear_dim = dw->output_dim + 1 - OSRS_ENTITY_TARGET_SLOTS;
+    int linear_count = B * linear_dim;
+    osrs_entity_decoder_gather_linear_grad<<<
+        grid_size(linear_count), BLOCK_SIZE, 0, stream>>>(
+        a->linear_grad.data, grad_logits.data, grad_value.data,
+        B, dw->output_dim);
+    osrs_entity_decoder_pointer_grad<<<B, OSRS_ENTITY_TARGET_KEY_DIM, 0, stream>>>(
+        a->query_grad.data, a->projected_key_grad.data,
+        a->temperature_grad_contrib.data, grad_logits.data,
+        a->query.data, a->projected_keys.data,
+        dw->log_temperature.data, B, dw->output_dim);
+
+    OsrsEntityBranchActivations* branches =
+        osrs_entity_branch_activations(a->encoder);
+    Prec keys = branches[OSRS_ENTITY_TARGET_BRANCH].h1;
+    puf_mm_tn(&a->linear_grad, &a->saved_input, &a->linear_wgrad, stream);
+    puf_mm_tn(&a->query_grad, &a->saved_input, &a->query_wgrad, stream);
+    puf_mm_tn(&a->projected_key_grad, &keys, &a->key_wgrad, stream);
+    sum_rows_to_precision_kernel<<<1, BLOCK_SIZE, 0, stream>>>(
+        a->temperature_grad.data, a->temperature_grad_contrib.data,
+        B * OSRS_ENTITY_TARGET_SLOTS, 1);
+    puf_mm_nn(
+        &a->linear_grad, &dw->linear_w, &a->linear_hidden_grad, stream);
+    puf_mm_nn(&a->query_grad, &dw->query_w, &a->query_hidden_grad, stream);
+    puf_mm_nn(&a->projected_key_grad, &dw->key_w, &a->key_grad, stream);
+    int hidden_count = B * dw->hidden_dim;
+    osrs_entity_decoder_add_hidden_grad<<<
+        grid_size(hidden_count), BLOCK_SIZE, 0, stream>>>(
+        a->grad_input.data, a->linear_hidden_grad.data,
+        a->query_hidden_grad.data, hidden_count);
+    return a->grad_input;
+}
+
+static void create_osrs_entity_decoder(Decoder* decoder) {
+    assert(!decoder->continuous);
+    assert(decoder->output_dim == 436);
+    *decoder = Decoder{
+        .forward = osrs_entity_decoder_forward,
+        .backward = osrs_entity_decoder_backward,
+        .init_weights = osrs_entity_decoder_init_weights,
+        .reg_params = osrs_entity_decoder_reg_params,
+        .reg_train = osrs_entity_decoder_reg_train,
+        .reg_rollout = osrs_entity_decoder_reg_rollout,
+        .create_weights = osrs_entity_decoder_create_weights,
+        .hidden_dim = decoder->hidden_dim,
+        .output_dim = decoder->output_dim,
+        .continuous = decoder->continuous,
+        .activation_size = sizeof(OsrsEntityDecoderActivations),
+    };
+}

--- a/ocean/osrs/osrs_entity_encoder.cu
+++ b/ocean/osrs/osrs_entity_encoder.cu
@@ -30,6 +30,7 @@ struct OsrsEntityBranchDescriptor {
 struct OsrsEntityEncoderDescriptor {
     const OsrsEntityBranchDescriptor* branches;
     int num_branches;
+    int pointer_branch;
 };
 
 struct OsrsEntityBranchWeights {
@@ -68,6 +69,9 @@ struct OsrsEntityEncoderActivations {
     Prec inv_l1_wgrad;
     Prec inv_l2_wgrad;
 };
+
+static OsrsEntityEncoderActivations* osrs_entity_encoder_last = nullptr;
+static Prec* osrs_entity_decoder_keygrad = nullptr;
 
 static OsrsEntityBranchWeights* osrs_entity_branch_weights(
     OsrsEntityEncoderWeights* weights
@@ -262,6 +266,7 @@ __global__ void osrs_entity_fused_grad_z1(
     const precision_t* __restrict__ grad,
     const precision_t* __restrict__ l2_w,
     const precision_t* __restrict__ z1,
+    const precision_t* __restrict__ additional_grad_h1,
     const int* __restrict__ argmax,
     int B,
     int H,
@@ -307,8 +312,11 @@ __global__ void osrs_entity_fused_grad_z1(
             idx += blockDim.x) {
         int64_t out_idx =
             (int64_t)b * num_records * OSRS_ENTITY_BOTTLENECK + idx;
+        float additional = additional_grad_h1 == nullptr
+            ? 0.0f : to_float(additional_grad_h1[out_idx]);
         grad_z1[out_idx] = from_float(
-            accum[idx] * osrs_entity_gelu_grad(to_float(z1[out_idx])));
+            (accum[idx] + additional) *
+            osrs_entity_gelu_grad(to_float(z1[out_idx])));
     }
 }
 
@@ -346,6 +354,7 @@ static void osrs_entity_launch_fused_bwd(
     const precision_t* l2_w,
     const precision_t* z1,
     const precision_t* h1,
+    const precision_t* additional_grad_h1,
     const int* argmax,
     int B,
     int H,
@@ -358,7 +367,8 @@ static void osrs_entity_launch_fused_bwd(
         ((size_t)num_records * OSRS_ENTITY_BOTTLENECK + 2 * BLOCK_SIZE) *
         sizeof(float);
     osrs_entity_fused_grad_z1<<<B, BLOCK_SIZE, shared_bytes, stream>>>(
-        grad_z1, grad, l2_w, z1, argmax, B, H, num_records);
+        grad_z1, grad, l2_w, z1, additional_grad_h1,
+        argmax, B, H, num_records);
 }
 
 static int osrs_entity_branch_features(const OsrsEntityBranchDescriptor* branch) {
@@ -446,7 +456,7 @@ static void osrs_entity_encoder_backward(
     int inventory_batch = B * OSRS_ENTITY_INV_NUM_RECORDS;
     osrs_entity_launch_fused_bwd(
         a->inv_l2_wgrad.data, a->inv_grad_z1.data, grad.data,
-        ew->inv_l2_w.data, a->inv_z1.data, a->inv_h1.data,
+        ew->inv_l2_w.data, a->inv_z1.data, a->inv_h1.data, nullptr,
         a->inv_pool_argmax.data, B, H, OSRS_ENTITY_INV_NUM_RECORDS, stream);
     Prec inventory_2d = {
         .data = a->inv_flat.data,
@@ -465,10 +475,14 @@ static void osrs_entity_encoder_backward(
             &osrs_entity_branch_activations(a)[branch_idx];
         int features = osrs_entity_branch_features(descriptor);
         int branch_batch = B * descriptor->num_records;
+        const precision_t* additional_grad_h1 =
+            branch_idx == ew->descriptor->pointer_branch &&
+            osrs_entity_decoder_keygrad != nullptr
+                ? osrs_entity_decoder_keygrad->data : nullptr;
         osrs_entity_launch_fused_bwd(
             ba->l2_wgrad.data, ba->grad_z1.data, grad.data,
-            bw->l2_w.data, ba->z1.data, ba->h1.data, ba->pool_argmax.data,
-            B, H, descriptor->num_records, stream);
+            bw->l2_w.data, ba->z1.data, ba->h1.data, additional_grad_h1,
+            ba->pool_argmax.data, B, H, descriptor->num_records, stream);
         Prec branch_2d = {
             .data = ba->flat.data,
             .shape = {branch_batch, features},
@@ -600,6 +614,8 @@ static void osrs_entity_encoder_reg_train(
             &osrs_entity_branch_activations(a)[branch_idx],
             acts, grads, B, H);
     }
+    osrs_entity_encoder_last = a;
+    osrs_entity_decoder_keygrad = nullptr;
 }
 
 static void osrs_entity_register_branch_rollout(
@@ -640,11 +656,22 @@ static void osrs_entity_encoder_reg_rollout(
     for (int branch_idx = 0;
             branch_idx < ew->descriptor->num_branches;
             branch_idx++) {
+        OsrsEntityBranchActivations* branch =
+            &osrs_entity_branch_activations(a)[branch_idx];
         osrs_entity_register_branch_rollout(
             &ew->descriptor->branches[branch_idx],
-            &osrs_entity_branch_activations(a)[branch_idx],
-            allocator, B);
+            branch, allocator, B);
+        if (branch_idx == ew->descriptor->pointer_branch) {
+            branch->h1 = {
+                .shape = {
+                    B * ew->descriptor->branches[branch_idx].num_records,
+                    OSRS_ENTITY_BOTTLENECK,
+                },
+            };
+            alloc_register(allocator, &branch->h1);
+        }
     }
+    osrs_entity_encoder_last = a;
 }
 
 template <const OsrsEntityEncoderDescriptor* descriptor>
@@ -692,6 +719,7 @@ static constexpr OsrsEntityBranchDescriptor OSRS_EQUIPMENT_ENTITY_BRANCH[] = {
 static constexpr OsrsEntityEncoderDescriptor OSRS_EQUIPMENT_ENTITY_DESCRIPTOR = {
     .branches = OSRS_EQUIPMENT_ENTITY_BRANCH,
     .num_branches = 1,
+    .pointer_branch = -1,
 };
 #ifdef ZUL_NUM_OBS
 static_assert(ZUL_NUM_OBS == 205);

--- a/ocean/osrs_colosseum/osrs_colosseum.cu
+++ b/ocean/osrs_colosseum/osrs_colosseum.cu
@@ -23,4 +23,5 @@ static_assert(101 + 24 * 23 <= 904);
 static constexpr OsrsEntityEncoderDescriptor OSRS_COLOSSEUM_ENTITY_DESCRIPTOR = {
     .branches = OSRS_COLOSSEUM_ENTITY_BRANCHES,
     .num_branches = 2,
+    .pointer_branch = -1,
 };

--- a/ocean/osrs_inferno/osrs_inferno.cu
+++ b/ocean/osrs_inferno/osrs_inferno.cu
@@ -23,4 +23,5 @@ static_assert(124 + 14 * 13 <= 530);
 static constexpr OsrsEntityEncoderDescriptor OSRS_INFERNO_ENTITY_DESCRIPTOR = {
     .branches = OSRS_INFERNO_ENTITY_BRANCHES,
     .num_branches = 2,
+    .pointer_branch = 1,
 };

--- a/src/ocean.cu
+++ b/src/ocean.cu
@@ -39,6 +39,7 @@ __device__ static const float OSRS_ITEM_OBS_TABLE_DEV
 #include "../ocean/osrs/osrs_item_obs_table.inc"
 };
 #include "../ocean/osrs/osrs_entity_encoder.cu"
+#include "../ocean/osrs/osrs_entity_decoder.cu"
 #endif
 #ifdef PUFFER_OSRS_COLOSSEUM
 #include "../ocean/osrs_colosseum/osrs_colosseum.cu"
@@ -114,6 +115,12 @@ static void create_custom_decoder(const char* env_name, Decoder* dec) {
 #ifdef PUFFER_NETHACK
     if (strcmp(env_name, "nethack") == 0) {
         create_nethack_decoder(dec);
+        return;
+    }
+#endif
+#ifdef PUFFER_OSRS_INFERNO
+    if (strcmp(env_name, "osrs_inferno") == 0) {
+        create_osrs_entity_decoder(dec);
         return;
     }
 #endif

--- a/tests/test_osrs_entity_decoder.py
+++ b/tests/test_osrs_entity_decoder.py
@@ -1,0 +1,234 @@
+import ctypes
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CUDA_SOURCE = Path(__file__).with_name("test_osrs_entity_decoder_cuda.cu")
+BATCH = 7
+HIDDEN = 40
+OUTPUT_DIM = 436
+TARGET_START = 25
+TARGET_SLOTS = 14
+KEY_DIM = 16
+LINEAR_DIM = OUTPUT_DIM + 1 - TARGET_SLOTS
+
+
+def _pointer(tensor):
+    return ctypes.c_void_p(tensor.data_ptr())
+
+
+def _configure_library(path: Path):
+    library = ctypes.CDLL(path)
+    pointer = ctypes.c_void_p
+    library.osrs_entity_decoder_test_init.argtypes = [ctypes.c_int, ctypes.c_int]
+    library.osrs_entity_decoder_test_set_weights.argtypes = [
+        pointer,
+        pointer,
+        pointer,
+        pointer,
+    ]
+    library.osrs_entity_decoder_test_forward.argtypes = [pointer, pointer, pointer]
+    library.osrs_entity_decoder_test_backward.argtypes = [pointer, pointer, pointer]
+    library.osrs_entity_decoder_test_get_grad.argtypes = [ctypes.c_int, pointer]
+    return library
+
+
+@pytest.fixture(scope="session")
+def cuda_library(tmp_path_factory):
+    nvcc = shutil.which("nvcc")
+    if nvcc is None:
+        pytest.skip("nvcc is not installed")
+    raylib_include = next(ROOT.glob("raylib-*/include"))
+    raylib_archive = raylib_include.parent / "lib/libraylib.a"
+    pytest.importorskip("torch")
+    library_path = (
+        tmp_path_factory.mktemp("osrs_entity_decoder") /
+        "osrs_entity_decoder.so"
+    )
+    subprocess.run(
+        [
+            nvcc,
+            "-shared",
+            "-o",
+            str(library_path),
+            str(CUDA_SOURCE),
+            "-I",
+            str(ROOT / "src"),
+            "-I",
+            str(raylib_include),
+            "-Xlinker",
+            "--no-as-needed",
+            "-lcublas",
+            "-lcudnn",
+            "-lcurand",
+            "-lnccl",
+            "-lnvidia-ml",
+            "-lcusolver",
+            str(raylib_archive),
+            "-lGL",
+            "-lm",
+            "-lpthread",
+            "-ldl",
+            "-lrt",
+            "--compiler-options",
+            "-fPIC",
+            "-Xcompiler",
+            "-O2",
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+    return _configure_library(library_path)
+
+
+def _reference_output(torch, hidden, keys, weights):
+    linear_w, query_w, key_w, log_temperature = weights
+    linear = torch.nn.functional.linear(hidden, linear_w)
+    query = torch.nn.functional.linear(hidden, query_w)
+    projected_keys = torch.nn.functional.linear(keys, key_w)
+    dot = (query[:, None, :] * projected_keys).sum(dim=-1)
+    denominator = torch.sqrt(
+        torch.clamp(
+            query.square().sum(dim=-1)[:, None]
+            * projected_keys.square().sum(dim=-1),
+            min=1.0e-12,
+        )
+    )
+    target_logits = torch.exp(log_temperature[0]) * dot / denominator
+    return torch.cat(
+        [
+            linear[:, :TARGET_START],
+            target_logits,
+            linear[:, TARGET_START:],
+        ],
+        dim=-1,
+    )
+
+
+def test_forward_backward_and_slot_permutation(cuda_library):
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    generator = torch.Generator(device="cuda").manual_seed(4187)
+    hidden = torch.randn(
+        (BATCH, HIDDEN), generator=generator, device="cuda", requires_grad=True
+    )
+    keys = torch.randn(
+        (BATCH, TARGET_SLOTS, KEY_DIM),
+        generator=generator,
+        device="cuda",
+        requires_grad=True,
+    )
+    with torch.no_grad():
+        keys[:, -1].zero_()
+    weights = [
+        torch.randn(
+            (LINEAR_DIM, HIDDEN),
+            generator=generator,
+            device="cuda",
+            requires_grad=True,
+        ),
+        torch.randn(
+            (KEY_DIM, HIDDEN),
+            generator=generator,
+            device="cuda",
+            requires_grad=True,
+        ),
+        torch.randn(
+            (KEY_DIM, KEY_DIM),
+            generator=generator,
+            device="cuda",
+            requires_grad=True,
+        ),
+        torch.tensor([1.7], device="cuda", requires_grad=True),
+    ]
+    cuda_library.osrs_entity_decoder_test_init(BATCH, HIDDEN)
+    cuda_library.osrs_entity_decoder_test_set_weights(
+        *[_pointer(weight) for weight in weights]
+    )
+
+    expected = _reference_output(torch, hidden, keys, weights)
+    actual = torch.empty_like(expected)
+    cuda_library.osrs_entity_decoder_test_forward(
+        _pointer(hidden), _pointer(keys), _pointer(actual)
+    )
+    torch.testing.assert_close(actual, expected, atol=3e-4, rtol=3e-4)
+    assert torch.isfinite(actual).all()
+    assert torch.count_nonzero(
+        actual[:, TARGET_START + TARGET_SLOTS - 1]
+    ).item() == 0
+
+    output_gradient = torch.randn(
+        expected.shape, generator=generator, device="cuda"
+    )
+    output_gradient[:, TARGET_START + TARGET_SLOTS - 1] = 0.0
+    expected.backward(output_gradient)
+    actual_hidden_grad = torch.empty_like(hidden)
+    cuda_library.osrs_entity_decoder_test_backward(
+        _pointer(output_gradient[:, :OUTPUT_DIM].contiguous()),
+        _pointer(output_gradient[:, OUTPUT_DIM].contiguous()),
+        _pointer(actual_hidden_grad),
+    )
+    torch.testing.assert_close(
+        actual_hidden_grad, hidden.grad, atol=5e-3, rtol=5e-3
+    )
+
+    expected_gradients = [weight.grad for weight in weights] + [keys.grad]
+    for index, expected_gradient in enumerate(expected_gradients):
+        actual_gradient = torch.empty_like(expected_gradient)
+        cuda_library.osrs_entity_decoder_test_get_grad(
+            index, _pointer(actual_gradient)
+        )
+        torch.testing.assert_close(
+            actual_gradient, expected_gradient, atol=5e-3, rtol=5e-3
+        )
+
+    permutation = torch.randperm(
+        TARGET_SLOTS, generator=generator, device="cuda"
+    )
+    permuted_keys = keys.detach()[:, permutation].contiguous()
+    permuted_output = torch.empty_like(actual)
+    cuda_library.osrs_entity_decoder_test_forward(
+        _pointer(hidden), _pointer(permuted_keys), _pointer(permuted_output)
+    )
+    torch.testing.assert_close(
+        permuted_output[:, :TARGET_START],
+        actual[:, :TARGET_START],
+        atol=3e-4,
+        rtol=3e-4,
+    )
+    torch.testing.assert_close(
+        permuted_output[:, TARGET_START:TARGET_START + TARGET_SLOTS],
+        actual[:, TARGET_START:TARGET_START + TARGET_SLOTS][:, permutation],
+        atol=3e-4,
+        rtol=3e-4,
+    )
+    torch.testing.assert_close(
+        permuted_output[:, TARGET_START + TARGET_SLOTS:],
+        actual[:, TARGET_START + TARGET_SLOTS:],
+        atol=3e-4,
+        rtol=3e-4,
+    )
+    target_mask = torch.rand(
+        (BATCH, TARGET_SLOTS), generator=generator, device="cuda"
+    ) > 0.4
+    target_mask[:, 0] = True
+    target_mask[:, -1] = False
+    target_logits = actual[:, TARGET_START:TARGET_START + TARGET_SLOTS]
+    selected_slots = target_logits.masked_fill(~target_mask, -torch.inf).argmax(
+        dim=-1
+    )
+    permuted_target_mask = target_mask[:, permutation]
+    permuted_target_logits = permuted_output[
+        :, TARGET_START:TARGET_START + TARGET_SLOTS
+    ]
+    selected_permuted_slots = permuted_target_logits.masked_fill(
+        ~permuted_target_mask, -torch.inf
+    ).argmax(dim=-1)
+    torch.testing.assert_close(
+        permutation[selected_permuted_slots], selected_slots
+    )

--- a/tests/test_osrs_entity_decoder_cuda.cu
+++ b/tests/test_osrs_entity_decoder_cuda.cu
@@ -1,0 +1,159 @@
+#define PRECISION_FLOAT
+#define ENV_HEADER "../ocean/minimal/minimal.h"
+#define PUFFER_ENV_NAME "minimal"
+#define NUM_GEAR_SLOTS 11
+#define PUFFER_OSRS_INFERNO
+#include "../src/pufferl.cu"
+
+extern "C" {
+
+static Decoder test_decoder;
+static OsrsEntityDecoderWeights* test_weights;
+static OsrsEntityDecoderActivations* test_activations;
+static OsrsEntityEncoderActivations* test_encoder_activations;
+static Allocator test_params;
+static Allocator test_acts;
+static Allocator test_grads;
+static bool test_cublas_initialized;
+
+static void test_free_allocator(Allocator* allocator) {
+    if (allocator->mem) cudaFree(allocator->mem);
+    free(allocator->regs);
+    *allocator = {};
+}
+
+static void test_reset() {
+    test_free_allocator(&test_params);
+    test_free_allocator(&test_acts);
+    test_free_allocator(&test_grads);
+    free(test_weights);
+    free(test_activations);
+    free(test_encoder_activations);
+    test_weights = nullptr;
+    test_activations = nullptr;
+    test_encoder_activations = nullptr;
+}
+
+void osrs_entity_decoder_test_init(int batch, int hidden) {
+    test_reset();
+    if (!test_cublas_initialized) {
+        cublas_init_handle();
+        test_cublas_initialized = true;
+    }
+    test_decoder = {};
+    test_decoder.hidden_dim = hidden;
+    test_decoder.output_dim = 436;
+    create_osrs_entity_decoder(&test_decoder);
+    test_weights = (OsrsEntityDecoderWeights*)
+        test_decoder.create_weights(&test_decoder);
+    test_decoder.reg_params(test_weights, &test_params);
+    alloc_create(&test_params);
+
+    size_t encoder_activation_size = sizeof(OsrsEntityEncoderActivations) +
+        2 * sizeof(OsrsEntityBranchActivations);
+    test_encoder_activations = (OsrsEntityEncoderActivations*)calloc(
+        1, encoder_activation_size);
+    OsrsEntityBranchActivations* branches =
+        osrs_entity_branch_activations(test_encoder_activations);
+    branches[OSRS_ENTITY_TARGET_BRANCH].h1 = {
+        .shape = {
+            batch * OSRS_ENTITY_TARGET_SLOTS,
+            OSRS_ENTITY_TARGET_KEY_DIM,
+        },
+    };
+    osrs_entity_encoder_last = test_encoder_activations;
+
+    test_activations = (OsrsEntityDecoderActivations*)calloc(
+        1, test_decoder.activation_size);
+    test_decoder.reg_train(
+        test_weights, test_activations, &test_acts, &test_grads, batch);
+    alloc_create(&test_acts);
+    alloc_create(&test_grads);
+}
+
+void osrs_entity_decoder_test_set_weights(
+    void* linear_w,
+    void* query_w,
+    void* key_w,
+    void* log_temperature
+) {
+    Prec* destinations[] = {
+        &test_weights->linear_w,
+        &test_weights->query_w,
+        &test_weights->key_w,
+        &test_weights->log_temperature,
+    };
+    void* sources[] = {linear_w, query_w, key_w, log_temperature};
+    for (int index = 0; index < 4; index++) {
+        cudaMemcpy(
+            destinations[index]->data,
+            sources[index],
+            numel(destinations[index]->shape) * sizeof(float),
+            cudaMemcpyDeviceToDevice);
+    }
+}
+
+void osrs_entity_decoder_test_forward(
+    void* hidden,
+    void* keys,
+    void* output
+) {
+    int batch = test_activations->out.shape[0];
+    int hidden_size = test_weights->hidden_dim;
+    OsrsEntityBranchActivations* branches =
+        osrs_entity_branch_activations(test_encoder_activations);
+    branches[OSRS_ENTITY_TARGET_BRANCH].h1.data = (precision_t*)keys;
+    Prec input = {
+        .data = (precision_t*)hidden,
+        .shape = {batch, hidden_size},
+    };
+    Prec result = test_decoder.forward(
+        test_weights, test_activations, input, 0);
+    cudaMemcpy(
+        output,
+        result.data,
+        numel(result.shape) * sizeof(float),
+        cudaMemcpyDeviceToDevice);
+}
+
+void osrs_entity_decoder_test_backward(
+    void* grad_logits,
+    void* grad_value,
+    void* hidden_grad
+) {
+    int batch = test_activations->out.shape[0];
+    Float logits = {
+        .data = (float*)grad_logits,
+        .shape = {batch, test_weights->output_dim},
+    };
+    Float value = {
+        .data = (float*)grad_value,
+        .shape = {batch},
+    };
+    Float logstd = {};
+    Prec result = test_decoder.backward(
+        test_weights, test_activations, logits, logstd, value, 0);
+    cudaMemcpy(
+        hidden_grad,
+        result.data,
+        numel(result.shape) * sizeof(float),
+        cudaMemcpyDeviceToDevice);
+}
+
+void osrs_entity_decoder_test_get_grad(int index, void* output) {
+    Prec* gradients[] = {
+        &test_activations->linear_wgrad,
+        &test_activations->query_wgrad,
+        &test_activations->key_wgrad,
+        &test_activations->temperature_grad,
+        &test_activations->key_grad,
+    };
+    Prec* gradient = gradients[index];
+    cudaMemcpy(
+        output,
+        gradient->data,
+        numel(gradient->shape) * sizeof(float),
+        cudaMemcpyDeviceToDevice);
+}
+
+}

--- a/tests/test_osrs_entity_encoders.py
+++ b/tests/test_osrs_entity_encoders.py
@@ -218,18 +218,29 @@ def _torch_reference(
             ~active.unsqueeze(2),
             -torch.inf,
         ).amax(dim=1)
-        return torch.where(
+        output = torch.where(
             active.any(dim=1, keepdim=True),
             pooled,
             torch.zeros_like(pooled),
         )
+        return output, hidden
 
-    return (
-        functional.linear(observations, global_w)
-        + branch(inventory, inventory_l1_w, inventory_l2_w, 1)
-        + branch(equipment, equipment_l1_w, equipment_l2_w, 1)
-        + branch(npc, npc_l1_w, npc_l2_w, contract.type_count)
+    inventory_output, _ = branch(
+        inventory, inventory_l1_w, inventory_l2_w, 1
     )
+    equipment_output, _ = branch(
+        equipment, equipment_l1_w, equipment_l2_w, 1
+    )
+    npc_output, npc_hidden = branch(
+        npc, npc_l1_w, npc_l2_w, contract.type_count
+    )
+    output = (
+        functional.linear(observations, global_w)
+        + inventory_output
+        + equipment_output
+        + npc_output
+    )
+    return output, npc_hidden
 
 
 def _configure_library(path: Path):
@@ -242,6 +253,7 @@ def _configure_library(path: Path):
         ctypes.c_int,
     ]
     library.osrs_entity_test_set_weights.argtypes = [pointer] * 7
+    library.osrs_entity_test_set_pointer_keygrad.argtypes = [pointer]
     library.osrs_entity_test_forward.argtypes = [
         pointer,
         pointer,
@@ -341,7 +353,7 @@ def test_cuda_forward_and_all_weight_gradients(cuda_library, contract):
         BATCH,
         contract.obs_size,
     )
-    reference_output = _torch_reference(
+    reference_output, npc_hidden = _torch_reference(
         torch,
         functional,
         contract,
@@ -356,8 +368,24 @@ def test_cuda_forward_and_all_weight_gradients(cuda_library, contract):
         generator=generator,
         device="cuda",
     )
-    reference_output.backward(output_gradient)
-    cuda_library.osrs_entity_test_backward(_pointer(output_gradient), BATCH, HIDDEN)
+    if contract.kind == 1:
+        pointer_key_gradient = torch.randn(
+            (BATCH, contract.npc_count, BOTTLENECK),
+            generator=generator,
+            device="cuda",
+        )
+        torch.autograd.backward(
+            (reference_output, npc_hidden),
+            (output_gradient, pointer_key_gradient),
+        )
+        cuda_library.osrs_entity_test_set_pointer_keygrad(
+            _pointer(pointer_key_gradient)
+        )
+    else:
+        reference_output.backward(output_gradient)
+    cuda_library.osrs_entity_test_backward(
+        _pointer(output_gradient), BATCH, HIDDEN
+    )
 
     for index, weight in enumerate(weights):
         cuda_gradient = torch.empty_like(weight)

--- a/tests/test_osrs_entity_encoders_cuda.cu
+++ b/tests/test_osrs_entity_encoders_cuda.cu
@@ -2,6 +2,8 @@
 #define ENV_HEADER "../ocean/minimal/minimal.h"
 #define PUFFER_ENV_NAME "minimal"
 #define NUM_GEAR_SLOTS 11
+#define PUFFER_OSRS_COLOSSEUM
+#define PUFFER_OSRS_INFERNO
 #include "../src/pufferl.cu"
 
 extern "C" {
@@ -9,6 +11,7 @@ extern "C" {
 static Encoder test_encoder;
 static OsrsEntityEncoderWeights* test_weights;
 static OsrsEntityEncoderActivations* test_activations;
+static Prec test_pointer_keygrad;
 static Allocator test_params;
 static Allocator test_acts;
 static Allocator test_grads;
@@ -28,6 +31,7 @@ static void test_reset() {
     free(test_activations);
     test_weights = nullptr;
     test_activations = nullptr;
+    test_pointer_keygrad = {};
 }
 
 void osrs_entity_test_init(int kind, int batch, int obs_size, int hidden) {
@@ -79,6 +83,14 @@ void osrs_entity_test_set_weights(
         cudaMemcpy(dst[i]->data, src[i], numel(dst[i]->shape) * sizeof(float),
             cudaMemcpyDeviceToDevice);
     }
+}
+
+void osrs_entity_test_set_pointer_keygrad(void* grad) {
+    OsrsEntityBranchActivations* branches =
+        osrs_entity_branch_activations(test_activations);
+    test_pointer_keygrad = branches[OSRS_ENTITY_TARGET_BRANCH].h1;
+    test_pointer_keygrad.data = (precision_t*)grad;
+    osrs_entity_decoder_keygrad = &test_pointer_keygrad;
 }
 
 void osrs_entity_test_forward(void* output, void* observations, int batch, int obs_size) {

--- a/tests/test_osrs_inferno_config.py
+++ b/tests/test_osrs_inferno_config.py
@@ -1,0 +1,100 @@
+import configparser
+import itertools
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+RUN_76_DEFAULTS = {
+    "base": {
+        "async": "1",
+    },
+    "env": {
+        "offensive_prayer_reward_coeff": "0.0692558885",
+        "death_penalty_coeff": "0.26163137",
+        "curriculum_frac_1": "0.186450824",
+        "curriculum_frac_5": "0.0685265288",
+        "zuk_untagged_healer_nonmagic_attack_bonus_coeff": "0.932179332",
+    },
+    "train": {
+        "total_timesteps": "395922816",
+        "learning_rate": "0.000352853211",
+        "min_lr_ratio": "0.0223900452",
+        "momentum": "0.996223032",
+        "ent_coef": "4.47068851e-06",
+        "gamma": "0.999429405",
+        "gae_lambda": "0.833382428",
+        "prio_alpha": "0.469595075",
+        "clip_coef": "0.145622194",
+        "vf_coef": "2.38069582",
+        "vf_clip_coef": "0.214555308",
+        "max_grad_norm": "0.571861565",
+        "replay_ratio": "4.0840683",
+    },
+}
+ASYNC_ARCHITECTURE_VALUES = {
+    "policy.hidden_size": (256, 512, 1024),
+    "policy.num_layers": (1, 2, 3),
+    "vec.total_agents": (1024, 2048, 4096),
+    "vec.num_buffers": (1, 2, 4),
+    "train.horizon": (64, 128, 256, 512),
+    "train.minibatch_size": (2048, 4096, 8192, 16384),
+}
+
+
+def read_inferno_config() -> configparser.ConfigParser:
+    config = configparser.ConfigParser()
+    loaded = config.read(
+        [
+            REPOSITORY_ROOT / "config/default.ini",
+            REPOSITORY_ROOT / "config/osrs_inferno.ini",
+        ]
+    )
+    assert len(loaded) == 2
+    return config
+
+
+def test_inferno_defaults_match_run_76_anchor() -> None:
+    config = read_inferno_config()
+
+    for section, expected_values in RUN_76_DEFAULTS.items():
+        actual_values = {key: config[section][key] for key in expected_values}
+        assert actual_values == expected_values
+
+
+def test_inferno_sweep_contains_its_anchor() -> None:
+    config = read_inferno_config()
+
+    for sweep_section in (
+        section for section in config.sections() if section.startswith("sweep.")
+    ):
+        target_section, key = sweep_section.removeprefix("sweep.").rsplit(".", 1)
+        value = float(config[target_section][key])
+        assert float(config[sweep_section]["min"]) <= value
+        assert value <= float(config[sweep_section]["max"])
+
+
+def test_async_architecture_sweep_values_are_trainer_compatible() -> None:
+    config = read_inferno_config()
+
+    for path, expected_values in ASYNC_ARCHITECTURE_VALUES.items():
+        sweep_section = f"sweep.{path}"
+        low = int(config[sweep_section]["min"])
+        high = int(config[sweep_section]["max"])
+        if config[sweep_section]["distribution"] == "uniform_pow2":
+            actual_values = tuple(
+                1 << exponent
+                for exponent in range(low.bit_length() - 1, high.bit_length())
+            )
+        else:
+            actual_values = tuple(range(low, high + 1))
+        assert actual_values == expected_values
+
+    for total_agents, num_buffers, horizon, minibatch_size in itertools.product(
+        ASYNC_ARCHITECTURE_VALUES["vec.total_agents"],
+        ASYNC_ARCHITECTURE_VALUES["vec.num_buffers"],
+        ASYNC_ARCHITECTURE_VALUES["train.horizon"],
+        ASYNC_ARCHITECTURE_VALUES["train.minibatch_size"],
+    ):
+        assert total_agents % num_buffers == 0
+        assert minibatch_size % horizon == 0
+        assert minibatch_size <= total_agents * horizon


### PR DESCRIPTION
Promote Run 76 and enable async training for Inferno. Add an Inferno-only cosine pointer head for NPC target logits 25-38 while preserving every other action head. Add CUDA parity, permutation, and encoder gradient-handoff tests.